### PR TITLE
Add reusable Kontext result reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,21 +46,33 @@ jobs:
       - name: Scan for known Go vulnerabilities
         run: make vulncheck
 
-  # Anthropic is never loaded into kind for PR e2e (keyless echo path only).
-  # Build it here so Dockerfile breakage still fails CI without pretending it is
-  # part of the kind install surface.
+  # These images are not loaded into kind for PR e2e (keyless echo path only).
+  # Build them here so Dockerfile breakage still fails CI without pretending
+  # they are part of the kind install surface.
   image-smoke:
     name: Image smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       KONTEXT_ANTHROPIC_IMAGE: kontext-runtime-anthropic:dev
+      KONTEXT_REPORTER_IMAGE: kontext-reporter:dev
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Build reusable reporter image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: runtimes/reporter/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
+          cache-from: type=gha,scope=reporter
+          cache-to: type=gha,mode=max,scope=reporter
 
       - name: Build Anthropic reference runtime image
         uses: docker/build-push-action@v6

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 IMG ?= kontext-operator:dev
 ECHO_IMG ?= kontext-echo:dev
 ANTHROPIC_IMG ?= kontext-runtime-anthropic:dev
+REPORTER_IMG ?= kontext-reporter:dev
 
 # Get the currently used golang version
 GO_VERSION ?= 1.26.5
@@ -101,8 +102,12 @@ docker-build-echo: ## Build docker image for the echo runtime.
 docker-build-anthropic: ## Build docker image for the Anthropic reference runtime.
 	docker build -t ${ANTHROPIC_IMG} runtimes/python-anthropic
 
+.PHONY: docker-build-reporter
+docker-build-reporter: ## Build the reusable result reporter image.
+	docker build -f runtimes/reporter/Dockerfile -t ${REPORTER_IMG} .
+
 .PHONY: docker-build-all
-docker-build-all: docker-build docker-build-echo docker-build-anthropic ## Build operator and runtime images.
+docker-build-all: docker-build docker-build-echo docker-build-anthropic docker-build-reporter ## Build operator and runtime images.
 
 .PHONY: kind-install
 kind-install: docker-build docker-build-echo ## Build kind images and install the operator into kind.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ kubectl get agentruns -w
 |---|---|
 | [`runtimes/echo/`](runtimes/echo) | Keyless test runtime. Exercises the full contract (stdout thoughts, termination-log result, service heartbeat) without any API key. |
 | [`runtimes/python-anthropic/`](runtimes/python-anthropic) | Real runtime backed by the Anthropic Messages API. Needs an `ANTHROPIC_API_KEY` secret via `spec.secretRef`. |
+| [`runtimes/reporter/`](runtimes/reporter) | Reusable PID 1 supervisor. Preserves child logs and process semantics while producing the versioned result envelope. |
 
 Provider credentials are wired by the controller from a Kubernetes Secret into the env vars each provider expects (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, AWS credential pairs for Bedrock, and so on). See `internal/runtimepolicy/`.
 
@@ -89,7 +90,8 @@ Every run is bounded and auditable:
 make verify            # CRD/deepcopy generation + gofmt drift check
 make test              # unit + envtest reconciler tests
 make vulncheck         # scan reachable Go code for known vulnerabilities
-make docker-build-all  # operator + echo + Anthropic runtime images
+make docker-build-all  # operator + all maintained runtime images
+make docker-build-reporter  # build the reusable result reporter image
 make kind-install      # build operator + echo, load into kind, install controller
 make build             # compile operator binary to bin/manager
 make run               # run the controller locally against your kubeconfig
@@ -109,7 +111,7 @@ internal/status/           Pod observation, termination parsing
 internal/conditions/       Condition merge helpers
 config/                    Kustomize install (CRDs, RBAC, manager)
 deploy/examples/v1alpha1/  Sample manifests
-runtimes/                  Runtime images (echo, python-anthropic)
+runtimes/                  Runtime images and reusable result reporter
 scripts/                   kind install + e2e
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -219,6 +219,24 @@ always fails the run. A failed envelope also fails the run even if the process
 exits zero. Malformed or partially written JSON is an actionable failure, not
 a successful plain-text result.
 
