### PR TITLE
Establish pull-request CI and kind-based end-to-end validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,134 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Cache controller tools
+        uses: actions/cache@v4
+        with:
+          path: bin
+          key: ${{ runner.os }}-controller-tools-${{ hashFiles('Makefile', 'go.mod', 'go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-controller-tools-
+
+      - name: Verify generated artifacts and formatting
+        run: make verify
+
+      - name: Run unit and envtest suites
+        run: make test
+
+  # Anthropic is never loaded into kind for PR e2e (keyless echo path only).
+  # Build it here so Dockerfile breakage still fails CI without pretending it is
+  # part of the kind install surface.
+  image-smoke:
+    name: Image smoke
+    runs-on: ubuntu-latest
+    env:
+      KONTEXT_ANTHROPIC_IMAGE: kontext-runtime-anthropic:dev
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Anthropic reference runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: runtimes/python-anthropic
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_ANTHROPIC_IMAGE }}
+          cache-from: type=gha,scope=anthropic
+          cache-to: type=gha,mode=max,scope=anthropic
+
+  e2e:
+    name: Kind e2e
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+      - image-smoke
+    env:
+      KIND_CLUSTER_NAME: kontext-ci
+      KONTEXT_OPERATOR_IMAGE: kontext-operator:dev
+      KONTEXT_ECHO_IMAGE: kontext-echo:dev
+      KONTEXT_DIAG_DIR: ${{ github.workspace }}/.ci-diagnostics
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build operator image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
+          cache-from: type=gha,scope=operator
+          cache-to: type=gha,mode=max,scope=operator
+
+      - name: Build echo runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: runtimes/echo
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_ECHO_IMAGE }}
+          cache-from: type=gha,scope=echo
+          cache-to: type=gha,mode=max,scope=echo
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          wait: 120s
+
+      - name: Install Kontext with local images
+        run: ./scripts/install-go-kind.sh
+
+      - name: Run keyless kind end-to-end scenarios
+        run: ./scripts/e2e-kind.sh
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: ./scripts/collect-kind-diagnostics.sh "${KONTEXT_DIAG_DIR}"
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-diagnostics-${{ github.run_id }}
+          path: ${{ env.KONTEXT_DIAG_DIR }}
+          if-no-files-found: ignore
+
+      - name: Delete kind cluster
+        if: always()
+        run: kind delete cluster --name "${KIND_CLUSTER_NAME}" || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   validate:
     name: Validate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -48,6 +49,7 @@ jobs:
   image-smoke:
     name: Image smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       KONTEXT_ANTHROPIC_IMAGE: kontext-runtime-anthropic:dev
     steps:
@@ -70,6 +72,7 @@ jobs:
   e2e:
     name: Kind e2e
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs:
       - validate
       - image-smoke

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,8 @@ bin/
 cover.out
 vendor/
 
+# CI diagnostics
+.ci-diagnostics/
+
 # Local development files
 AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ verify: manifests generate ## Check generated artifacts and gofmt; fail on drift
 		git --no-pager diff -- api/v1alpha1/zz_generated.deepcopy.go config/crd/bases config/rbac/role.yaml; \
 		exit 1; \
 	fi
-	@unformatted="$$(gofmt -l $$(find . -name '*.go' -not -path './vendor/*' -not -path './bin/*'))"; \
+	@unformatted="$$(find . -name '*.go' -not -path './vendor/*' -not -path './bin/*' -exec gofmt -l {} +)"; \
 	if [[ -n "$${unformatted}" ]]; then \
 		echo "go files need formatting; run 'make fmt'" >&2; \
 		echo "$${unformatted}"; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= kontext-operator:dev
+ECHO_IMG ?= kontext-echo:dev
+ANTHROPIC_IMG ?= kontext-runtime-anthropic:dev
 
 # Get the currently used golang version
 GO_VERSION ?= 1.23.0
@@ -41,6 +43,23 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: verify
+verify: manifests generate ## Check generated artifacts and gofmt; fail on drift.
+	@if ! git diff --quiet --exit-code -- \
+		api/v1alpha1/zz_generated.deepcopy.go \
+		config/crd/bases \
+		config/rbac/role.yaml; then \
+		echo "generated files are out of date; run 'make manifests generate' and commit the result" >&2; \
+		git --no-pager diff -- api/v1alpha1/zz_generated.deepcopy.go config/crd/bases config/rbac/role.yaml; \
+		exit 1; \
+	fi
+	@unformatted="$$(gofmt -l $$(find . -name '*.go' -not -path './vendor/*' -not -path './bin/*'))"; \
+	if [[ -n "$${unformatted}" ]]; then \
+		echo "go files need formatting; run 'make fmt'" >&2; \
+		echo "$${unformatted}"; \
+		exit 1; \
+	fi
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
@@ -58,6 +77,21 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: docker-build
 docker-build: ## Build docker image for the operator.
 	docker build -t ${IMG} .
