### PR TITLE
fix: restore status test compile after #9 merge

### DIFF
--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -315,7 +315,10 @@ func TestObservePodUnknownPhaseDefaultsPending(t *testing.T) {
 }
 
 func TestParseTerminationMessageEmpty(t *testing.T) {
-	payload := status.ParseTerminationMessage("   ")
+	payload, err := status.ParseTerminationMessage("   ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if payload.Result != "" || payload.TokensUsed != 0 {
 		t.Fatalf("expected empty payload, got %#v", payload)
 	}


### PR DESCRIPTION
## Summary

Main CI broke after merging #9 onto #8: `ParseTerminationMessage` returns `(TerminationPayload, error)`, but `TestParseTerminationMessageEmpty` still used a single-value assignment, so `go vet` failed.

## Test plan

- [x] `go test ./internal/status/...`
- [x] `make test`
- [ ] Confirm Validate CI is green on this PR