+### Optional result reporter
+
+The maintained `runtimes/reporter` executable can supervise an explicit child
+command and produce the versioned envelope without requiring the child to write
+the termination log itself. It preserves child stdout, stderr, signals, and
+process exit status.
+
+Reporter extraction supports:
+
+- `last-line` — the last non-empty stdout line becomes `text/plain` output.
+- `kontext-envelope` — the last stdout line prefixed with
+  `KONTEXT_RESULT:` supplies a complete versioned envelope.
+
+The reporter bounds only captured result data; streamed logs remain unbounded.
+It compacts every emitted envelope to the termination-message limit. Reporter
+injection and workload configuration are control-plane concerns defined
+separately from this executable.
+
 ### Mode expectations for the image
 
 - **Task / Scheduled run image:** does its work, writes result, exits. Pod `restartPolicy: Never`.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kontext-dev/kontext
 go 1.26.5
 
 require (
+	golang.org/x/sys v0.47.0
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
@@ -49,7 +50,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.7.0 // indirect

--- a/runtimes/reporter/Dockerfile
+++ b/runtimes/reporter/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.26.5 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY pkg/result/ pkg/result/
+COPY runtimes/reporter/ runtimes/reporter/
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath -ldflags="-s -w" -o /kontext-reporter ./runtimes/reporter
+
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=builder /kontext-reporter /kontext-reporter
+
+USER 65532:65532
+ENTRYPOINT ["/kontext-reporter"]

--- a/runtimes/reporter/README.md
+++ b/runtimes/reporter/README.md
@@ -30,7 +30,9 @@ entrypoint.
 
 The last non-empty stdout line becomes `text/plain` output. Empty stdout
 produces a successful envelope with no output. This mode is intentionally
-heuristic and cannot infer usage metrics.
+heuristic and cannot infer usage metrics. A line larger than the capture limit
+produces a successful envelope with an explicit truncated-output marker instead
+of silently returning partial text.
 
 ### `kontext-envelope`
 

--- a/runtimes/reporter/README.md
+++ b/runtimes/reporter/README.md
@@ -1,0 +1,83 @@
+# Kontext result reporter
+
+The reporter is a small process supervisor for agent containers. It runs as
+PID 1, launches an explicit child command, preserves the child's logs and
+process exit code, and writes the versioned Kontext result envelope to the
+container termination log.
+
+It contains no model, provider, tool, or Kubernetes control-plane behavior.
+
+## Local usage
+
+Use a temporary termination path outside Kubernetes:
+
+```bash
+go run ./runtimes/reporter \
+  --format last-line \
+  --termination-log /tmp/kontext-result.json \
+  -- sh -c 'echo "working"; echo "final answer"'
+```
+
+The child output is still printed normally. The reporter writes a compact
+`kontext.dev/result/v1alpha1` envelope to `/tmp/kontext-result.json`.
+
+The command after `--` is required. The reporter does not discover an image
+entrypoint.
+
+## Result formats
+
+### `last-line`
+
+The last non-empty stdout line becomes `text/plain` output. Empty stdout
+produces a successful envelope with no output. This mode is intentionally
+heuristic and cannot infer usage metrics.
+
+### `kontext-envelope`
+
+The child emits a complete versioned envelope on one stdout line:
+
+```text
+KONTEXT_RESULT: {"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","output":{"mediaType":"application/json","value":{"ok":true}}}
+```
+
+The line remains visible in ordinary logs. If multiple prefixed lines are
+present, the last one wins. Missing, malformed, legacy, or capture-truncated
+candidates produce a failed result envelope.
+
+`RESULT:` is not a reporter prefix. The exact prefix is `KONTEXT_RESULT:`.
+
+## Configuration
+
+| Flag | Environment | Default |
+|---|---|---|
+| `--format` | `KONTEXT_RESULT_FORMAT` | `last-line` |
+| `--termination-log` | `KONTEXT_TERMINATION_MESSAGE` | `/dev/termination-log` |
+| `--max-capture-bytes` | — | 65536 |
+
+The capture limit must be at least 4096 bytes. Logs themselves are not
+buffered or limited by the reporter.
+
+## Process behavior
+
+- Child stdout and stderr are forwarded unchanged.
+- SIGTERM and SIGINT are forwarded to the child process group.
+- Remaining processes in the child process group are killed after the main
+  child exits.
+- Normal completion preserves the child exit code.
+- Reporter infrastructure failures use exit code `125`.
+- Failure to start the child uses exit code `126`.
+- Reporter-generated failure envelopes use stable error codes so they remain
+  distinguishable from agent process failures.
+
+The production image is Linux-only and builds a static binary for the selected
+`TARGETOS` and `TARGETARCH`.
+
+## Development
+
+```bash
+go test ./runtimes/reporter -count=1
+make docker-build-reporter
+```
+
+Reporter injection into arbitrary workload images is intentionally deferred to
+issue #16.

--- a/runtimes/reporter/capture.go
+++ b/runtimes/reporter/capture.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+)
+
+const KontextEnvelopePrefix = "KONTEXT_RESULT:"
+
+type CapturedResult struct {
+	Data      []byte
+	Found     bool
+	Truncated bool
+}
+
+type Capture struct {
+	format   CaptureFormat
+	maxBytes int
+
+	current          []byte
+	currentTotal     int
+	currentTruncated bool
+
+	lastLine  CapturedResult
+	candidate CapturedResult
+}
+
+func newCapture(format CaptureFormat, maxBytes int) *Capture {
+	return &Capture{
+		format:   format,
+		maxBytes: maxBytes,
+		current:  make([]byte, 0, min(maxBytes, 4096)),
+	}
+}
+
+func (capture *Capture) Write(data []byte) (int, error) {
+	written := len(data)
+	for len(data) > 0 {
+		newline := bytes.IndexByte(data, '\n')
+		if newline < 0 {
+			capture.appendCurrent(data)
+			break
+		}
+		capture.appendCurrent(data[:newline])
+		capture.completeLine()
+		data = data[newline+1:]
+	}
+	return written, nil
+}
+
+func (capture *Capture) Result() CapturedResult {
+	if capture.currentTotal > 0 {
+		capture.completeLine()
+	}
+	switch capture.format {
+	case CaptureFormatLastLine:
+		return cloneCapturedResult(capture.lastLine)
+	case CaptureFormatKontextEnvelope:
+		return cloneCapturedResult(capture.candidate)
+	default:
+		return CapturedResult{}
+	}
+}
+
+func (capture *Capture) appendCurrent(data []byte) {
+	capture.currentTotal += len(data)
+	remaining := capture.maxBytes - len(capture.current)
+	if remaining <= 0 {
+		capture.currentTruncated = true
+		return
+	}
+	if len(data) > remaining {
+		capture.current = append(capture.current, data[:remaining]...)
+		capture.currentTruncated = true
+		return
+	}
+	capture.current = append(capture.current, data...)
+}
+
+func (capture *Capture) completeLine() {
+	line := bytes.TrimSuffix(capture.current, []byte{'\r'})
+	if len(bytes.TrimSpace(line)) > 0 {
+		switch capture.format {
+		case CaptureFormatLastLine:
+			capture.lastLine = CapturedResult{
+				Data:      append([]byte(nil), line...),
+				Found:     true,
+				Truncated: capture.currentTruncated,
+			}
+		case CaptureFormatKontextEnvelope:
+			trimmed := bytes.TrimSpace(line)
+			if bytes.HasPrefix(trimmed, []byte(KontextEnvelopePrefix)) {
+				candidate := bytes.TrimSpace(trimmed[len(KontextEnvelopePrefix):])
+				capture.candidate = CapturedResult{
+					Data:      append([]byte(nil), candidate...),
+					Found:     true,
+					Truncated: capture.currentTruncated,
+				}
+			}
+		}
+	}
+	capture.current = capture.current[:0]
+	capture.currentTotal = 0
+	capture.currentTruncated = false
+}
+
+func cloneCapturedResult(result CapturedResult) CapturedResult {
+	result.Data = append([]byte(nil), result.Data...)
+	return result
+}