+
+.PHONY: docker-build-echo
+docker-build-echo: ## Build docker image for the echo runtime.
+	docker build -t ${ECHO_IMG} runtimes/echo
+
+.PHONY: docker-build-anthropic
+docker-build-anthropic: ## Build docker image for the Anthropic reference runtime.
+	docker build -t ${ANTHROPIC_IMG} runtimes/python-anthropic
+
+.PHONY: docker-build-all
+docker-build-all: docker-build docker-build-echo docker-build-anthropic ## Build operator and runtime images.
+
+.PHONY: kind-install
+kind-install: docker-build docker-build-echo ## Build kind images and install the operator into kind.
+	./scripts/install-go-kind.sh
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Agents themselves are **bring-your-own-runtime**: any container image that reads
 Requires Docker, [kind](https://kind.sigs.k8s.io/), and kubectl.
 
 ```bash
-./scripts/install-go-kind.sh   # build operator + echo runtime, install CRDs and controller
-./scripts/e2e-kind.sh          # end-to-end verification
+make kind-install       # build operator + echo images, load into kind, install controller
+./scripts/e2e-kind.sh   # end-to-end verification
 ```
 
 The e2e script proves the two core behaviors:
@@ -86,10 +86,15 @@ Every run is bounded and auditable:
 ## Development
 
 ```bash
-make test    # unit + envtest reconciler tests
-make build   # compile operator binary to bin/manager
-make run     # run the controller locally against your kubeconfig
+make verify            # CRD/deepcopy generation + gofmt drift check
+make test              # unit + envtest reconciler tests
+make docker-build-all  # operator + echo + Anthropic runtime images
+make kind-install      # build operator + echo, load into kind, install controller
+make build             # compile operator binary to bin/manager
+make run               # run the controller locally against your kubeconfig
 ```
+
+Pull requests and pushes to `main` run validate, Dockerfile smoke for every shipped image, and keyless kind e2e via `.github/workflows/ci.yml`. After a failed local kind run, collect cluster state with `./scripts/collect-kind-diagnostics.sh`.
 
 ## Layout
 

--- a/scripts/collect-kind-diagnostics.sh
+++ b/scripts/collect-kind-diagnostics.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${1:-${ROOT_DIR}/.ci-diagnostics}"
+NAMESPACE="${KONTEXT_NAMESPACE:-kontext-system}"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+dump_logs_for_label() {
+  local label="$1"
+  local out="$2"
+  {
+    echo "# pods with label ${label}"
+    kubectl get pods -A -l "${label}" -o wide || true
+    echo
+    echo "# logs"
+    while read -r ns name; do
+      [[ -z "${ns}" || -z "${name}" ]] && continue
+      echo "----- ${ns}/${name} -----"
+      kubectl logs -n "${ns}" "${name}" --all-containers --tail=200 || true
+    done < <(kubectl get pods -A -l "${label}" -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+  } >>"${out}" 2>&1 || true
+}
+
+need kubectl
+
+mkdir -p "${OUT_DIR}"
+
+echo "==> collecting kind diagnostics into ${OUT_DIR}"
+
+{
+  echo "# cluster-info"
+  kubectl cluster-info || true
+  echo
+  echo "# nodes"
+  kubectl get nodes -o wide || true
+  echo
+  echo "# namespaces"
+  kubectl get ns || true
+} >"${OUT_DIR}/cluster.txt" 2>&1 || true
+
+{
+  echo "# pods -A"
+  kubectl get pods -A -o wide || true
+  echo
+  echo "# deployments -A"
+  kubectl get deploy -A -o wide || true
+  echo
+  echo "# events -A (newest first)"
+  kubectl get events -A --sort-by=.lastTimestamp || true
+} >"${OUT_DIR}/workload-overview.txt" 2>&1 || true
+
+{
+  echo "# controller-manager deployment"
+  kubectl get deploy -n "${NAMESPACE}" controller-manager -o yaml || true
+  echo
+  echo "# controller-manager pods"
+  kubectl get pods -n "${NAMESPACE}" -l control-plane=controller-manager -o wide || true
+  echo
+  echo "# controller-manager describe"
+  kubectl describe deploy -n "${NAMESPACE}" controller-manager || true
+  kubectl describe pods -n "${NAMESPACE}" -l control-plane=controller-manager || true
+} >"${OUT_DIR}/controller.txt" 2>&1 || true
+
+kubectl logs -n "${NAMESPACE}" -l control-plane=controller-manager --all-containers --tail=500 >"${OUT_DIR}/controller.log" 2>&1 || true
+kubectl logs -n "${NAMESPACE}" -l control-plane=controller-manager --all-containers --previous --tail=500 >"${OUT_DIR}/controller-previous.log" 2>&1 || true
+
+{
+  echo "# agents"
+  kubectl get agents -A -o wide || true
+  echo
+  echo "# agentruns"
+  kubectl get agentruns -A -o wide || true
+  echo
+  echo "# agent descriptions"
+  kubectl describe agents -A || true
+  echo
+  echo "# agentrun descriptions"
+  kubectl describe agentruns -A || true
+} >"${OUT_DIR}/kontext-resources.txt" 2>&1 || true
+
+: >"${OUT_DIR}/agent-workloads.txt"
+dump_logs_for_label 'kontext.dev/run' "${OUT_DIR}/agent-workloads.txt"
+dump_logs_for_label 'kontext.dev/agent' "${OUT_DIR}/agent-workloads.txt"
+
+{
+  echo "# CRDs"
+  kubectl get crd agents.kontext.dev agentruns.kontext.dev -o yaml || true
+} >"${OUT_DIR}/crds.txt" 2>&1 || true
+
+echo "==> diagnostics written to ${OUT_DIR}"
+ls -la "${OUT_DIR}" || true

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -12,16 +12,28 @@ need() {
   fi
 }
 
+is_terminal_failure_phase() {
+  case "$1" in
+    Failed|BudgetExceeded) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 need kubectl
 
 echo "==> applying standalone echo task run"
 kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/echo-task-run.yaml"
 
 echo "==> waiting for AgentRun to succeed"
+phase=""
 for _ in $(seq 1 60); do
   phase="$(kubectl get agentrun echo-review -o jsonpath='{.status.phase}' 2>/dev/null || true)"
   if [[ "${phase}" == "Succeeded" ]]; then
     break
+  fi
+  if is_terminal_failure_phase "${phase}"; then
+    echo "expected echo-review to succeed, got phase=${phase}" >&2
+    exit 1
   fi
   sleep 2
 done

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+# Keyless kind scenarios. On failure, CI collects diagnostics separately via
+# scripts/collect-kind-diagnostics.sh; locally run that script after a failed e2e.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CLUSTER_NAME="${KIND_CLUSTER_NAME:-kontext}"
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -29,8 +30,6 @@ phase="$(kubectl get agentrun echo-review -o jsonpath='{.status.phase}')"
 result="$(kubectl get agentrun echo-review -o jsonpath='{.status.result}')"
 if [[ "${phase}" != "Succeeded" ]]; then
   echo "expected echo-review to succeed, got phase=${phase}" >&2
-  kubectl describe agentrun echo-review || true
-  kubectl logs "$(kubectl get pod -l kontext.dev/run=echo-review -o jsonpath='{.items[0].metadata.name}')" || true
   exit 1
 fi
 echo "task result: ${result}"
@@ -51,7 +50,6 @@ done
 service_pod="$(kubectl get pod -l kontext.dev/agent=echo-service -o jsonpath='{.items[0].metadata.name}')"
 if [[ -z "${service_pod}" ]]; then
   echo "service agent pod not found" >&2
-  kubectl describe agent echo-service || true
   exit 1
 fi
 
@@ -70,5 +68,4 @@ for _ in $(seq 1 60); do
 done
 
 echo "service recast did not complete in time" >&2
-kubectl describe agent echo-service || true
 exit 1

--- a/scripts/install-go-kind.sh
+++ b/scripts/install-go-kind.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Load prebuilt operator + echo images into kind and install the controller.
+# Build images first, e.g. `make docker-build docker-build-echo` or `make kind-install`.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -17,11 +19,14 @@ need docker
 need kind
 need kubectl
 
-echo "==> building operator image ${OPERATOR_IMAGE}"
-docker build -t "${OPERATOR_IMAGE}" "${ROOT_DIR}"
-
-echo "==> building echo runtime ${ECHO_IMAGE}"
-docker build -t "${ECHO_IMAGE}" "${ROOT_DIR}/runtimes/echo"
+if ! docker image inspect "${OPERATOR_IMAGE}" >/dev/null 2>&1; then
+  echo "missing local image ${OPERATOR_IMAGE}; build with: make docker-build" >&2
+  exit 1
+fi
+if ! docker image inspect "${ECHO_IMAGE}" >/dev/null 2>&1; then
+  echo "missing local image ${ECHO_IMAGE}; build with: make docker-build-echo" >&2
+  exit 1
+fi
 
 if ! kind get clusters | grep -qx "${CLUSTER_NAME}"; then
   echo "==> creating kind cluster ${CLUSTER_NAME}"


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI for pull requests and pushes to `main`: `make verify`, `make test`, Anthropic Dockerfile smoke, and keyless kind e2e.
- Splits responsibilities clearly: Makefile/Buildx build images, `install-go-kind.sh` loads and installs, `e2e-kind.sh` asserts, and CI collects diagnostics on failure.
- Keeps PR validation free of provider credentials and public registry pushes.

Closes #5

## Test plan
- [ ] CI `Validate` job passes (`make verify` + `make test`)
- [ ] CI `Image smoke` job builds `runtimes/python-anthropic`
- [ ] CI `Kind e2e` job installs from local operator/echo images and passes standalone + Service recast scenarios
- [ ] Failed e2e uploads a diagnostics artifact
- [ ] Locally: `make verify && make test && make kind-install && ./scripts/e2e-kind.sh`