--- a/runtimes/reporter/capture.go
+++ b/runtimes/reporter/capture.go
@@ -7,9 +7,10 @@ import (
 const KontextEnvelopePrefix = "KONTEXT_RESULT:"
 
 type CapturedResult struct {
-	Data      []byte
-	Found     bool
-	Truncated bool
+	Data          []byte
+	Found         bool
+	Truncated     bool
+	OriginalBytes int
 }
 
 type Capture struct {
@@ -82,18 +83,20 @@ func (capture *Capture) completeLine() {
 		switch capture.format {
 		case CaptureFormatLastLine:
 			capture.lastLine = CapturedResult{
-				Data:      append([]byte(nil), line...),
-				Found:     true,
-				Truncated: capture.currentTruncated,
+				Data:          append([]byte(nil), line...),
+				Found:         true,
+				Truncated:     capture.currentTruncated,
+				OriginalBytes: capture.currentTotal,
 			}
 		case CaptureFormatKontextEnvelope:
 			trimmed := bytes.TrimSpace(line)
 			if bytes.HasPrefix(trimmed, []byte(KontextEnvelopePrefix)) {
 				candidate := bytes.TrimSpace(trimmed[len(KontextEnvelopePrefix):])
 				capture.candidate = CapturedResult{
-					Data:      append([]byte(nil), candidate...),
-					Found:     true,
-					Truncated: capture.currentTruncated,
+					Data:          append([]byte(nil), candidate...),
+					Found:         true,
+					Truncated:     capture.currentTruncated,
+					OriginalBytes: capture.currentTotal,
 				}
 			}
 		}

--- a/runtimes/reporter/capture_test.go
+++ b/runtimes/reporter/capture_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCaptureLastNonEmptyLine(t *testing.T) {
+	capture := newCapture(CaptureFormatLastLine, 4096)
+	_, _ = capture.Write([]byte("first\n\nsecond"))
+	_, _ = capture.Write([]byte(" line\n\n"))
+
+	result := capture.Result()
+	if !result.Found {
+		t.Fatalf("expected captured result")
+	}
+	if got := string(result.Data); got != "second line" {
+		t.Fatalf("expected final non-empty line, got %q", got)
+	}
+	if result.Truncated {
+		t.Fatalf("did not expect truncation")
+	}
+}
+
+func TestCaptureUsesLastPrefixedEnvelope(t *testing.T) {
+	capture := newCapture(CaptureFormatKontextEnvelope, 4096)
+	_, _ = capture.Write([]byte(
+		"ordinary log\n" +
+			`KONTEXT_RESULT: {"apiVersion":"old"}` + "\n" +
+			`KONTEXT_RESULT: {"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded"}`,
+	))
+
+	result := capture.Result()
+	if !result.Found {
+		t.Fatalf("expected prefixed result")
+	}
+	want := `{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded"}`
+	if got := string(result.Data); got != want {
+		t.Fatalf("expected last candidate %q, got %q", want, got)
+	}
+}
+
+func TestCaptureBoundsLongLines(t *testing.T) {
+	capture := newCapture(CaptureFormatLastLine, 4096)
+	_, _ = capture.Write([]byte(strings.Repeat("x", 8192)))
+
+	result := capture.Result()
+	if !result.Found || !result.Truncated {
+		t.Fatalf("expected truncated capture, got %#v", result)
+	}
+	if len(result.Data) != 4096 {
+		t.Fatalf("expected 4096 retained bytes, got %d", len(result.Data))
+	}
+}
+
+func TestCaptureDoesNotTreatOrdinaryLogsAsEnvelope(t *testing.T) {
+	capture := newCapture(CaptureFormatKontextEnvelope, 4096)
+	_, _ = capture.Write([]byte("RESULT: not the reporter protocol\nordinary log\n"))
+	if result := capture.Result(); result.Found {
+		t.Fatalf("unexpected result %#v", result)
+	}
+}

--- a/runtimes/reporter/capture_test.go
+++ b/runtimes/reporter/capture_test.go
@@ -51,6 +51,9 @@ func TestCaptureBoundsLongLines(t *testing.T) {
 	if len(result.Data) != 4096 {
 		t.Fatalf("expected 4096 retained bytes, got %d", len(result.Data))
 	}
+	if result.OriginalBytes != 8192 {
+		t.Fatalf("expected original length 8192, got %d", result.OriginalBytes)
+	}
 }
 
 func TestCaptureDoesNotTreatOrdinaryLogsAsEnvelope(t *testing.T) {

--- a/runtimes/reporter/config.go
+++ b/runtimes/reporter/config.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+const (
+	defaultTerminationPath = "/dev/termination-log"
+	defaultCaptureBytes    = 64 * 1024
+)
+
+type CaptureFormat string
+
+const (
+	CaptureFormatLastLine        CaptureFormat = "last-line"
+	CaptureFormatKontextEnvelope CaptureFormat = "kontext-envelope"
+)
+
+type Config struct {
+	Format          CaptureFormat
+	TerminationPath string
+	MaxCaptureBytes int
+	Command         []string
+}
+
+func parseConfig(args []string, getenv func(string) string) (Config, error) {
+	formatDefault := getenv("KONTEXT_RESULT_FORMAT")
+	if formatDefault == "" {
+		formatDefault = string(CaptureFormatLastLine)
+	}
+	terminationDefault := getenv("KONTEXT_TERMINATION_MESSAGE")
+	if terminationDefault == "" {
+		terminationDefault = defaultTerminationPath
+	}
+
+	flags := flag.NewFlagSet("kontext-reporter", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	formatValue := flags.String("format", formatDefault, "result format: last-line or kontext-envelope")
+	terminationPath := flags.String("termination-log", terminationDefault, "termination message path")
+	maxCaptureBytes := flags.Int("max-capture-bytes", defaultCaptureBytes, "maximum bytes retained from one result line")
+	if err := flags.Parse(args); err != nil {
+		return Config{}, err
+	}
+
+	format, err := parseCaptureFormat(*formatValue)
+	if err != nil {
+		return Config{}, err
+	}
+	if strings.TrimSpace(*terminationPath) == "" {
+		return Config{}, errors.New("termination log path cannot be empty")
+	}
+	if *maxCaptureBytes < resultv1alpha1.MaxTerminationMessageBytes {
+		return Config{}, fmt.Errorf(
+			"max capture bytes must be at least %d",
+			resultv1alpha1.MaxTerminationMessageBytes,
+		)
+	}
+	command := flags.Args()
+	if len(command) == 0 {
+		return Config{}, errors.New("child command is required after --")
+	}
+
+	return Config{
+		Format:          format,
+		TerminationPath: *terminationPath,
+		MaxCaptureBytes: *maxCaptureBytes,
+		Command:         command,
+	}, nil
+}
+
+func parseCaptureFormat(value string) (CaptureFormat, error) {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
+	switch normalized {
+	case "lastline", string(CaptureFormatLastLine):
+		return CaptureFormatLastLine, nil
+	case "kontextenvelope", string(CaptureFormatKontextEnvelope):
+		return CaptureFormatKontextEnvelope, nil
+	default:
+		return "", fmt.Errorf("unsupported result format %q", value)
+	}
+}

--- a/runtimes/reporter/config_test.go
+++ b/runtimes/reporter/config_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseConfigDefaults(t *testing.T) {
+	config, err := parseConfig([]string{"--", "echo", "hello"}, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if config.Format != CaptureFormatLastLine {
+		t.Fatalf("expected last-line format, got %q", config.Format)
+	}
+	if config.TerminationPath != defaultTerminationPath {
+		t.Fatalf("unexpected termination path %q", config.TerminationPath)
+	}
+	if config.MaxCaptureBytes != defaultCaptureBytes {
+		t.Fatalf("unexpected capture limit %d", config.MaxCaptureBytes)
+	}
+	if len(config.Command) != 2 || config.Command[0] != "echo" || config.Command[1] != "hello" {
+		t.Fatalf("unexpected command %#v", config.Command)
+	}
+}
+
+func TestParseConfigUsesEnvironment(t *testing.T) {
+	values := map[string]string{
+		"KONTEXT_RESULT_FORMAT":       "KontextEnvelope",
+		"KONTEXT_TERMINATION_MESSAGE": "/tmp/result.json",
+	}
+	config, err := parseConfig([]string{"--", "agent"}, func(name string) string {
+		return values[name]
+	})
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if config.Format != CaptureFormatKontextEnvelope {
+		t.Fatalf("unexpected format %q", config.Format)
+	}
+	if config.TerminationPath != "/tmp/result.json" {
+		t.Fatalf("unexpected termination path %q", config.TerminationPath)
+	}
+}
+
+func TestParseConfigRejectsInvalidConfiguration(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing command"},
+		{name: "unknown format", args: []string{"--format", "json", "--", "agent"}},
+		{name: "empty termination path", args: []string{"--termination-log", "", "--", "agent"}},
+		{name: "capture limit below termination message", args: []string{"--max-capture-bytes", "100", "--", "agent"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseConfig(test.args, func(string) string { return "" }); err == nil {
+				t.Fatalf("expected configuration error")
+			}
+		})
+	}
+}

--- a/runtimes/reporter/main.go
+++ b/runtimes/reporter/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	os.Exit(execute(os.Args[1:], os.Getenv, os.Stdout, os.Stderr))
+}
+
+func execute(
+	args []string,
+	getenv func(string) string,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	config, err := parseConfig(args, getenv)
+	if err != nil {
+		fmt.Fprintf(
+			stderr,
+			"kontext reporter: %v\nusage: kontext-reporter [--format last-line|kontext-envelope] [--termination-log path] -- command [args...]\n",
+			err,
+		)
+		return reporterFailureExitCode
+	}
+
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(signals)
+
+	return runReporter(context.Background(), config, stdout, stderr, signals)
+}

--- a/runtimes/reporter/process_linux.go
+++ b/runtimes/reporter/process_linux.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const reapTimeout = 2 * time.Second
+
+var (
+	prepareOnce sync.Once
+	prepareErr  error
+)
+
+func prepareProcessSupervisor() error {
+	prepareOnce.Do(func() {
+		prepareErr = unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+	})
+	return prepareErr
+}
+
+func waitForMainProcess(mainPID int) (syscall.WaitStatus, error) {
+	for {
+		var status syscall.WaitStatus
+		waitedPID, err := syscall.Wait4(-1, &status, 0, nil)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		if waitedPID == mainPID {
+			return status, nil
+		}
+		// The reporter is a subreaper and may receive an orphaned descendant
+		// before the main child exits. Waiting for any child reaps it here.
+	}
+}
+
+func reapRemainingProcesses() error {
+	deadline := time.Now().Add(reapTimeout)
+	for {
+		var status syscall.WaitStatus
+		waitedPID, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+		switch {
+		case errors.Is(err, syscall.ECHILD):
+			return nil
+		case errors.Is(err, syscall.EINTR):
+			continue
+		case err != nil:
+			return fmt.Errorf("reap child processes: %w", err)
+		case waitedPID > 0:
+			continue
+		case time.Now().After(deadline):
+			return errors.New("timed out reaping child processes")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}

--- a/runtimes/reporter/process_linux_test.go
+++ b/runtimes/reporter/process_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestRunChildReapsOrphansWhileMainProcessRuns(t *testing.T) {
+	script := `
+orphan_pid=$(sh -c 'sleep 0.05 & echo $!')
+sleep 0.3
+if [ -e "/proc/${orphan_pid}/stat" ]; then
+  echo "orphan ${orphan_pid} was not reaped" >&2
+  exit 42
+fi
+`
+	var stderr bytes.Buffer
+	result, err := runChild(
+		context.Background(),
+		[]string{"sh", "-c", script},
+		&bytes.Buffer{},
+		&stderr,
+		newCapture(CaptureFormatLastLine, defaultCaptureBytes),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("run child: %v (stderr: %s)", err, stderr.String())
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", result.ExitCode, stderr.String())
+	}
+}

--- a/runtimes/reporter/process_other.go
+++ b/runtimes/reporter/process_other.go
@@ -1,0 +1,27 @@
+//go:build !linux
+
+package main
+
+import (
+	"errors"
+	"syscall"
+)
+
+func prepareProcessSupervisor() error {
+	return nil
+}
+
+func waitForMainProcess(mainPID int) (syscall.WaitStatus, error) {
+	for {
+		var status syscall.WaitStatus
+		_, err := syscall.Wait4(mainPID, &status, 0, nil)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		return status, err
+	}
+}
+
+func reapRemainingProcesses() error {
+	return nil
+}

--- a/runtimes/reporter/reporter.go
+++ b/runtimes/reporter/reporter.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+const (
+	reporterFailureExitCode = 125
+	childStartExitCode      = 126
+)
+
+func runReporter(
+	ctx context.Context,
+	config Config,
+	stdout io.Writer,
+	stderr io.Writer,
+	signals <-chan os.Signal,
+) int {
+	capture := newCapture(config.Format, config.MaxCaptureBytes)
+	child, err := runChild(ctx, config.Command, stdout, stderr, capture, signals)
+	if err != nil {
+		exitCode := reporterFailureExitCode
+		errorCode := "reporter_internal"
+		var startErr *ChildStartError
+		if errors.As(err, &startErr) {
+			exitCode = childStartExitCode
+			errorCode = "child_start_failed"
+		}
+		fmt.Fprintf(stderr, "kontext reporter: %v\n", err)
+		if writeErr := writeEnvelope(config.TerminationPath, failureEnvelope(errorCode, err.Error())); writeErr != nil {
+			fmt.Fprintf(stderr, "kontext reporter: write failure result: %v\n", writeErr)
+		}
+		return exitCode
+	}
+
+	envelope := envelopeFromCapture(config.Format, capture.Result(), child.ExitCode)
+	if err := writeEnvelope(config.TerminationPath, envelope); err != nil {
+		fmt.Fprintf(stderr, "kontext reporter: write termination message: %v\n", err)
+		return reporterFailureExitCode
+	}
+	return child.ExitCode
+}
+
+func envelopeFromCapture(format CaptureFormat, captured CapturedResult, childExitCode int) resultv1alpha1.Envelope {
+	var envelope resultv1alpha1.Envelope
+	switch format {
+	case CaptureFormatLastLine:
+		envelope = resultv1alpha1.Envelope{
+			APIVersion: resultv1alpha1.APIVersion,
+			Outcome:    resultv1alpha1.OutcomeSucceeded,
+		}
+		if captured.Found {
+			value, _ := json.Marshal(string(captured.Data))
+			envelope.Output = &resultv1alpha1.Output{
+				MediaType: resultv1alpha1.DefaultMediaType,
+				Value:     value,
+			}
+		}
+	case CaptureFormatKontextEnvelope:
+		envelope = envelopeFromPrefixedCandidate(captured)
+	default:
+		envelope = failureEnvelope("result_format_invalid", fmt.Sprintf("unsupported result format %q", format))
+	}
+
+	if childExitCode != 0 && envelope.Outcome != resultv1alpha1.OutcomeFailed {
+		envelope.Outcome = resultv1alpha1.OutcomeFailed
+		envelope.Error = &resultv1alpha1.ErrorInfo{
+			Code:    "agent_process_exit",
+			Message: fmt.Sprintf("agent process exited with code %d", childExitCode),
+		}
+	}
+	return envelope
+}
+
+func envelopeFromPrefixedCandidate(captured CapturedResult) resultv1alpha1.Envelope {
+	if !captured.Found {
+		return failureEnvelope("result_missing", "agent did not emit a prefixed Kontext result")
+	}
+	if captured.Truncated {
+		return failureEnvelope("result_invalid", "prefixed Kontext result exceeded the capture limit")
+	}
+
+	parsed, err := resultv1alpha1.Parse(string(captured.Data))
+	if err != nil {
+		return failureEnvelope("result_invalid", fmt.Sprintf("invalid prefixed Kontext result: %v", err))
+	}
+	if parsed.Envelope == nil {
+		return failureEnvelope("result_invalid", "prefixed Kontext result must be a versioned envelope")
+	}
+	return *parsed.Envelope
+}
+
+func failureEnvelope(code string, message string) resultv1alpha1.Envelope {
+	return resultv1alpha1.Envelope{
+		APIVersion: resultv1alpha1.APIVersion,
+		Outcome:    resultv1alpha1.OutcomeFailed,
+		Error: &resultv1alpha1.ErrorInfo{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+func writeEnvelope(path string, envelope resultv1alpha1.Envelope) error {
+	payload, err := resultv1alpha1.Compact(envelope, resultv1alpha1.MaxTerminationMessageBytes)
+	if err != nil {
+		return fmt.Errorf("compact result envelope: %w", err)
+	}
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/runtimes/reporter/reporter.go
+++ b/runtimes/reporter/reporter.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	reporterFailureExitCode = 125
-	childStartExitCode      = 126
+	reporterFailureExitCode  = 125
+	childStartExitCode       = 126
+	truncatedOutputMediaType = "application/vnd.kontext.truncated+json"
+	truncatedOutputJSON      = `{"truncated":true}`
 )
 
 func runReporter(
@@ -56,7 +58,16 @@ func envelopeFromCapture(format CaptureFormat, captured CapturedResult, childExi
 			APIVersion: resultv1alpha1.APIVersion,
 			Outcome:    resultv1alpha1.OutcomeSucceeded,
 		}
-		if captured.Found {
+		if captured.Truncated {
+			envelope.Output = &resultv1alpha1.Output{
+				MediaType: truncatedOutputMediaType,
+				Value:     json.RawMessage(truncatedOutputJSON),
+			}
+			envelope.Truncation = &resultv1alpha1.Truncation{
+				OriginalBytes:   captured.OriginalBytes,
+				OutputTruncated: true,
+			}
+		} else if captured.Found {
 			value, _ := json.Marshal(string(captured.Data))
 			envelope.Output = &resultv1alpha1.Output{
 				MediaType: resultv1alpha1.DefaultMediaType,

--- a/runtimes/reporter/reporter_test.go
+++ b/runtimes/reporter/reporter_test.go
@@ -45,6 +45,28 @@ func TestEnvelopeFromLastLine(t *testing.T) {
 	if empty.Outcome != resultv1alpha1.OutcomeSucceeded || empty.Output != nil {
 		t.Fatalf("expected successful empty output, got %#v", empty)
 	}
+
+	truncated := envelopeFromCapture(
+		CaptureFormatLastLine,
+		CapturedResult{
+			Data:          []byte("partial"),
+			Found:         true,
+			Truncated:     true,
+			OriginalBytes: 8192,
+		},
+		0,
+	)
+	if truncated.Outcome != resultv1alpha1.OutcomeSucceeded {
+		t.Fatalf("expected successful truncated result, got %s", truncated.Outcome)
+	}
+	if truncated.Truncation == nil || !truncated.Truncation.OutputTruncated ||
+		truncated.Truncation.OriginalBytes != 8192 {
+		t.Fatalf("expected explicit truncation metadata, got %#v", truncated.Truncation)
+	}
+	if truncated.Output == nil || truncated.Output.MediaType != truncatedOutputMediaType ||
+		string(truncated.Output.Value) != truncatedOutputJSON {
+		t.Fatalf("unexpected truncated output %#v", truncated.Output)
+	}
 }
 
 func TestEnvelopeFromPrefixedCandidate(t *testing.T) {

--- a/runtimes/reporter/reporter_test.go
+++ b/runtimes/reporter/reporter_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+func TestEnvelopeFromLastLine(t *testing.T) {
+	success := envelopeFromCapture(
+		CaptureFormatLastLine,
+		CapturedResult{Data: []byte("final answer"), Found: true},
+		0,
+	)
+	if success.Outcome != resultv1alpha1.OutcomeSucceeded {
+		t.Fatalf("expected success, got %s", success.Outcome)
+	}
+	if got := resultv1alpha1.ProjectLegacyResult(success.Output); got != "final answer" {
+		t.Fatalf("unexpected output %q", got)
+	}
+
+	failure := envelopeFromCapture(
+		CaptureFormatLastLine,
+		CapturedResult{Data: []byte("partial answer"), Found: true},
+		17,
+	)
+	if failure.Outcome != resultv1alpha1.OutcomeFailed {
+		t.Fatalf("expected failure, got %s", failure.Outcome)
+	}
+	if failure.Error == nil || failure.Error.Code != "agent_process_exit" {
+		t.Fatalf("unexpected process error %#v", failure.Error)
+	}
+	if got := resultv1alpha1.ProjectLegacyResult(failure.Output); got != "partial answer" {
+		t.Fatalf("unexpected partial output %q", got)
+	}
+
+	empty := envelopeFromCapture(CaptureFormatLastLine, CapturedResult{}, 0)
+	if empty.Outcome != resultv1alpha1.OutcomeSucceeded || empty.Output != nil {
+		t.Fatalf("expected successful empty output, got %#v", empty)
+	}
+}
+
+func TestEnvelopeFromPrefixedCandidate(t *testing.T) {
+	valid := CapturedResult{
+		Found: true,
+		Data: []byte(
+			`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","output":{"mediaType":"application/json","value":{"ok":true}}}`,
+		),
+	}
+	envelope := envelopeFromCapture(CaptureFormatKontextEnvelope, valid, 0)
+	if envelope.Outcome != resultv1alpha1.OutcomeSucceeded || envelope.Output == nil {
+		t.Fatalf("unexpected envelope %#v", envelope)
+	}
+
+	tests := []struct {
+		name     string
+		captured CapturedResult
+	}{
+		{name: "missing"},
+		{name: "truncated", captured: CapturedResult{Found: true, Truncated: true, Data: []byte(`{}`)}},
+		{name: "malformed", captured: CapturedResult{Found: true, Data: []byte(`{"apiVersion":`)}},
+		{name: "legacy", captured: CapturedResult{Found: true, Data: []byte(`{"result":"old"}`)}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := envelopeFromCapture(CaptureFormatKontextEnvelope, test.captured, 0)
+			if got.Outcome != resultv1alpha1.OutcomeFailed {
+				t.Fatalf("expected failed result, got %#v", got)
+			}
+			if got.Error == nil || (got.Error.Code != "result_missing" && got.Error.Code != "result_invalid") {
+				t.Fatalf("unexpected error %#v", got.Error)
+			}
+		})
+	}
+}
+
+func TestWriteEnvelopeCompactsOversizedOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "termination.json")
+	value, err := json.Marshal(strings.Repeat("x", 16*1024))
+	if err != nil {
+		t.Fatalf("marshal output: %v", err)
+	}
+	envelope := resultv1alpha1.Envelope{
+		APIVersion: resultv1alpha1.APIVersion,
+		Outcome:    resultv1alpha1.OutcomeSucceeded,
+		Output: &resultv1alpha1.Output{
+			MediaType: resultv1alpha1.DefaultMediaType,
+			Value:     value,
+		},
+	}
+	if err := writeEnvelope(path, envelope); err != nil {
+		t.Fatalf("write envelope: %v", err)
+	}
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read envelope: %v", err)
+	}
+	if len(payload) > resultv1alpha1.MaxTerminationMessageBytes {
+		t.Fatalf("termination payload is %d bytes", len(payload))
+	}
+	var compacted resultv1alpha1.Envelope
+	if err := json.Unmarshal(payload, &compacted); err != nil {
+		t.Fatalf("decode compacted envelope: %v", err)
+	}
+	if compacted.Truncation == nil || !compacted.Truncation.OutputTruncated {
+		t.Fatalf("expected explicit output truncation, got %#v", compacted.Truncation)
+	}
+}
+
+func TestRunReporterPreservesLogsAndChildExit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "termination.json")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	config := Config{
+		Format:          CaptureFormatLastLine,
+		TerminationPath: path,
+		MaxCaptureBytes: defaultCaptureBytes,
+		Command:         []string{"sh", "-c", `printf 'log one\nfinal answer\n'; printf 'warning\n' >&2; exit 7`},
+	}
+
+	exitCode := runReporter(context.Background(), config, &stdout, &stderr, nil)
+	if exitCode != 7 {
+		t.Fatalf("expected child exit 7, got %d", exitCode)
+	}
+	if stdout.String() != "log one\nfinal answer\n" {
+		t.Fatalf("stdout changed: %q", stdout.String())
+	}
+	if stderr.String() != "warning\n" {
+		t.Fatalf("stderr changed: %q", stderr.String())
+	}
+
+	envelope := readTestEnvelope(t, path)
+	if envelope.Outcome != resultv1alpha1.OutcomeFailed {
+		t.Fatalf("expected failed envelope, got %s", envelope.Outcome)
+	}
+	if envelope.Error == nil || envelope.Error.Code != "agent_process_exit" {
+		t.Fatalf("unexpected error %#v", envelope.Error)
+	}
+	if got := resultv1alpha1.ProjectLegacyResult(envelope.Output); got != "final answer" {
+		t.Fatalf("unexpected final output %q", got)
+	}
+}
+
+func TestRunReporterDistinguishesReporterFailures(t *testing.T) {
+	t.Run("child start", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "termination.json")
+		var stderr bytes.Buffer
+		config := Config{
+			Format:          CaptureFormatLastLine,
+			TerminationPath: path,
+			MaxCaptureBytes: defaultCaptureBytes,
+			Command:         []string{"/definitely/missing/agent"},
+		}
+		if exitCode := runReporter(context.Background(), config, &bytes.Buffer{}, &stderr, nil); exitCode != childStartExitCode {
+			t.Fatalf("expected child-start exit %d, got %d", childStartExitCode, exitCode)
+		}
+		envelope := readTestEnvelope(t, path)
+		if envelope.Error == nil || envelope.Error.Code != "child_start_failed" {
+			t.Fatalf("unexpected error %#v", envelope.Error)
+		}
+	})
+
+	t.Run("log forwarding", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "termination.json")
+		config := Config{
+			Format:          CaptureFormatLastLine,
+			TerminationPath: path,
+			MaxCaptureBytes: defaultCaptureBytes,
+			Command:         []string{"sh", "-c", "printf output"},
+		}
+		if exitCode := runReporter(context.Background(), config, failingWriter{}, &bytes.Buffer{}, nil); exitCode != reporterFailureExitCode {
+			t.Fatalf("expected reporter exit %d, got %d", reporterFailureExitCode, exitCode)
+		}
+		envelope := readTestEnvelope(t, path)
+		if envelope.Error == nil || envelope.Error.Code != "reporter_internal" {
+			t.Fatalf("unexpected error %#v", envelope.Error)
+		}
+	})
+}
+
+func readTestEnvelope(t *testing.T, path string) resultv1alpha1.Envelope {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read termination message: %v", err)
+	}
+	var envelope resultv1alpha1.Envelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		t.Fatalf("decode termination message: %v", err)
+	}
+	if err := envelope.Validate(); err != nil {
+		t.Fatalf("validate termination message: %v", err)
+	}
+	return envelope
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("log sink unavailable")
+}

--- a/runtimes/reporter/supervisor.go
+++ b/runtimes/reporter/supervisor.go
@@ -84,7 +84,7 @@ func runChild(
 
 	cleanupErr := cleanupProcessGroup(processGroupID)
 	reapErr := reapRemainingProcesses()
-	copies.Wait()
+	waitForStreamCopies(&copies, stdoutPipe, stderrPipe, cleanupErr, reapErr)
 	close(copyErrors)
 	copyErr := errors.Join(channelErrors(copyErrors)...)
 	result := ChildResult{ExitCode: exitCode(status)}
@@ -109,6 +109,25 @@ func runChild(
 	}
 
 	return result, nil
+}
+
+func waitForStreamCopies(
+	copies *sync.WaitGroup,
+	stdoutPipe io.Closer,
+	stderrPipe io.Closer,
+	cleanupErr error,
+	reapErr error,
+) {
+	if cleanupErr != nil || reapErr != nil {
+		// A descendant may still hold the write end of either pipe (for
+		// example while stuck in uninterruptible sleep). Close our readers so
+		// log-copy goroutines cannot block reporter shutdown indefinitely.
+		_ = stdoutPipe.Close()
+		_ = stderrPipe.Close()
+	}
+	copies.Wait()
+	_ = stdoutPipe.Close()
+	_ = stderrPipe.Close()
 }
 
 func copyChildStream(

--- a/runtimes/reporter/supervisor.go
+++ b/runtimes/reporter/supervisor.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+)
+
+type ChildStartError struct {
+	Err error
+}
+
+func (err *ChildStartError) Error() string {
+	return fmt.Sprintf("start child process: %v", err.Err)
+}
+
+func (err *ChildStartError) Unwrap() error {
+	return err.Err
+}
+
+type ChildResult struct {
+	ExitCode int
+}
+
+func runChild(
+	ctx context.Context,
+	command []string,
+	stdout io.Writer,
+	stderr io.Writer,
+	capture *Capture,
+	signals <-chan os.Signal,
+) (ChildResult, error) {
+	if len(command) == 0 {
+		return ChildResult{}, &ChildStartError{Err: errors.New("child command is empty")}
+	}
+	if err := prepareProcessSupervisor(); err != nil {
+		return ChildResult{}, fmt.Errorf("prepare process supervisor: %w", err)
+	}
+
+	stdoutForwarder := newStreamForwarder(stdout, capture)
+	stderrForwarder := newStreamForwarder(stderr, nil)
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return ChildResult{}, &ChildStartError{Err: fmt.Errorf("open child stdout: %w", err)}
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return ChildResult{}, &ChildStartError{Err: fmt.Errorf("open child stderr: %w", err)}
+	}
+
+	if err := cmd.Start(); err != nil {
+		return ChildResult{}, &ChildStartError{Err: err}
+	}
+	processGroupID := cmd.Process.Pid
+	if err := cmd.Process.Release(); err != nil {
+		_ = cleanupProcessGroup(processGroupID)
+		return ChildResult{}, fmt.Errorf("release child process handle: %w", err)
+	}
+
+	var copies sync.WaitGroup
+	copyErrors := make(chan error, 2)
+	copies.Add(2)
+	go copyChildStream(&copies, stdoutForwarder, stdoutPipe, copyErrors)
+	go copyChildStream(&copies, stderrForwarder, stderrPipe, copyErrors)
+
+	done := make(chan struct{})
+	forwardingDone := make(chan struct{})
+	signalErrors := &errorRecorder{}
+	go func() {
+		defer close(forwardingDone)
+		forwardSignals(ctx, signals, processGroupID, done, signalErrors)
+	}()
+
+	status, waitErr := waitForMainProcess(processGroupID)
+	close(done)
+	<-forwardingDone
+
+	cleanupErr := cleanupProcessGroup(processGroupID)
+	reapErr := reapRemainingProcesses()
+	copies.Wait()
+	close(copyErrors)
+	copyErr := errors.Join(channelErrors(copyErrors)...)
+	result := ChildResult{ExitCode: exitCode(status)}
+
+	if waitErr != nil {
+		return result, fmt.Errorf("wait for child process: %w", waitErr)
+	}
+	if copyErr != nil {
+		return result, fmt.Errorf("read child output: %w", copyErr)
+	}
+	if streamErr := errors.Join(stdoutForwarder.Err(), stderrForwarder.Err()); streamErr != nil {
+		return result, fmt.Errorf("forward child output: %w", streamErr)
+	}
+	if signalErr := signalErrors.Err(); signalErr != nil {
+		return result, signalErr
+	}
+	if cleanupErr != nil {
+		return result, cleanupErr
+	}
+	if reapErr != nil {
+		return result, reapErr
+	}
+
+	return result, nil
+}
+
+func copyChildStream(
+	waitGroup *sync.WaitGroup,
+	destination io.Writer,
+	source io.Reader,
+	copyErrors chan<- error,
+) {
+	defer waitGroup.Done()
+	if _, err := io.Copy(destination, source); err != nil {
+		copyErrors <- err
+	}
+}
+
+func channelErrors(errorsChannel <-chan error) []error {
+	var collected []error
+	for err := range errorsChannel {
+		collected = append(collected, err)
+	}
+	return collected
+}
+
+type streamForwarder struct {
+	sink    io.Writer
+	capture io.Writer
+
+	mu  sync.Mutex
+	err error
+}
+
+func newStreamForwarder(sink io.Writer, capture io.Writer) *streamForwarder {
+	return &streamForwarder{sink: sink, capture: capture}
+}
+
+func (forwarder *streamForwarder) Write(data []byte) (int, error) {
+	if forwarder.capture != nil {
+		_, _ = forwarder.capture.Write(data)
+	}
+
+	forwarder.mu.Lock()
+	defer forwarder.mu.Unlock()
+	if forwarder.err == nil {
+		if err := writeAll(forwarder.sink, data); err != nil {
+			forwarder.err = err
+		}
+	}
+
+	// Always report the input as consumed so os/exec continues draining the
+	// child's pipe even if the log destination fails.
+	return len(data), nil
+}
+
+func (forwarder *streamForwarder) Err() error {
+	forwarder.mu.Lock()
+	defer forwarder.mu.Unlock()
+	return forwarder.err
+}
+
+func writeAll(writer io.Writer, data []byte) error {
+	for len(data) > 0 {
+		written, err := writer.Write(data)
+		if err != nil {
+			return err
+		}
+		if written == 0 {
+			return io.ErrShortWrite
+		}
+		data = data[written:]
+	}
+	return nil
+}
+
+func forwardSignals(
+	ctx context.Context,
+	signals <-chan os.Signal,
+	processGroupID int,
+	done <-chan struct{},
+	recorder *errorRecorder,
+) {
+	contextDone := ctx.Done()
+	for {
+		select {
+		case <-done:
+			return
+		case signal, open := <-signals:
+			if !open {
+				signals = nil
+				continue
+			}
+			if err := forwardSignal(processGroupID, signal); err != nil {
+				recorder.Set(fmt.Errorf("forward signal %v: %w", signal, err))
+			}
+		case <-contextDone:
+			if err := syscall.Kill(-processGroupID, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+				recorder.Set(fmt.Errorf("forward context cancellation: %w", err))
+			}
+			contextDone = nil
+		}
+	}
+}
+
+func forwardSignal(processGroupID int, signal os.Signal) error {
+	unixSignal, ok := signal.(syscall.Signal)
+	if !ok {
+		return fmt.Errorf("unsupported signal type %T", signal)
+	}
+	if err := syscall.Kill(-processGroupID, unixSignal); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	return nil
+}
+
+func cleanupProcessGroup(processGroupID int) error {
+	if err := syscall.Kill(-processGroupID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("clean up child process group: %w", err)
+	}
+	return nil
+}
+
+func exitCode(status syscall.WaitStatus) int {
+	if status.Signaled() {
+		return 128 + int(status.Signal())
+	}
+	return status.ExitStatus()
+}
+
+type errorRecorder struct {
+	mu  sync.Mutex
+	err error
+}
+
+func (recorder *errorRecorder) Set(err error) {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.err == nil {
+		recorder.err = err
+	}
+}
+
+func (recorder *errorRecorder) Err() error {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	return recorder.err
+}

--- a/runtimes/reporter/supervisor_test.go
+++ b/runtimes/reporter/supervisor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -124,6 +125,44 @@ func TestRunChildCleansUpRemainingProcessGroup(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("descendant process %d survived reporter cleanup", pid)
+}
+
+func TestWaitForStreamCopiesClosesPipesAfterCleanupFailure(t *testing.T) {
+	stdoutReader, stdoutWriter := io.Pipe()
+	stderrReader, stderrWriter := io.Pipe()
+	t.Cleanup(func() {
+		_ = stdoutWriter.Close()
+		_ = stderrWriter.Close()
+	})
+
+	var copies sync.WaitGroup
+	copies.Add(2)
+	go func() {
+		defer copies.Done()
+		_, _ = io.Copy(io.Discard, stdoutReader)
+	}()
+	go func() {
+		defer copies.Done()
+		_, _ = io.Copy(io.Discard, stderrReader)
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		waitForStreamCopies(
+			&copies,
+			stdoutReader,
+			stderrReader,
+			nil,
+			errors.New("reap timeout"),
+		)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("stream copies remained blocked after cleanup failure")
+	}
 }
 
 type notifyingBuffer struct {

--- a/runtimes/reporter/supervisor_test.go
+++ b/runtimes/reporter/supervisor_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRunChildForwardsStreamsConcurrently(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	capture := newCapture(CaptureFormatLastLine, defaultCaptureBytes)
+	result, err := runChild(
+		context.Background(),
+		[]string{"sh", "-c", `printf 'out-1\n'; printf 'err-1\n' >&2; printf 'out-2\n'; printf 'err-2\n' >&2`},
+		&stdout,
+		&stderr,
+		capture,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("run child: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", result.ExitCode)
+	}
+	if stdout.String() != "out-1\nout-2\n" {
+		t.Fatalf("stdout changed: %q", stdout.String())
+	}
+	if stderr.String() != "err-1\nerr-2\n" {
+		t.Fatalf("stderr changed: %q", stderr.String())
+	}
+	if got := string(capture.Result().Data); got != "out-2" {
+		t.Fatalf("unexpected captured result %q", got)
+	}
+}
+
+func TestRunChildForwardsTerminationSignals(t *testing.T) {
+	tests := []struct {
+		name     string
+		signal   syscall.Signal
+		exitCode int
+	}{
+		{name: "SIGTERM", signal: syscall.SIGTERM, exitCode: 143},
+		{name: "SIGINT", signal: syscall.SIGINT, exitCode: 130},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout := newNotifyingBuffer("READY\n")
+			signals := make(chan os.Signal, 1)
+			type response struct {
+				result ChildResult
+				err    error
+			}
+			responseChannel := make(chan response, 1)
+			go func() {
+				result, err := runChild(
+					context.Background(),
+					[]string{"sh", "-c", "printf 'READY\\n'; exec sleep 30"},
+					stdout,
+					&bytes.Buffer{},
+					newCapture(CaptureFormatLastLine, defaultCaptureBytes),
+					signals,
+				)
+				responseChannel <- response{result: result, err: err}
+			}()
+
+			select {
+			case <-stdout.Ready():
+			case <-time.After(5 * time.Second):
+				t.Fatalf("child did not become ready")
+			}
+			signals <- test.signal
+
+			select {
+			case response := <-responseChannel:
+				if response.err != nil {
+					t.Fatalf("run child: %v", response.err)
+				}
+				if response.result.ExitCode != test.exitCode {
+					t.Fatalf("expected exit %d, got %d", test.exitCode, response.result.ExitCode)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatalf("child did not exit after signal")
+			}
+		})
+	}
+}
+
+func TestRunChildCleansUpRemainingProcessGroup(t *testing.T) {
+	var stdout bytes.Buffer
+	result, err := runChild(
+		context.Background(),
+		[]string{"sh", "-c", "sleep 30 & echo $!; exit 0"},
+		&stdout,
+		&bytes.Buffer{},
+		newCapture(CaptureFormatLastLine, defaultCaptureBytes),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("run child: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", result.ExitCode)
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(stdout.String()))
+	if err != nil {
+		t.Fatalf("parse descendant pid from %q: %v", stdout.String(), err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("descendant process %d survived reporter cleanup", pid)
+}
+
+type notifyingBuffer struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+	needle string
+	ready  chan struct{}
+	once   sync.Once
+}
+
+func newNotifyingBuffer(needle string) *notifyingBuffer {
+	return &notifyingBuffer{
+		needle: needle,
+		ready:  make(chan struct{}),
+	}
+}
+
+func (buffer *notifyingBuffer) Write(data []byte) (int, error) {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	written, err := buffer.buffer.Write(data)
+	if strings.Contains(buffer.buffer.String(), buffer.needle) {
+		buffer.once.Do(func() {
+			close(buffer.ready)
+		})
+	}
+	return written, err
+}
+
+func (buffer *notifyingBuffer) Ready() <-chan struct{} {
+	return buffer.ready
+}


### PR DESCRIPTION
## Summary
- add a static PID 1 reporter that supervises explicit agent commands while preserving stdout, stderr, signals, exit codes, and process-group cleanup
- extract bounded last-line or `KONTEXT_RESULT:` output and emit compact `kontext.dev/result/v1alpha1` termination envelopes with distinguishable failure modes
- add Linux orphan reaping, multi-architecture image packaging, CI smoke coverage, and reporter documentation

## Test plan
- [x] `make test`
- [x] `make verify`
- [x] `make vulncheck`
- [x] `go test -race ./runtimes/reporter -count=1`
- [x] reporter tests in a Linux container
- [x] local last-line and prefixed-envelope smoke tests
- [x] `linux/amd64` and `linux/arm64` image builds

Closes #15