### PR TITLE
Build model-agnostic reference runtime core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,8 @@ jobs:
       - name: Scan for known Go vulnerabilities
         run: make vulncheck
 
-  # These images are not loaded into kind for PR e2e (keyless echo path only).
-  # Build them here so Dockerfile breakage still fails CI without pretending
-  # they are part of the kind install surface.
+  # Build optional runtime images independently so Dockerfile breakage is
+  # visible even when a specific image is not exercised by every kind scenario.
   image-smoke:
     name: Image smoke
     runs-on: ubuntu-latest
@@ -56,6 +55,7 @@ jobs:
     env:
       KONTEXT_ANTHROPIC_IMAGE: kontext-runtime-anthropic:dev
       KONTEXT_REPORTER_IMAGE: kontext-reporter:dev
+      KONTEXT_REFERENCE_IMAGE: kontext-reference:dev
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -73,6 +73,17 @@ jobs:
           tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
           cache-from: type=gha,scope=reporter
           cache-to: type=gha,mode=max,scope=reporter
+
+      - name: Build model-agnostic reference runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: runtimes/reference/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
+          cache-from: type=gha,scope=reference
+          cache-to: type=gha,mode=max,scope=reference
 
       - name: Build Anthropic reference runtime image
         uses: docker/build-push-action@v6
@@ -96,6 +107,7 @@ jobs:
       KONTEXT_OPERATOR_IMAGE: kontext-operator:dev
       KONTEXT_ECHO_IMAGE: kontext-echo:dev
       KONTEXT_REPORTER_IMAGE: kontext-reporter:dev
+      KONTEXT_REFERENCE_IMAGE: kontext-reference:dev
       KONTEXT_STDOUT_FIXTURE_IMAGE: kontext-stdout-fixture:dev
       KONTEXT_DIAG_DIR: ${{ github.workspace }}/.ci-diagnostics
     steps:
@@ -135,6 +147,17 @@ jobs:
           tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
           cache-from: type=gha,scope=reporter
           cache-to: type=gha,mode=max,scope=reporter
+
+      - name: Build model-agnostic reference runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: runtimes/reference/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
+          cache-from: type=gha,scope=reference
+          cache-to: type=gha,mode=max,scope=reference
 
       - name: Build stdout-capture fixture image
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,34 @@ jobs:
           cache-from: type=gha,scope=reference
           cache-to: type=gha,mode=max,scope=reference
 
+      - name: Smoke test reference runtime execution
+        run: |
+          success_output="$(
+            docker run --rm \
+              -e KONTEXT_TERMINATION_MESSAGE=/dev/null \
+              -e KONTEXT_GOAL='CI fake success' \
+              -e KONTEXT_PROVIDER=fake \
+              -e KONTEXT_MODEL='opaque/ci-model' \
+              "${KONTEXT_REFERENCE_IMAGE}"
+          )"
+          [[ "${success_output}" == *'"apiVersion":"kontext.dev/event/v1alpha1"'* ]]
+          [[ "${success_output}" == *'KONTEXT_RESULT:'* ]]
+
+          set +e
+          failure_output="$(
+            docker run --rm \
+              -e KONTEXT_TERMINATION_MESSAGE=/dev/null \
+              -e KONTEXT_GOAL='CI fake failure' \
+              -e KONTEXT_PROVIDER=fake \
+              -e KONTEXT_MODEL='opaque/ci-model' \
+              -e KONTEXT_FAKE_SCENARIO=failure \
+              "${KONTEXT_REFERENCE_IMAGE}"
+          )"
+          failure_code=$?
+          set -e
+          [[ "${failure_code}" -eq 1 ]]
+          [[ "${failure_output}" == *'"outcome":"Failed"'* ]]
+
       - name: Build Anthropic reference runtime image
         uses: docker/build-push-action@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ IMG ?= kontext-operator:dev
 ECHO_IMG ?= kontext-echo:dev
 ANTHROPIC_IMG ?= kontext-runtime-anthropic:dev
 REPORTER_IMG ?= kontext-reporter:dev
+REFERENCE_IMG ?= kontext-reference:dev
 STDOUT_FIXTURE_IMG ?= kontext-stdout-fixture:dev
 
 # Get the currently used golang version
@@ -107,15 +108,19 @@ docker-build-anthropic: ## Build docker image for the Anthropic reference runtim
 docker-build-reporter: ## Build the reusable result reporter image.
 	docker build -f runtimes/reporter/Dockerfile -t ${REPORTER_IMG} .
 
+.PHONY: docker-build-reference
+docker-build-reference: ## Build the model-agnostic reference runtime image.
+	docker build -f runtimes/reference/Dockerfile -t ${REFERENCE_IMG} .
+
 .PHONY: docker-build-stdout-fixture
 docker-build-stdout-fixture: ## Build the generic image used by stdout-capture e2e.
 	docker build -t ${STDOUT_FIXTURE_IMG} runtimes/stdout-fixture
 
 .PHONY: docker-build-all
-docker-build-all: docker-build docker-build-echo docker-build-anthropic docker-build-reporter ## Build operator and runtime images.
+docker-build-all: docker-build docker-build-echo docker-build-anthropic docker-build-reporter docker-build-reference ## Build operator and runtime images.
 
 .PHONY: kind-install
-kind-install: docker-build docker-build-echo docker-build-reporter docker-build-stdout-fixture ## Build kind images and install the operator into kind.
+kind-install: docker-build docker-build-echo docker-build-reporter docker-build-reference docker-build-stdout-fixture ## Build kind images and install the operator into kind.
 	./scripts/install-go-kind.sh
 
 .PHONY: docker-push

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ kubectl get agentruns -w
 | Image | Purpose |
 |---|---|
 | [`runtimes/echo/`](runtimes/echo) | Keyless test runtime. Exercises the full contract (stdout thoughts, termination-log result, service heartbeat) without any API key. |
+| [`runtimes/reference/`](runtimes/reference) | Maintained model-agnostic Go runtime. Issue #17 provides a deterministic fake provider; real HTTP transports follow separately. |
 | [`runtimes/python-anthropic/`](runtimes/python-anthropic) | Real runtime backed by the Anthropic Messages API. Needs an `ANTHROPIC_API_KEY` secret via `spec.secretRef`. |
 | [`runtimes/reporter/`](runtimes/reporter) | Reusable PID 1 supervisor. Preserves child logs and process semantics while producing the versioned result envelope. |
 
@@ -116,6 +117,7 @@ make test              # unit + envtest reconciler tests
 make vulncheck         # scan reachable Go code for known vulnerabilities
 make docker-build-all  # operator + all maintained runtime images
 make docker-build-reporter  # build the reusable result reporter image
+make docker-build-reference # build the model-agnostic reference runtime
 make kind-install      # build operator + echo, load into kind, install controller
 make build             # compile operator binary to bin/manager
 make run               # run the controller locally against your kubeconfig

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,6 +38,7 @@ Kontext provides generic `Agent` and `AgentRun` primitives. Consumer-specific co
 ### M4 — Bring-your-own-runtime hardening
 - Echo runtime shipped (`runtimes/echo/`). Anthropic Python runner remains under `runtimes/python-anthropic/`.
 - Versioned results, the reusable reporter, and optional stdout capture support existing Linux images with explicit commands.
+- The maintained Go reference runtime has a provider-neutral core and deterministic fake-provider path.
 
 ### M5 — Governance
 - Per-agent ServiceAccount, finalizers, budget enforcement, CEL validation on the CRDs, events on transitions.

--- a/SPEC.md
+++ b/SPEC.md
@@ -267,6 +267,30 @@ otherwise empty shared volume; it drops capabilities, disables privilege
 escalation, and uses a read-only root filesystem. The workload container's own
 user and security context remain unchanged.
 
+### Maintained reference runtime
+
+`runtimes/reference` is the optional maintained Go runtime. It owns a small
+provider-neutral completion loop behind a normalized provider interface; it is
+not an agent framework. The runtime image bundles the reporter as PID 1 and
+emits its final versioned envelope through the `KONTEXT_RESULT:` stream
+contract.
+
+The initial keyless `fake` provider is deterministic and exercises the same
+configuration, conversation, event, result, cancellation, and failure paths
+that real HTTP transports use. `KONTEXT_MODEL` remains opaque and is never
+aliased or rewritten.
+
+Runtime wallclock cancellation is enabled only when
+`KONTEXT_BUDGET_WALLCLOCK` is present. Omission means no runtime deadline; the
+runtime does not invent a five-minute default. Declared tools are recorded in
+lifecycle events but are not exposed to the provider or executed until the
+bounded tool loop is implemented.
+
+The reference runtime emits versioned JSONL lifecycle, usage, output, and error
+events to stdout. It retains conversation state only in memory for one run and
+does not provide retries, planning, memory, retrieval, subagents, or background
+orchestration.
+
 ### Mode expectations for the image
 
 - **Task / Scheduled run image:** does its work, writes result, exits. Pod `restartPolicy: Never`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -280,11 +280,12 @@ configuration, conversation, event, result, cancellation, and failure paths
 that real HTTP transports use. `KONTEXT_MODEL` remains opaque and is never
 aliased or rewritten.
 
-Runtime wallclock cancellation is enabled only when
-`KONTEXT_BUDGET_WALLCLOCK` is present. Omission means no runtime deadline; the
-runtime does not invent a five-minute default. Declared tools are recorded in
-lifecycle events but are not exposed to the provider or executed until the
-bounded tool loop is implemented.
+The controller remains authoritative for wallclock enforcement. The runtime
+parses `KONTEXT_BUDGET_WALLCLOCK` but does not start a competing timer; it
+reacts to cancellation when the reporter forwards controller signals.
+Omission means no deadline, and the runtime does not invent a five-minute
+default. Declared tools are recorded in lifecycle events but are not exposed to
+the provider or executed until the bounded tool loop is implemented.
 
 The reference runtime emits versioned JSONL lifecycle, usage, output, and error
 events to stdout. It retains conversation state only in memory for one run and

--- a/deploy/examples/v1alpha1/reference-fake-run.yaml
+++ b/deploy/examples/v1alpha1/reference-fake-run.yaml
@@ -1,0 +1,15 @@
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-fake
+spec:
+  goal: Explain the Kontext runtime contract in one sentence.
+  provider: fake
+  model: vendor/opaque-model@2026
+  runtime:
+    image: kontext-reference:dev
+  env:
+    - name: KONTEXT_FAKE_SCENARIO
+      value: success
+  budget:
+    wallclock: 2m

--- a/pkg/result/v1alpha1/stream.go
+++ b/pkg/result/v1alpha1/stream.go
@@ -1,0 +1,34 @@
+package v1alpha1
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+// EnvelopeLinePrefix identifies a complete versioned result envelope in a
+// runtime's stdout stream.
+const EnvelopeLinePrefix = "KONTEXT_RESULT:"
+
+// WriteEnvelopeLine compacts the envelope and writes the single stdout line
+// that reporters recognize. This is the producer half of the stream contract;
+// ExtractEnvelopePayload is the consumer half.
+func WriteEnvelopeLine(writer io.Writer, envelope Envelope) error {
+	payload, err := Compact(envelope, MaxTerminationMessageBytes)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(writer, "%s %s\n", EnvelopeLinePrefix, payload)
+	return err
+}
+
+// ExtractEnvelopePayload reports whether line carries a result envelope and,
+// if so, returns the payload with the prefix and surrounding whitespace
+// stripped. The returned slice aliases line.
+func ExtractEnvelopePayload(line []byte) ([]byte, bool) {
+	trimmed := bytes.TrimSpace(line)
+	if !bytes.HasPrefix(trimmed, []byte(EnvelopeLinePrefix)) {
+		return nil, false
+	}
+	return bytes.TrimSpace(trimmed[len(EnvelopeLinePrefix):]), true
+}

--- a/pkg/result/v1alpha1/stream_test.go
+++ b/pkg/result/v1alpha1/stream_test.go
@@ -1,0 +1,54 @@
+package v1alpha1_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+func TestWriteEnvelopeLineRoundTripsThroughExtract(t *testing.T) {
+	envelope := resultv1alpha1.Envelope{
+		APIVersion: resultv1alpha1.APIVersion,
+		Outcome:    resultv1alpha1.OutcomeFailed,
+		Error: &resultv1alpha1.ErrorInfo{
+			Code:    "provider_error",
+			Message: "unavailable",
+		},
+	}
+	var output bytes.Buffer
+	if err := resultv1alpha1.WriteEnvelopeLine(&output, envelope); err != nil {
+		t.Fatalf("write envelope line: %v", err)
+	}
+	line := strings.TrimSuffix(output.String(), "\n")
+	if strings.Contains(line, "\n") {
+		t.Fatalf("expected a single line, got %q", output.String())
+	}
+
+	payload, found := resultv1alpha1.ExtractEnvelopePayload([]byte(line))
+	if !found {
+		t.Fatalf("payload not recognized in %q", line)
+	}
+	parsed, err := resultv1alpha1.Parse(string(payload))
+	if err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	if parsed.Envelope == nil || parsed.Envelope.Outcome != resultv1alpha1.OutcomeFailed {
+		t.Fatalf("unexpected parsed result %#v", parsed)
+	}
+}
+
+func TestExtractEnvelopePayloadIgnoresOrdinaryLines(t *testing.T) {
+	for _, line := range []string{"", "   ", "plain output", `{"apiVersion":"x"}`} {
+		if _, found := resultv1alpha1.ExtractEnvelopePayload([]byte(line)); found {
+			t.Fatalf("line %q must not be treated as an envelope", line)
+		}
+	}
+	payload, found := resultv1alpha1.ExtractEnvelopePayload(
+		[]byte("  " + resultv1alpha1.EnvelopeLinePrefix + "  {} \r"),
+	)
+	if !found || string(payload) != "{}" {
+		t.Fatalf("expected trimmed payload {}, got %q found=%v", payload, found)
+	}
+}

--- a/runtimes/reference/Dockerfile
+++ b/runtimes/reference/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.26.5 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY pkg/result/ pkg/result/
+COPY runtimes/reporter/ runtimes/reporter/
+COPY runtimes/reference/ runtimes/reference/
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath -ldflags="-s -w" -o /kontext-reporter ./runtimes/reporter
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath -ldflags="-s -w" -o /kontext-reference ./runtimes/reference
+
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=builder /kontext-reporter /kontext-reporter
+COPY --from=builder /kontext-reference /kontext-reference
+
+USER 65532:65532
+ENTRYPOINT ["/kontext-reporter", "--format", "kontext-envelope", "--", "/kontext-reference"]

--- a/runtimes/reference/README.md
+++ b/runtimes/reference/README.md
@@ -40,8 +40,10 @@ No private chain-of-thought is emitted.
 | `KONTEXT_FAKE_SCENARIO` | no | `success`, `failure`, `malformed`, or `delay` |
 | `KONTEXT_FAKE_DELAY` | delay only | Positive Go duration such as `250ms` |
 
-There is deliberately no hidden five-minute deadline. The runtime creates a
-timeout only when `KONTEXT_BUDGET_WALLCLOCK` is present.
+There is deliberately no hidden five-minute deadline. The Kubernetes
+controller remains authoritative for `KONTEXT_BUDGET_WALLCLOCK`; the runtime
+parses the value but does not start a competing timer. It reacts promptly when
+the reporter forwards controller cancellation signals.
 
 Model identifiers pass through unchanged.
 

--- a/runtimes/reference/README.md
+++ b/runtimes/reference/README.md
@@ -1,0 +1,82 @@
+# Kontext reference runtime
+
+The maintained reference runtime is a small provider-neutral execution loop.
+It demonstrates how a model-backed agent behaves as a Kubernetes workload
+without adopting an agent framework.
+
+Issue #17 ships only the deterministic `fake` provider. Anthropic and
+OpenAI-compatible HTTP adapters are added separately.
+
+## Execution model
+
+The image bundles two static binaries:
+
+```text
+kontext-reporter (PID 1)
+└─ kontext-reference
+```
+
+The runtime emits versioned JSONL lifecycle, usage, output, and error events to
+stdout. Its final line is a `KONTEXT_RESULT:`-prefixed result envelope. The
+reporter preserves the logs and process exit status, compacts the envelope, and
+writes `/dev/termination-log`.
+
+No private chain-of-thought is emitted.
+
+## Configuration
+
+| Environment variable | Required | Meaning |
+|---|---|---|
+| `KONTEXT_GOAL` | yes | Concrete task for this run |
+| `KONTEXT_PROVIDER` | yes | Provider adapter name; currently `fake` |
+| `KONTEXT_MODEL` | yes | Opaque provider model identifier |
+| `KONTEXT_RUN_NAME` | no | Run metadata; defaults to `unknown-run` |
+| `KONTEXT_AGENT_NAME` | no | Agent metadata; defaults to run name |
+| `KONTEXT_TOOLS` | no | Declared allowlist; recorded but not executed yet |
+| `KONTEXT_BUDGET_TOKENS` | no | Positive requested output/token limit |
+| `KONTEXT_BUDGET_WALLCLOCK` | no | Optional Go duration; omitted means disabled |
+| `KONTEXT_BUDGET_DOLLARS` | no | Optional non-negative recorded budget |
+| `KONTEXT_PROVIDER_ENDPOINT` | no | Absolute HTTP(S) endpoint for future adapters |
+| `KONTEXT_FAKE_SCENARIO` | no | `success`, `failure`, `malformed`, or `delay` |
+| `KONTEXT_FAKE_DELAY` | delay only | Positive Go duration such as `250ms` |
+
+There is deliberately no hidden five-minute deadline. The runtime creates a
+timeout only when `KONTEXT_BUDGET_WALLCLOCK` is present.
+
+Model identifiers pass through unchanged.
+
+## Local fake-provider run
+
+```bash
+KONTEXT_GOAL="Explain the runtime contract" \
+KONTEXT_PROVIDER=fake \
+KONTEXT_MODEL="any-opaque-model-id" \
+go run ./runtimes/reference
+```
+
+Build the production image:
+
+```bash
+make docker-build-reference
+```
+
+## Dependency inventory
+
+The reference binary uses only the Go standard library and in-repository
+Kontext packages. The bundled reporter additionally uses `golang.org/x/sys`
+for Linux process supervision. The production image contains:
+
+- `gcr.io/distroless/static:nonroot`
+- `/kontext-reporter`
+- `/kontext-reference`
+
+It contains no shell, package manager, CA bundle requirement for the fake
+provider, agent framework, retrieval system, or persistent storage.
+
+## Explicit limits
+
+- One provider completion per run.
+- Conversation state exists only in memory for that run.
+- Tools are declared but not executed.
+- No retries, planning, memory, retrieval, subagents, or background work.
+- No real provider credentials or network calls in issue #17.

--- a/runtimes/reference/internal/config/config.go
+++ b/runtimes/reference/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"net/url"
 	"strconv"
 	"strings"
@@ -34,7 +35,7 @@ func Load(getenv func(string) string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	model, err := required(getenv, "KONTEXT_MODEL")
+	model, err := requiredOpaque(getenv, "KONTEXT_MODEL")
 	if err != nil {
 		return Config{}, err
 	}
@@ -107,6 +108,14 @@ func required(getenv func(string) string, name string) (string, error) {
 	return value, nil
 }
 
+func requiredOpaque(getenv func(string) string, name string) (string, error) {
+	value := getenv(name)
+	if strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	return value, nil
+}
+
 func optionalPositiveInt64(value string, name string) (*int64, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -137,7 +146,7 @@ func optionalNonNegativeFloat(value string, name string) (*float64, error) {
 		return nil, nil
 	}
 	parsed, err := strconv.ParseFloat(value, 64)
-	if err != nil || parsed < 0 {
+	if err != nil || parsed < 0 || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
 		return nil, fmt.Errorf("%s must be a non-negative number", name)
 	}
 	return &parsed, nil

--- a/runtimes/reference/internal/config/config.go
+++ b/runtimes/reference/internal/config/config.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	RunName   string
+	AgentName string
+	Goal      string
+	Provider  string
+	Model     string
+	Tools     []string
+
+	TokenBudget     *int64
+	WallclockBudget *time.Duration
+	DollarBudget    *float64
+
+	ProviderEndpoint string
+	FakeScenario     string
+	FakeDelay        time.Duration
+}
+
+func Load(getenv func(string) string) (Config, error) {
+	goal, err := required(getenv, "KONTEXT_GOAL")
+	if err != nil {
+		return Config{}, err
+	}
+	provider, err := required(getenv, "KONTEXT_PROVIDER")
+	if err != nil {
+		return Config{}, err
+	}
+	model, err := required(getenv, "KONTEXT_MODEL")
+	if err != nil {
+		return Config{}, err
+	}
+
+	tokenBudget, err := optionalPositiveInt64(getenv("KONTEXT_BUDGET_TOKENS"), "KONTEXT_BUDGET_TOKENS")
+	if err != nil {
+		return Config{}, err
+	}
+	wallclockBudget, err := optionalPositiveDuration(
+		getenv("KONTEXT_BUDGET_WALLCLOCK"),
+		"KONTEXT_BUDGET_WALLCLOCK",
+	)
+	if err != nil {
+		return Config{}, err
+	}
+	dollarBudget, err := optionalNonNegativeFloat(
+		getenv("KONTEXT_BUDGET_DOLLARS"),
+		"KONTEXT_BUDGET_DOLLARS",
+	)
+	if err != nil {
+		return Config{}, err
+	}
+	endpoint, err := optionalEndpoint(getenv("KONTEXT_PROVIDER_ENDPOINT"))
+	if err != nil {
+		return Config{}, err
+	}
+
+	runName := strings.TrimSpace(getenv("KONTEXT_RUN_NAME"))
+	if runName == "" {
+		runName = "unknown-run"
+	}
+	agentName := strings.TrimSpace(getenv("KONTEXT_AGENT_NAME"))
+	if agentName == "" {
+		agentName = runName
+	}
+
+	// The fake-provider knobs are opaque strings here; the provider package
+	// owns their meaning and validation.
+	fakeScenario := strings.ToLower(strings.TrimSpace(getenv("KONTEXT_FAKE_SCENARIO")))
+	fakeDelayValue, err := optionalPositiveDuration(getenv("KONTEXT_FAKE_DELAY"), "KONTEXT_FAKE_DELAY")
+	if err != nil {
+		return Config{}, err
+	}
+	var fakeDelay time.Duration
+	if fakeDelayValue != nil {
+		fakeDelay = *fakeDelayValue
+	}
+
+	return Config{
+		RunName:          runName,
+		AgentName:        agentName,
+		Goal:             goal,
+		Provider:         strings.ToLower(provider),
+		Model:            model,
+		Tools:            parseTools(getenv("KONTEXT_TOOLS")),
+		TokenBudget:      tokenBudget,
+		WallclockBudget:  wallclockBudget,
+		DollarBudget:     dollarBudget,
+		ProviderEndpoint: endpoint,
+		FakeScenario:     fakeScenario,
+		FakeDelay:        fakeDelay,
+	}, nil
+}
+
+func required(getenv func(string) string, name string) (string, error) {
+	value := strings.TrimSpace(getenv(name))
+	if value == "" {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	return value, nil
+}
+
+func optionalPositiveInt64(value string, name string) (*int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || parsed <= 0 {
+		return nil, fmt.Errorf("%s must be a positive integer", name)
+	}
+	return &parsed, nil
+}
+
+func optionalPositiveDuration(value string, name string) (*time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil || parsed <= 0 {
+		return nil, fmt.Errorf("%s must be a positive duration", name)
+	}
+	return &parsed, nil
+}
+
+func optionalNonNegativeFloat(value string, name string) (*float64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil || parsed < 0 {
+		return nil, fmt.Errorf("%s must be a non-negative number", name)
+	}
+	return &parsed, nil
+}
+
+func optionalEndpoint(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", fmt.Errorf("KONTEXT_PROVIDER_ENDPOINT must be an absolute HTTP(S) URL")
+	}
+	return value, nil
+}
+
+func parseTools(value string) []string {
+	var tools []string
+	for _, tool := range strings.Split(value, ",") {
+		if normalized := strings.TrimSpace(tool); normalized != "" {
+			tools = append(tools, normalized)
+		}
+	}
+	return tools
+}

--- a/runtimes/reference/internal/config/config_test.go
+++ b/runtimes/reference/internal/config/config_test.go
@@ -14,7 +14,7 @@ func TestLoadPreservesOpaqueModelAndParsesOptionalInputs(t *testing.T) {
 		"KONTEXT_AGENT_NAME":        "agent-1",
 		"KONTEXT_GOAL":              "explain the contract",
 		"KONTEXT_PROVIDER":          "FAKE",
-		"KONTEXT_MODEL":             "vendor/model@2026:beta",
+		"KONTEXT_MODEL":             " vendor/model@2026:beta ",
 		"KONTEXT_TOOLS":             " one, two ,,",
 		"KONTEXT_BUDGET_TOKENS":     "123",
 		"KONTEXT_BUDGET_WALLCLOCK":  "1m30s",
@@ -25,7 +25,7 @@ func TestLoadPreservesOpaqueModelAndParsesOptionalInputs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
-	if loaded.Model != "vendor/model@2026:beta" {
+	if loaded.Model != " vendor/model@2026:beta " {
 		t.Fatalf("model identifier changed: %q", loaded.Model)
 	}
 	if loaded.Provider != "fake" {
@@ -69,6 +69,8 @@ func TestLoadValidatesRequiredAndOptionalConfiguration(t *testing.T) {
 		{name: "invalid tokens", change: func(values map[string]string) { values["KONTEXT_BUDGET_TOKENS"] = "zero" }},
 		{name: "invalid wallclock", change: func(values map[string]string) { values["KONTEXT_BUDGET_WALLCLOCK"] = "5 minutes" }},
 		{name: "negative dollars", change: func(values map[string]string) { values["KONTEXT_BUDGET_DOLLARS"] = "-1" }},
+		{name: "NaN dollars", change: func(values map[string]string) { values["KONTEXT_BUDGET_DOLLARS"] = "NaN" }},
+		{name: "infinite dollars", change: func(values map[string]string) { values["KONTEXT_BUDGET_DOLLARS"] = "+Inf" }},
 		{name: "invalid endpoint", change: func(values map[string]string) { values["KONTEXT_PROVIDER_ENDPOINT"] = "localhost:8080" }},
 		{name: "invalid fake delay", change: func(values map[string]string) { values["KONTEXT_FAKE_DELAY"] = "-3s" }},
 	}

--- a/runtimes/reference/internal/config/config_test.go
+++ b/runtimes/reference/internal/config/config_test.go
@@ -1,0 +1,111 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+)
+
+func TestLoadPreservesOpaqueModelAndParsesOptionalInputs(t *testing.T) {
+	values := map[string]string{
+		"KONTEXT_RUN_NAME":          "run-1",
+		"KONTEXT_AGENT_NAME":        "agent-1",
+		"KONTEXT_GOAL":              "explain the contract",
+		"KONTEXT_PROVIDER":          "FAKE",
+		"KONTEXT_MODEL":             "vendor/model@2026:beta",
+		"KONTEXT_TOOLS":             " one, two ,,",
+		"KONTEXT_BUDGET_TOKENS":     "123",
+		"KONTEXT_BUDGET_WALLCLOCK":  "1m30s",
+		"KONTEXT_BUDGET_DOLLARS":    "0",
+		"KONTEXT_PROVIDER_ENDPOINT": "http://provider.default.svc:8080/v1",
+	}
+	loaded, err := config.Load(lookup(values))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.Model != "vendor/model@2026:beta" {
+		t.Fatalf("model identifier changed: %q", loaded.Model)
+	}
+	if loaded.Provider != "fake" {
+		t.Fatalf("expected normalized provider fake, got %q", loaded.Provider)
+	}
+	if strings.Join(loaded.Tools, ",") != "one,two" {
+		t.Fatalf("unexpected tools %#v", loaded.Tools)
+	}
+	if loaded.TokenBudget == nil || *loaded.TokenBudget != 123 {
+		t.Fatalf("unexpected token budget %v", loaded.TokenBudget)
+	}
+	if loaded.WallclockBudget == nil || *loaded.WallclockBudget != 90*time.Second {
+		t.Fatalf("unexpected wallclock budget %v", loaded.WallclockBudget)
+	}
+	if loaded.DollarBudget == nil || *loaded.DollarBudget != 0 {
+		t.Fatalf("expected measured zero dollar budget, got %v", loaded.DollarBudget)
+	}
+	if loaded.ProviderEndpoint != "http://provider.default.svc:8080/v1" {
+		t.Fatalf("unexpected endpoint %q", loaded.ProviderEndpoint)
+	}
+}
+
+func TestLoadLeavesLimitsDisabledWhenOmitted(t *testing.T) {
+	loaded, err := config.Load(lookup(requiredValues()))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.TokenBudget != nil || loaded.WallclockBudget != nil || loaded.DollarBudget != nil {
+		t.Fatalf("omitted limits must remain disabled: %#v", loaded)
+	}
+}
+
+func TestLoadValidatesRequiredAndOptionalConfiguration(t *testing.T) {
+	tests := []struct {
+		name   string
+		change func(map[string]string)
+	}{
+		{name: "missing goal", change: func(values map[string]string) { delete(values, "KONTEXT_GOAL") }},
+		{name: "missing provider", change: func(values map[string]string) { delete(values, "KONTEXT_PROVIDER") }},
+		{name: "missing model", change: func(values map[string]string) { delete(values, "KONTEXT_MODEL") }},
+		{name: "invalid tokens", change: func(values map[string]string) { values["KONTEXT_BUDGET_TOKENS"] = "zero" }},
+		{name: "invalid wallclock", change: func(values map[string]string) { values["KONTEXT_BUDGET_WALLCLOCK"] = "5 minutes" }},
+		{name: "negative dollars", change: func(values map[string]string) { values["KONTEXT_BUDGET_DOLLARS"] = "-1" }},
+		{name: "invalid endpoint", change: func(values map[string]string) { values["KONTEXT_PROVIDER_ENDPOINT"] = "localhost:8080" }},
+		{name: "invalid fake delay", change: func(values map[string]string) { values["KONTEXT_FAKE_DELAY"] = "-3s" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values := requiredValues()
+			test.change(values)
+			if _, err := config.Load(lookup(values)); err == nil {
+				t.Fatalf("expected configuration error")
+			}
+		})
+	}
+}
+
+func TestLoadParsesFakeDelay(t *testing.T) {
+	values := requiredValues()
+	values["KONTEXT_FAKE_SCENARIO"] = "delay"
+	values["KONTEXT_FAKE_DELAY"] = "25ms"
+	loaded, err := config.Load(lookup(values))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.FakeDelay != 25*time.Millisecond {
+		t.Fatalf("unexpected fake delay %s", loaded.FakeDelay)
+	}
+}
+
+func requiredValues() map[string]string {
+	return map[string]string{
+		"KONTEXT_GOAL":     "test goal",
+		"KONTEXT_PROVIDER": "fake",
+		"KONTEXT_MODEL":    "opaque-model",
+	}
+}
+
+func lookup(values map[string]string) func(string) string {
+	return func(name string) string {
+		return values[name]
+	}
+}

--- a/runtimes/reference/internal/conversation/state.go
+++ b/runtimes/reference/internal/conversation/state.go
@@ -1,0 +1,40 @@
+package conversation
+
+import (
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+type State struct {
+	messages []runtimeapi.Message
+}
+
+func New(goal string) *State {
+	return &State{
+		messages: []runtimeapi.Message{
+			{
+				Role: runtimeapi.RoleUser,
+				Content: []runtimeapi.ContentBlock{
+					{Type: runtimeapi.ContentTypeText, Text: goal},
+				},
+			},
+		},
+	}
+}
+
+func (state *State) Append(message runtimeapi.Message) {
+	state.messages = append(state.messages, cloneMessage(message))
+}
+
+func (state *State) Messages() []runtimeapi.Message {
+	messages := make([]runtimeapi.Message, len(state.messages))
+	for index, message := range state.messages {
+		messages[index] = cloneMessage(message)
+	}
+	return messages
+}
+
+func cloneMessage(message runtimeapi.Message) runtimeapi.Message {
+	cloned := message
+	cloned.Content = append([]runtimeapi.ContentBlock(nil), message.Content...)
+	return cloned
+}

--- a/runtimes/reference/internal/conversation/state_test.go
+++ b/runtimes/reference/internal/conversation/state_test.go
@@ -1,0 +1,27 @@
+package conversation_test
+
+import (
+	"testing"
+
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/conversation"
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+func TestStateTracksConversationWithoutExposingMutableSlices(t *testing.T) {
+	state := conversation.New("goal")
+	state.Append(runtimeapi.Message{
+		Role: runtimeapi.RoleAssistant,
+		Content: []runtimeapi.ContentBlock{
+			{Type: runtimeapi.ContentTypeText, Text: "answer"},
+		},
+	})
+
+	messages := state.Messages()
+	if len(messages) != 2 || runtimeapi.MessageText(messages[0]) != "goal" {
+		t.Fatalf("unexpected conversation %#v", messages)
+	}
+	messages[0].Content[0].Text = "mutated"
+	if got := runtimeapi.MessageText(state.Messages()[0]); got != "goal" {
+		t.Fatalf("state was mutated through returned slice: %q", got)
+	}
+}

--- a/runtimes/reference/internal/engine/engine.go
+++ b/runtimes/reference/internal/engine/engine.go
@@ -1,0 +1,179 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+// Emitter publishes best-effort observability events. The result envelope is
+// the runtime contract; event emission never fails a run.
+type Emitter interface {
+	Emit(events.Type, any)
+}
+
+type Resolver func(config.Config) (provider.Provider, error)
+
+type Runner struct {
+	Emitter Emitter
+	Resolve Resolver
+	Now     func() time.Time
+}
+
+type Result struct {
+	Envelope resultv1alpha1.Envelope
+	ExitCode int
+}
+
+func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Result {
+	resolve := runner.Resolve
+	if resolve == nil {
+		resolve = provider.Resolve
+	}
+	now := runner.Now
+	if now == nil {
+		now = time.Now
+	}
+	startedAt := now().UTC()
+	metadata := func(requestID string) Metadata {
+		return Metadata{
+			Provider:    runtimeConfig.Provider,
+			Model:       runtimeConfig.Model,
+			RequestID:   requestID,
+			StartedAt:   startedAt,
+			CompletedAt: now().UTC(),
+		}
+	}
+
+	runner.emit(events.TypeLifecycle, map[string]any{
+		"phase":    "started",
+		"runName":  runtimeConfig.RunName,
+		"provider": runtimeConfig.Provider,
+		"model":    runtimeConfig.Model,
+	})
+	if len(runtimeConfig.Tools) > 0 {
+		runner.emit(events.TypeLifecycle, map[string]any{
+			"phase": "tools_declared_not_executed",
+			"count": len(runtimeConfig.Tools),
+		})
+	}
+
+	selectedProvider, err := resolve(runtimeConfig)
+	if err != nil {
+		runner.emitError("unsupported_provider", err.Error(), nil)
+		return failed("unsupported_provider", err.Error(), nil, metadata(""))
+	}
+
+	request := runtimeapi.CompletionRequest{
+		Model: runtimeConfig.Model,
+		Messages: []runtimeapi.Message{
+			{
+				Role: runtimeapi.RoleUser,
+				Content: []runtimeapi.ContentBlock{
+					{Type: runtimeapi.ContentTypeText, Text: runtimeConfig.Goal},
+				},
+			},
+		},
+		Tools:     append([]string(nil), runtimeConfig.Tools...),
+		MaxTokens: runtimeConfig.TokenBudget,
+	}
+
+	providerContext := ctx
+	cancel := func() {}
+	if runtimeConfig.WallclockBudget != nil {
+		providerContext, cancel = context.WithTimeout(ctx, *runtimeConfig.WallclockBudget)
+	}
+	defer cancel()
+
+	response, err := selectedProvider.Complete(providerContext, request)
+	if err != nil {
+		code, message, retryable, requestID := normalizeError(providerContext, err)
+		runner.emitError(code, message, retryable)
+		return failed(code, message, retryable, metadata(requestID))
+	}
+	if err := runtimeapi.ValidateResponse(response); err != nil {
+		message := fmt.Sprintf("provider returned an invalid response: %v", err)
+		runner.emitError("invalid_provider_response", message, nil)
+		return failed(
+			"invalid_provider_response",
+			message,
+			nil,
+			metadata(response.RequestID),
+		)
+	}
+
+	completedMetadata := metadata(response.RequestID)
+	runner.emit(events.TypeLifecycle, map[string]any{
+		"phase":          "provider_completed",
+		"stopReason":     response.StopReason,
+		"durationMillis": completedMetadata.CompletedAt.Sub(startedAt).Milliseconds(),
+	})
+	if usage := envelopeUsage(response.Usage); usage != nil {
+		runner.emit(events.TypeUsage, usage)
+	}
+	runner.emit(events.TypeOutput, map[string]any{
+		"mediaType": resultv1alpha1.DefaultMediaType,
+		"value":     runtimeapi.MessageText(response.Message),
+	})
+
+	return Result{
+		Envelope: Success(response, completedMetadata),
+		ExitCode: 0,
+	}
+}
+
+func (runner Runner) emit(eventType events.Type, data any) {
+	if runner.Emitter == nil {
+		return
+	}
+	runner.Emitter.Emit(eventType, data)
+}
+
+func (runner Runner) emitError(code string, message string, retryable *bool) {
+	runner.emit(events.TypeError, map[string]any{
+		"code":      code,
+		"message":   message,
+		"retryable": retryable,
+	})
+}
+
+func failed(
+	code string,
+	message string,
+	retryable *bool,
+	metadata Metadata,
+) Result {
+	return Result{
+		Envelope: Failure(code, message, retryable, metadata),
+		ExitCode: 1,
+	}
+}
+
+func normalizeError(
+	ctx context.Context,
+	err error,
+) (code string, message string, retryable *bool, requestID string) {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+		value := true
+		return "deadline_exceeded", "runtime wallclock limit exceeded", &value, ""
+	}
+	if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
+		value := true
+		return "cancelled", "runtime execution was cancelled", &value, ""
+	}
+	var providerError *runtimeapi.ProviderError
+	if errors.As(err, &providerError) {
+		return providerError.Code,
+			providerError.Message,
+			providerError.Retryable,
+			providerError.RequestID
+	}
+	return "provider_error", err.Error(), nil, ""
+}

--- a/runtimes/reference/internal/engine/engine.go
+++ b/runtimes/reference/internal/engine/engine.go
@@ -8,6 +8,7 @@ import (
 
 	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
 	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/conversation"
 	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
 	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
 	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
@@ -53,10 +54,11 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 	}
 
 	runner.emit(events.TypeLifecycle, map[string]any{
-		"phase":    "started",
-		"runName":  runtimeConfig.RunName,
-		"provider": runtimeConfig.Provider,
-		"model":    runtimeConfig.Model,
+		"phase":     "started",
+		"runName":   runtimeConfig.RunName,
+		"agentName": runtimeConfig.AgentName,
+		"provider":  runtimeConfig.Provider,
+		"model":     runtimeConfig.Model,
 	})
 	if len(runtimeConfig.Tools) > 0 {
 		runner.emit(events.TypeLifecycle, map[string]any{
@@ -67,34 +69,25 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 
 	selectedProvider, err := resolve(runtimeConfig)
 	if err != nil {
-		runner.emitError("unsupported_provider", err.Error(), nil)
-		return failed("unsupported_provider", err.Error(), nil, metadata(""))
+		code := "unsupported_provider"
+		var configurationError *provider.ConfigurationError
+		if errors.As(err, &configurationError) {
+			code = "invalid_provider_configuration"
+		}
+		runner.emitError(code, err.Error(), nil)
+		return failed(code, err.Error(), nil, metadata(""))
 	}
 
+	state := conversation.New(runtimeConfig.Goal)
 	request := runtimeapi.CompletionRequest{
-		Model: runtimeConfig.Model,
-		Messages: []runtimeapi.Message{
-			{
-				Role: runtimeapi.RoleUser,
-				Content: []runtimeapi.ContentBlock{
-					{Type: runtimeapi.ContentTypeText, Text: runtimeConfig.Goal},
-				},
-			},
-		},
-		Tools:     append([]string(nil), runtimeConfig.Tools...),
+		Model:     runtimeConfig.Model,
+		Messages:  state.Messages(),
 		MaxTokens: runtimeConfig.TokenBudget,
 	}
 
-	providerContext := ctx
-	cancel := func() {}
-	if runtimeConfig.WallclockBudget != nil {
-		providerContext, cancel = context.WithTimeout(ctx, *runtimeConfig.WallclockBudget)
-	}
-	defer cancel()
-
-	response, err := selectedProvider.Complete(providerContext, request)
+	response, err := selectedProvider.Complete(ctx, request)
 	if err != nil {
-		code, message, retryable, requestID := normalizeError(providerContext, err)
+		code, message, retryable, requestID := normalizeError(ctx, err)
 		runner.emitError(code, message, retryable)
 		return failed(code, message, retryable, metadata(requestID))
 	}
@@ -109,6 +102,7 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 		)
 	}
 
+	state.Append(response.Message)
 	completedMetadata := metadata(response.RequestID)
 	runner.emit(events.TypeLifecycle, map[string]any{
 		"phase":          "provider_completed",

--- a/runtimes/reference/internal/engine/engine_test.go
+++ b/runtimes/reference/internal/engine/engine_test.go
@@ -77,6 +77,19 @@ func TestRunnerRejectsUnsupportedProvider(t *testing.T) {
 	}
 }
 
+func TestRunnerDistinguishesInvalidProviderConfiguration(t *testing.T) {
+	runtimeConfig := baseConfig()
+	runtimeConfig.FakeScenario = "unknown"
+	result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+		context.Background(),
+		runtimeConfig,
+	)
+	if result.Envelope.Error == nil ||
+		result.Envelope.Error.Code != "invalid_provider_configuration" {
+		t.Fatalf("unexpected error %#v", result.Envelope.Error)
+	}
+}
+
 func TestRunnerHasNoImplicitWallclockDeadline(t *testing.T) {
 	runtimeConfig := baseConfig()
 	runtimeConfig.FakeScenario = provider.FakeScenarioDelay
@@ -91,16 +104,31 @@ func TestRunnerHasNoImplicitWallclockDeadline(t *testing.T) {
 	}
 }
 
-func TestRunnerAppliesConfiguredWallclockAndCancellation(t *testing.T) {
-	t.Run("deadline", func(t *testing.T) {
+func TestRunnerLeavesWallclockAuthorityWithController(t *testing.T) {
+	runtimeConfig := baseConfig()
+	runtimeConfig.FakeScenario = provider.FakeScenarioDelay
+	runtimeConfig.FakeDelay = 30 * time.Millisecond
+	wallclock := 10 * time.Millisecond
+	runtimeConfig.WallclockBudget = &wallclock
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(ctx, runtimeConfig)
+	if result.ExitCode != 0 {
+		t.Fatalf("runtime must not race controller wallclock enforcement: %#v", result.Envelope.Error)
+	}
+}
+
+func TestRunnerHandlesParentDeadlineAndCancellation(t *testing.T) {
+	t.Run("parent deadline", func(t *testing.T) {
 		runtimeConfig := baseConfig()
 		runtimeConfig.FakeScenario = provider.FakeScenarioDelay
 		runtimeConfig.FakeDelay = time.Second
-		wallclock := 10 * time.Millisecond
-		runtimeConfig.WallclockBudget = &wallclock
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
 
 		result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
-			context.Background(),
+			ctx,
 			runtimeConfig,
 		)
 		if result.Envelope.Error == nil || result.Envelope.Error.Code != "deadline_exceeded" {

--- a/runtimes/reference/internal/engine/engine_test.go
+++ b/runtimes/reference/internal/engine/engine_test.go
@@ -1,0 +1,152 @@
+package engine_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/engine"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
+)
+
+func TestRunnerCompletesFakeConversation(t *testing.T) {
+	emitter := &recordingEmitter{}
+	runner := engine.Runner{Emitter: emitter}
+	result := runner.Run(context.Background(), baseConfig())
+
+	if result.ExitCode != 0 || result.Envelope.Outcome != resultv1alpha1.OutcomeSucceeded {
+		t.Fatalf("unexpected result %#v", result)
+	}
+	if result.Envelope.Execution == nil ||
+		result.Envelope.Execution.Model != "vendor/model@2026:beta" {
+		t.Fatalf("model identifier changed: %#v", result.Envelope.Execution)
+	}
+	if got := resultv1alpha1.ProjectLegacyResult(result.Envelope.Output); got !=
+		"Fake provider completed goal: explain the contract" {
+		t.Fatalf("unexpected output %q", got)
+	}
+	if result.Envelope.Usage == nil || result.Envelope.Usage.TotalTokens == nil {
+		t.Fatalf("expected normalized usage: %#v", result.Envelope.Usage)
+	}
+	if !emitter.has(events.TypeLifecycle) ||
+		!emitter.has(events.TypeUsage) ||
+		!emitter.has(events.TypeOutput) {
+		t.Fatalf("missing execution events %#v", emitter.types)
+	}
+}
+
+func TestRunnerNormalizesProviderFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		scenario string
+		code     string
+	}{
+		{name: "failure", scenario: provider.FakeScenarioFailure, code: "fake_provider_failure"},
+		{name: "malformed", scenario: provider.FakeScenarioMalformed, code: "invalid_provider_response"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runtimeConfig := baseConfig()
+			runtimeConfig.FakeScenario = test.scenario
+			result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+				context.Background(),
+				runtimeConfig,
+			)
+			if result.ExitCode == 0 || result.Envelope.Outcome != resultv1alpha1.OutcomeFailed {
+				t.Fatalf("expected failed execution, got %#v", result)
+			}
+			if result.Envelope.Error == nil || result.Envelope.Error.Code != test.code {
+				t.Fatalf("unexpected error %#v", result.Envelope.Error)
+			}
+		})
+	}
+}
+
+func TestRunnerRejectsUnsupportedProvider(t *testing.T) {
+	runtimeConfig := baseConfig()
+	runtimeConfig.Provider = "unknown"
+	result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+		context.Background(),
+		runtimeConfig,
+	)
+	if result.Envelope.Error == nil || result.Envelope.Error.Code != "unsupported_provider" {
+		t.Fatalf("unexpected error %#v", result.Envelope.Error)
+	}
+}
+
+func TestRunnerHasNoImplicitWallclockDeadline(t *testing.T) {
+	runtimeConfig := baseConfig()
+	runtimeConfig.FakeScenario = provider.FakeScenarioDelay
+	runtimeConfig.FakeDelay = 30 * time.Millisecond
+	runtimeConfig.WallclockBudget = nil
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(ctx, runtimeConfig)
+	if result.ExitCode != 0 {
+		t.Fatalf("delay should succeed without configured wallclock: %#v", result.Envelope.Error)
+	}
+}
+
+func TestRunnerAppliesConfiguredWallclockAndCancellation(t *testing.T) {
+	t.Run("deadline", func(t *testing.T) {
+		runtimeConfig := baseConfig()
+		runtimeConfig.FakeScenario = provider.FakeScenarioDelay
+		runtimeConfig.FakeDelay = time.Second
+		wallclock := 10 * time.Millisecond
+		runtimeConfig.WallclockBudget = &wallclock
+
+		result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+			context.Background(),
+			runtimeConfig,
+		)
+		if result.Envelope.Error == nil || result.Envelope.Error.Code != "deadline_exceeded" {
+			t.Fatalf("unexpected deadline result %#v", result.Envelope.Error)
+		}
+	})
+
+	t.Run("cancellation", func(t *testing.T) {
+		runtimeConfig := baseConfig()
+		runtimeConfig.FakeScenario = provider.FakeScenarioDelay
+		runtimeConfig.FakeDelay = time.Second
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(ctx, runtimeConfig)
+		if result.Envelope.Error == nil || result.Envelope.Error.Code != "cancelled" {
+			t.Fatalf("unexpected cancellation result %#v", result.Envelope.Error)
+		}
+	})
+}
+
+func baseConfig() config.Config {
+	return config.Config{
+		RunName:      "run-1",
+		AgentName:    "agent-1",
+		Goal:         "explain the contract",
+		Provider:     "fake",
+		Model:        "vendor/model@2026:beta",
+		Tools:        []string{"unused-tool"},
+		FakeScenario: provider.FakeScenarioSuccess,
+	}
+}
+
+type recordingEmitter struct {
+	types []events.Type
+}
+
+func (emitter *recordingEmitter) Emit(eventType events.Type, _ any) {
+	emitter.types = append(emitter.types, eventType)
+}
+
+func (emitter *recordingEmitter) has(eventType events.Type) bool {
+	for _, candidate := range emitter.types {
+		if candidate == eventType {
+			return true
+		}
+	}
+	return false
+}

--- a/runtimes/reference/internal/engine/envelope.go
+++ b/runtimes/reference/internal/engine/envelope.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"encoding/json"
+	"time"
+
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+type Metadata struct {
+	Provider    string
+	Model       string
+	RequestID   string
+	StartedAt   time.Time
+	CompletedAt time.Time
+}
+
+func Success(response runtimeapi.CompletionResponse, metadata Metadata) resultv1alpha1.Envelope {
+	text := runtimeapi.MessageText(response.Message)
+	value, _ := json.Marshal(text)
+	turns := int32(1)
+	toolCalls := int32(0)
+	durationMillis := metadata.CompletedAt.Sub(metadata.StartedAt).Milliseconds()
+
+	return resultv1alpha1.Envelope{
+		APIVersion: resultv1alpha1.APIVersion,
+		Outcome:    resultv1alpha1.OutcomeSucceeded,
+		Output: &resultv1alpha1.Output{
+			MediaType: resultv1alpha1.DefaultMediaType,
+			Value:     value,
+		},
+		Usage: envelopeUsage(response.Usage),
+		Timing: &resultv1alpha1.Timing{
+			StartedAt:      &metadata.StartedAt,
+			CompletedAt:    &metadata.CompletedAt,
+			DurationMillis: &durationMillis,
+		},
+		Execution: &resultv1alpha1.Execution{
+			Provider:  metadata.Provider,
+			Model:     metadata.Model,
+			RequestID: metadata.RequestID,
+			Turns:     &turns,
+			ToolCalls: &toolCalls,
+		},
+	}
+}
+
+func Failure(
+	code string,
+	message string,
+	retryable *bool,
+	metadata Metadata,
+) resultv1alpha1.Envelope {
+	durationMillis := metadata.CompletedAt.Sub(metadata.StartedAt).Milliseconds()
+	return resultv1alpha1.Envelope{
+		APIVersion: resultv1alpha1.APIVersion,
+		Outcome:    resultv1alpha1.OutcomeFailed,
+		Timing: &resultv1alpha1.Timing{
+			StartedAt:      &metadata.StartedAt,
+			CompletedAt:    &metadata.CompletedAt,
+			DurationMillis: &durationMillis,
+		},
+		Execution: &resultv1alpha1.Execution{
+			Provider:  metadata.Provider,
+			Model:     metadata.Model,
+			RequestID: metadata.RequestID,
+		},
+		Error: &resultv1alpha1.ErrorInfo{
+			Code:      code,
+			Message:   message,
+			Retryable: retryable,
+		},
+	}
+}
+
+func envelopeUsage(providerUsage runtimeapi.Usage) *resultv1alpha1.Usage {
+	if providerUsage.InputTokens == nil &&
+		providerUsage.OutputTokens == nil &&
+		providerUsage.TotalTokens == nil {
+		return nil
+	}
+	return &resultv1alpha1.Usage{
+		InputTokens:  providerUsage.InputTokens,
+		OutputTokens: providerUsage.OutputTokens,
+		TotalTokens:  providerUsage.TotalTokens,
+	}
+}

--- a/runtimes/reference/internal/engine/envelope_test.go
+++ b/runtimes/reference/internal/engine/envelope_test.go
@@ -1,0 +1,71 @@
+package engine_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/engine"
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+func TestSuccessPreservesStructuredUsageAndOpaqueModel(t *testing.T) {
+	zero := int64(0)
+	outputTokens := int64(4)
+	response := runtimeapi.CompletionResponse{
+		Message: runtimeapi.Message{
+			Role: runtimeapi.RoleAssistant,
+			Content: []runtimeapi.ContentBlock{
+				{Type: runtimeapi.ContentTypeText, Text: "answer"},
+			},
+		},
+		Usage: runtimeapi.Usage{
+			InputTokens:  &zero,
+			OutputTokens: &outputTokens,
+		},
+		StopReason: runtimeapi.StopReasonEndTurn,
+		RequestID:  "request-1",
+	}
+	started := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	envelope := engine.Success(response, engine.Metadata{
+		Provider:    "fake",
+		Model:       "vendor/model@2026:beta",
+		RequestID:   response.RequestID,
+		StartedAt:   started,
+		CompletedAt: started.Add(25 * time.Millisecond),
+	})
+
+	if err := envelope.Validate(); err != nil {
+		t.Fatalf("validate envelope: %v", err)
+	}
+	if envelope.Execution == nil || envelope.Execution.Model != "vendor/model@2026:beta" {
+		t.Fatalf("opaque model changed: %#v", envelope.Execution)
+	}
+	if envelope.Usage == nil || envelope.Usage.InputTokens == nil ||
+		*envelope.Usage.InputTokens != 0 {
+		t.Fatalf("measured zero input tokens were lost: %#v", envelope.Usage)
+	}
+	if envelope.Usage.TotalTokens != nil {
+		t.Fatalf("missing total tokens must remain absent: %#v", envelope.Usage)
+	}
+}
+
+func TestFailureBuildsValidatedFailureEnvelope(t *testing.T) {
+	started := time.Now().UTC()
+	envelope := engine.Failure(
+		"provider_error",
+		"unavailable",
+		nil,
+		engine.Metadata{
+			Provider:    "fake",
+			Model:       "model",
+			StartedAt:   started,
+			CompletedAt: started,
+		},
+	)
+	if err := envelope.Validate(); err != nil {
+		t.Fatalf("validate envelope: %v", err)
+	}
+	if envelope.Error == nil || envelope.Error.Code != "provider_error" {
+		t.Fatalf("unexpected error info %#v", envelope.Error)
+	}
+}

--- a/runtimes/reference/internal/events/emitter.go
+++ b/runtimes/reference/internal/events/emitter.go
@@ -1,0 +1,71 @@
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+const APIVersion = "kontext.dev/event/v1alpha1"
+
+type Type string
+
+const (
+	TypeLifecycle Type = "lifecycle"
+	TypeOutput    Type = "output"
+	TypeUsage     Type = "usage"
+	TypeError     Type = "error"
+)
+
+type Event struct {
+	APIVersion string          `json:"apiVersion"`
+	Timestamp  time.Time       `json:"timestamp"`
+	Type       Type            `json:"type"`
+	Data       json.RawMessage `json:"data"`
+}
+
+type Emitter struct {
+	writer      io.Writer
+	errorWriter io.Writer
+	now         func() time.Time
+	mu          sync.Mutex
+}
+
+func NewEmitter(writer io.Writer, errorWriter io.Writer, now func() time.Time) *Emitter {
+	if now == nil {
+		now = time.Now
+	}
+	return &Emitter{writer: writer, errorWriter: errorWriter, now: now}
+}
+
+// Emit writes one JSONL event. Events are best-effort observability: the
+// result envelope is the contract, so emission failures are logged to the
+// error writer instead of failing the run.
+func (emitter *Emitter) Emit(eventType Type, data any) {
+	encodedData, err := json.Marshal(data)
+	if err != nil {
+		emitter.logFailure(eventType, err)
+		return
+	}
+	event := Event{
+		APIVersion: APIVersion,
+		Timestamp:  emitter.now().UTC(),
+		Type:       eventType,
+		Data:       encodedData,
+	}
+
+	emitter.mu.Lock()
+	defer emitter.mu.Unlock()
+	if err := json.NewEncoder(emitter.writer).Encode(event); err != nil {
+		emitter.logFailure(eventType, err)
+	}
+}
+
+func (emitter *Emitter) logFailure(eventType Type, err error) {
+	if emitter.errorWriter == nil {
+		return
+	}
+	fmt.Fprintf(emitter.errorWriter, "kontext reference runtime: emit %s event: %v\n", eventType, err)
+}

--- a/runtimes/reference/internal/events/emitter_test.go
+++ b/runtimes/reference/internal/events/emitter_test.go
@@ -1,0 +1,50 @@
+package events_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
+)
+
+func TestEmitterWritesOneVersionedJSONEventPerLine(t *testing.T) {
+	var output bytes.Buffer
+	timestamp := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.FixedZone("test", 3600))
+	emitter := events.NewEmitter(&output, nil, func() time.Time { return timestamp })
+
+	emitter.Emit(events.TypeLifecycle, map[string]string{"phase": "started"})
+	if lines := strings.Count(output.String(), "\n"); lines != 1 {
+		t.Fatalf("expected one JSONL line, got %d: %q", lines, output.String())
+	}
+	var event events.Event
+	if err := json.Unmarshal(output.Bytes(), &event); err != nil {
+		t.Fatalf("decode event: %v", err)
+	}
+	if event.APIVersion != events.APIVersion || event.Type != events.TypeLifecycle {
+		t.Fatalf("unexpected event %#v", event)
+	}
+	if !event.Timestamp.Equal(timestamp.UTC()) {
+		t.Fatalf("expected UTC timestamp %s, got %s", timestamp.UTC(), event.Timestamp)
+	}
+}
+
+func TestEmitterLogsFailuresInsteadOfPropagating(t *testing.T) {
+	var errorOutput bytes.Buffer
+	emitter := events.NewEmitter(failingWriter{}, &errorOutput, nil)
+
+	emitter.Emit(events.TypeLifecycle, map[string]string{"phase": "started"})
+
+	if !strings.Contains(errorOutput.String(), "emit lifecycle event") {
+		t.Fatalf("expected logged emit failure, got %q", errorOutput.String())
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("stream closed")
+}

--- a/runtimes/reference/internal/provider/provider.go
+++ b/runtimes/reference/internal/provider/provider.go
@@ -1,0 +1,134 @@
+package provider
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+const (
+	FakeScenarioSuccess   = "success"
+	FakeScenarioFailure   = "failure"
+	FakeScenarioMalformed = "malformed"
+	FakeScenarioDelay     = "delay"
+)
+
+type Provider interface {
+	Name() string
+	Complete(context.Context, runtimeapi.CompletionRequest) (runtimeapi.CompletionResponse, error)
+}
+
+func Resolve(runtimeConfig config.Config) (Provider, error) {
+	switch runtimeConfig.Provider {
+	case "fake":
+		return resolveFake(runtimeConfig)
+	default:
+		return nil, fmt.Errorf("unsupported provider %q", runtimeConfig.Provider)
+	}
+}
+
+func resolveFake(runtimeConfig config.Config) (Provider, error) {
+	scenario := runtimeConfig.FakeScenario
+	if scenario == "" {
+		scenario = FakeScenarioSuccess
+	}
+	switch scenario {
+	case FakeScenarioSuccess, FakeScenarioFailure, FakeScenarioMalformed:
+	case FakeScenarioDelay:
+		if runtimeConfig.FakeDelay <= 0 {
+			return nil, fmt.Errorf("KONTEXT_FAKE_DELAY is required for delay scenario")
+		}
+	default:
+		return nil, fmt.Errorf("unsupported KONTEXT_FAKE_SCENARIO %q", scenario)
+	}
+	return &Fake{
+		Scenario: scenario,
+		Delay:    runtimeConfig.FakeDelay,
+	}, nil
+}
+
+type Fake struct {
+	Scenario string
+	Delay    time.Duration
+}
+
+func (fake *Fake) Name() string {
+	return "fake"
+}
+
+func (fake *Fake) Complete(
+	ctx context.Context,
+	request runtimeapi.CompletionRequest,
+) (runtimeapi.CompletionResponse, error) {
+	select {
+	case <-ctx.Done():
+		return runtimeapi.CompletionResponse{}, ctx.Err()
+	default:
+	}
+
+	switch fake.Scenario {
+	case FakeScenarioFailure:
+		retryable := false
+		return runtimeapi.CompletionResponse{}, &runtimeapi.ProviderError{
+			Code:      "fake_provider_failure",
+			Message:   "fake provider failed as configured",
+			Retryable: &retryable,
+		}
+	case FakeScenarioMalformed:
+		return runtimeapi.CompletionResponse{
+			Message: runtimeapi.Message{
+				Role: runtimeapi.Role("malformed"),
+				Content: []runtimeapi.ContentBlock{
+					{Type: runtimeapi.ContentTypeText, Text: "invalid response"},
+				},
+			},
+			StopReason: runtimeapi.StopReasonEndTurn,
+		}, nil
+	case FakeScenarioDelay:
+		timer := time.NewTimer(fake.Delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return runtimeapi.CompletionResponse{}, ctx.Err()
+		case <-timer.C:
+		}
+	case FakeScenarioSuccess:
+	default:
+		return runtimeapi.CompletionResponse{}, fmt.Errorf("unsupported fake scenario %q", fake.Scenario)
+	}
+
+	return fakeSuccess(request), nil
+}
+
+func fakeSuccess(request runtimeapi.CompletionRequest) runtimeapi.CompletionResponse {
+	goal := ""
+	if len(request.Messages) > 0 {
+		goal = runtimeapi.MessageText(request.Messages[len(request.Messages)-1])
+	}
+	output := fmt.Sprintf("Fake provider completed goal: %s", goal)
+	inputTokens := int64(len(strings.Fields(goal)))
+	outputTokens := int64(len(strings.Fields(output)))
+	totalTokens := inputTokens + outputTokens
+	requestHash := sha256.Sum256([]byte(request.Model + "\x00" + goal))
+
+	return runtimeapi.CompletionResponse{
+		Message: runtimeapi.Message{
+			Role: runtimeapi.RoleAssistant,
+			Content: []runtimeapi.ContentBlock{
+				{Type: runtimeapi.ContentTypeText, Text: output},
+			},
+		},
+		Usage: runtimeapi.Usage{
+			InputTokens:  &inputTokens,
+			OutputTokens: &outputTokens,
+			TotalTokens:  &totalTokens,
+		},
+		StopReason: runtimeapi.StopReasonEndTurn,
+		RequestID:  fmt.Sprintf("fake-%x", requestHash[:6]),
+	}
+}

--- a/runtimes/reference/internal/provider/provider.go
+++ b/runtimes/reference/internal/provider/provider.go
@@ -23,12 +23,29 @@ type Provider interface {
 	Complete(context.Context, runtimeapi.CompletionRequest) (runtimeapi.CompletionResponse, error)
 }
 
+type UnsupportedError struct {
+	Name string
+}
+
+func (err *UnsupportedError) Error() string {
+	return fmt.Sprintf("unsupported provider %q", err.Name)
+}
+
+type ConfigurationError struct {
+	Provider string
+	Message  string
+}
+
+func (err *ConfigurationError) Error() string {
+	return fmt.Sprintf("%s provider configuration is invalid: %s", err.Provider, err.Message)
+}
+
 func Resolve(runtimeConfig config.Config) (Provider, error) {
 	switch runtimeConfig.Provider {
 	case "fake":
 		return resolveFake(runtimeConfig)
 	default:
-		return nil, fmt.Errorf("unsupported provider %q", runtimeConfig.Provider)
+		return nil, &UnsupportedError{Name: runtimeConfig.Provider}
 	}
 }
 
@@ -41,10 +58,16 @@ func resolveFake(runtimeConfig config.Config) (Provider, error) {
 	case FakeScenarioSuccess, FakeScenarioFailure, FakeScenarioMalformed:
 	case FakeScenarioDelay:
 		if runtimeConfig.FakeDelay <= 0 {
-			return nil, fmt.Errorf("KONTEXT_FAKE_DELAY is required for delay scenario")
+			return nil, &ConfigurationError{
+				Provider: "fake",
+				Message:  "KONTEXT_FAKE_DELAY is required for delay scenario",
+			}
 		}
 	default:
-		return nil, fmt.Errorf("unsupported KONTEXT_FAKE_SCENARIO %q", scenario)
+		return nil, &ConfigurationError{
+			Provider: "fake",
+			Message:  fmt.Sprintf("unsupported KONTEXT_FAKE_SCENARIO %q", scenario),
+		}
 	}
 	return &Fake{
 		Scenario: scenario,

--- a/runtimes/reference/internal/provider/provider_test.go
+++ b/runtimes/reference/internal/provider/provider_test.go
@@ -1,0 +1,115 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+func TestResolveSelectsFakeProvider(t *testing.T) {
+	selected, err := provider.Resolve(config.Config{Provider: "fake"})
+	if err != nil {
+		t.Fatalf("resolve provider: %v", err)
+	}
+	if selected.Name() != "fake" {
+		t.Fatalf("unexpected provider %q", selected.Name())
+	}
+	if _, err := provider.Resolve(config.Config{Provider: "unknown"}); err == nil {
+		t.Fatalf("expected unsupported provider error")
+	}
+}
+
+func TestResolveValidatesFakeScenarios(t *testing.T) {
+	if _, err := provider.Resolve(config.Config{
+		Provider:     "fake",
+		FakeScenario: "other",
+	}); err == nil {
+		t.Fatalf("expected unsupported scenario error")
+	}
+	if _, err := provider.Resolve(config.Config{
+		Provider:     "fake",
+		FakeScenario: provider.FakeScenarioDelay,
+	}); err == nil {
+		t.Fatalf("expected missing delay error")
+	}
+}
+
+func TestFakeProviderScenarios(t *testing.T) {
+	request := completionRequest("vendor/model@2026:beta")
+
+	t.Run("success", func(t *testing.T) {
+		fake := &provider.Fake{Scenario: provider.FakeScenarioSuccess}
+		response, err := fake.Complete(context.Background(), request)
+		if err != nil {
+			t.Fatalf("complete: %v", err)
+		}
+		if err := runtimeapi.ValidateResponse(response); err != nil {
+			t.Fatalf("validate response: %v", err)
+		}
+		if got := runtimeapi.MessageText(response.Message); got != "Fake provider completed goal: test goal" {
+			t.Fatalf("unexpected output %q", got)
+		}
+		if response.Usage.InputTokens == nil || *response.Usage.InputTokens != 2 {
+			t.Fatalf("unexpected input usage %#v", response.Usage)
+		}
+		if response.RequestID == "" {
+			t.Fatalf("expected deterministic request id")
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		fake := &provider.Fake{Scenario: provider.FakeScenarioFailure}
+		_, err := fake.Complete(context.Background(), request)
+		var providerError *runtimeapi.ProviderError
+		if !errors.As(err, &providerError) || providerError.Code != "fake_provider_failure" {
+			t.Fatalf("unexpected error %v", err)
+		}
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		fake := &provider.Fake{Scenario: provider.FakeScenarioMalformed}
+		response, err := fake.Complete(context.Background(), request)
+		if err != nil {
+			t.Fatalf("complete: %v", err)
+		}
+		if err := runtimeapi.ValidateResponse(response); err == nil {
+			t.Fatalf("expected malformed response")
+		}
+	})
+
+	t.Run("delay cancellation", func(t *testing.T) {
+		fake := &provider.Fake{
+			Scenario: provider.FakeScenarioDelay,
+			Delay:    time.Second,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		started := time.Now()
+		_, err := fake.Complete(ctx, request)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected cancellation, got %v", err)
+		}
+		if time.Since(started) > 100*time.Millisecond {
+			t.Fatalf("fake provider did not cancel promptly")
+		}
+	})
+}
+
+func completionRequest(model string) runtimeapi.CompletionRequest {
+	return runtimeapi.CompletionRequest{
+		Model: model,
+		Messages: []runtimeapi.Message{
+			{
+				Role: runtimeapi.RoleUser,
+				Content: []runtimeapi.ContentBlock{
+					{Type: runtimeapi.ContentTypeText, Text: "test goal"},
+				},
+			},
+		},
+	}
+}

--- a/runtimes/reference/internal/provider/provider_test.go
+++ b/runtimes/reference/internal/provider/provider_test.go
@@ -21,6 +21,11 @@ func TestResolveSelectsFakeProvider(t *testing.T) {
 	}
 	if _, err := provider.Resolve(config.Config{Provider: "unknown"}); err == nil {
 		t.Fatalf("expected unsupported provider error")
+	} else {
+		var unsupported *provider.UnsupportedError
+		if !errors.As(err, &unsupported) {
+			t.Fatalf("expected typed unsupported error, got %T", err)
+		}
 	}
 }
 
@@ -30,6 +35,11 @@ func TestResolveValidatesFakeScenarios(t *testing.T) {
 		FakeScenario: "other",
 	}); err == nil {
 		t.Fatalf("expected unsupported scenario error")
+	} else {
+		var configurationError *provider.ConfigurationError
+		if !errors.As(err, &configurationError) {
+			t.Fatalf("expected typed configuration error, got %T", err)
+		}
 	}
 	if _, err := provider.Resolve(config.Config{
 		Provider:     "fake",

--- a/runtimes/reference/internal/runtimeapi/types.go
+++ b/runtimes/reference/internal/runtimeapi/types.go
@@ -46,7 +46,6 @@ const (
 type CompletionRequest struct {
 	Model     string
 	Messages  []Message
-	Tools     []string
 	MaxTokens *int64
 }
 

--- a/runtimes/reference/internal/runtimeapi/types.go
+++ b/runtimes/reference/internal/runtimeapi/types.go
@@ -1,0 +1,106 @@
+package runtimeapi
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type Role string
+
+const (
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+)
+
+type ContentType string
+
+const (
+	ContentTypeText ContentType = "text"
+)
+
+type ContentBlock struct {
+	Type ContentType
+	Text string
+}
+
+type Message struct {
+	Role    Role
+	Content []ContentBlock
+}
+
+type Usage struct {
+	InputTokens  *int64
+	OutputTokens *int64
+	TotalTokens  *int64
+}
+
+type StopReason string
+
+const (
+	StopReasonEndTurn      StopReason = "end_turn"
+	StopReasonMaxTokens    StopReason = "max_tokens"
+	StopReasonStopSequence StopReason = "stop_sequence"
+)
+
+type CompletionRequest struct {
+	Model     string
+	Messages  []Message
+	Tools     []string
+	MaxTokens *int64
+}
+
+type CompletionResponse struct {
+	Message    Message
+	Usage      Usage
+	StopReason StopReason
+	RequestID  string
+}
+
+type ProviderError struct {
+	Code       string
+	Message    string
+	Retryable  *bool
+	HTTPStatus *int
+	RequestID  string
+}
+
+func (err *ProviderError) Error() string {
+	if err.Code == "" {
+		return err.Message
+	}
+	return fmt.Sprintf("%s: %s", err.Code, err.Message)
+}
+
+func ValidateResponse(response CompletionResponse) error {
+	if response.Message.Role != RoleAssistant {
+		return fmt.Errorf("assistant response has invalid role %q", response.Message.Role)
+	}
+	if len(response.Message.Content) == 0 {
+		return errors.New("assistant response has no content")
+	}
+	for index, block := range response.Message.Content {
+		if block.Type != ContentTypeText {
+			return fmt.Errorf("assistant content block %d has unsupported type %q", index, block.Type)
+		}
+		if strings.TrimSpace(block.Text) == "" {
+			return fmt.Errorf("assistant content block %d has empty text", index)
+		}
+	}
+	switch response.StopReason {
+	case StopReasonEndTurn, StopReasonMaxTokens, StopReasonStopSequence:
+	default:
+		return fmt.Errorf("assistant response has unsupported stop reason %q", response.StopReason)
+	}
+	return nil
+}
+
+func MessageText(message Message) string {
+	var parts []string
+	for _, block := range message.Content {
+		if block.Type == ContentTypeText && strings.TrimSpace(block.Text) != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/runtimes/reference/internal/runtimeapi/types_test.go
+++ b/runtimes/reference/internal/runtimeapi/types_test.go
@@ -1,0 +1,69 @@
+package runtimeapi_test
+
+import (
+	"testing"
+
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+func TestValidateResponse(t *testing.T) {
+	valid := runtimeapi.CompletionResponse{
+		Message: runtimeapi.Message{
+			Role: runtimeapi.RoleAssistant,
+			Content: []runtimeapi.ContentBlock{
+				{Type: runtimeapi.ContentTypeText, Text: "answer"},
+			},
+		},
+		StopReason: runtimeapi.StopReasonEndTurn,
+	}
+	if err := runtimeapi.ValidateResponse(valid); err != nil {
+		t.Fatalf("validate response: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		change func(*runtimeapi.CompletionResponse)
+	}{
+		{name: "wrong role", change: func(response *runtimeapi.CompletionResponse) {
+			response.Message.Role = runtimeapi.RoleUser
+		}},
+		{name: "no content", change: func(response *runtimeapi.CompletionResponse) {
+			response.Message.Content = nil
+		}},
+		{name: "empty text", change: func(response *runtimeapi.CompletionResponse) {
+			response.Message.Content[0].Text = ""
+		}},
+		{name: "unknown content", change: func(response *runtimeapi.CompletionResponse) {
+			response.Message.Content[0].Type = runtimeapi.ContentType("image")
+		}},
+		{name: "unknown stop reason", change: func(response *runtimeapi.CompletionResponse) {
+			response.StopReason = runtimeapi.StopReason("unknown")
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := valid
+			response.Message.Content = append(
+				[]runtimeapi.ContentBlock(nil),
+				valid.Message.Content...,
+			)
+			test.change(&response)
+			if err := runtimeapi.ValidateResponse(response); err == nil {
+				t.Fatalf("expected invalid response")
+			}
+		})
+	}
+}
+
+func TestMessageTextJoinsTextBlocks(t *testing.T) {
+	message := runtimeapi.Message{
+		Role: runtimeapi.RoleAssistant,
+		Content: []runtimeapi.ContentBlock{
+			{Type: runtimeapi.ContentTypeText, Text: "first"},
+			{Type: runtimeapi.ContentTypeText, Text: "second"},
+		},
+	}
+	if got := runtimeapi.MessageText(message); got != "first\nsecond" {
+		t.Fatalf("unexpected text %q", got)
+	}
+}

--- a/runtimes/reference/main.go
+++ b/runtimes/reference/main.go
@@ -44,7 +44,7 @@ func run(
 			nil,
 			engine.Metadata{
 				Provider:    strings.TrimSpace(getenv("KONTEXT_PROVIDER")),
-				Model:       strings.TrimSpace(getenv("KONTEXT_MODEL")),
+				Model:       getenv("KONTEXT_MODEL"),
 				StartedAt:   startedAt,
 				CompletedAt: now().UTC(),
 			},

--- a/runtimes/reference/main.go
+++ b/runtimes/reference/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/engine"
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+	os.Exit(run(ctx, os.Getenv, os.Stdout, os.Stderr, time.Now))
+}
+
+func run(
+	ctx context.Context,
+	getenv func(string) string,
+	stdout io.Writer,
+	stderr io.Writer,
+	now func() time.Time,
+) int {
+	emitter := events.NewEmitter(stdout, stderr, now)
+	runtimeConfig, err := config.Load(getenv)
+	if err != nil {
+		fmt.Fprintf(stderr, "kontext reference runtime: %v\n", err)
+		startedAt := now().UTC()
+		emitter.Emit(events.TypeError, map[string]any{
+			"code":    "invalid_configuration",
+			"message": err.Error(),
+		})
+		envelope := engine.Failure(
+			"invalid_configuration",
+			err.Error(),
+			nil,
+			engine.Metadata{
+				Provider:    strings.TrimSpace(getenv("KONTEXT_PROVIDER")),
+				Model:       strings.TrimSpace(getenv("KONTEXT_MODEL")),
+				StartedAt:   startedAt,
+				CompletedAt: now().UTC(),
+			},
+		)
+		if emitErr := resultv1alpha1.WriteEnvelopeLine(stdout, envelope); emitErr != nil {
+			fmt.Fprintf(stderr, "kontext reference runtime: emit result: %v\n", emitErr)
+		}
+		return 2
+	}
+
+	execution := engine.Runner{
+		Emitter: emitter,
+		Now:     now,
+	}.Run(ctx, runtimeConfig)
+	if err := resultv1alpha1.WriteEnvelopeLine(stdout, execution.Envelope); err != nil {
+		fmt.Fprintf(stderr, "kontext reference runtime: emit result: %v\n", err)
+		return 1
+	}
+	return execution.ExitCode
+}

--- a/runtimes/reference/main_test.go
+++ b/runtimes/reference/main_test.go
@@ -71,11 +71,11 @@ func TestRunEmitsFailureEnvelopeForInvalidConfiguration(t *testing.T) {
 func resultLine(t *testing.T, output string) resultv1alpha1.Envelope {
 	t.Helper()
 	for _, line := range strings.Split(output, "\n") {
-		if !strings.HasPrefix(line, resultv1alpha1.EnvelopeLinePrefix+" ") {
+		payload, found := resultv1alpha1.ExtractEnvelopePayload([]byte(line))
+		if !found {
 			continue
 		}
-		payload := strings.TrimSpace(strings.TrimPrefix(line, resultv1alpha1.EnvelopeLinePrefix))
-		parsed, err := resultv1alpha1.Parse(payload)
+		parsed, err := resultv1alpha1.Parse(string(payload))
 		if err != nil {
 			t.Fatalf("parse result line: %v", err)
 		}

--- a/runtimes/reference/main_test.go
+++ b/runtimes/reference/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+func TestRunEmitsJSONLAndVersionedResult(t *testing.T) {
+	values := map[string]string{
+		"KONTEXT_RUN_NAME": "reference-test",
+		"KONTEXT_GOAL":     "explain the contract",
+		"KONTEXT_PROVIDER": "fake",
+		"KONTEXT_MODEL":    "opaque/model:id",
+		"KONTEXT_TOOLS":    "declared-only",
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := run(
+		context.Background(),
+		lookupEnv(values),
+		&stdout,
+		&stderr,
+		func() time.Time { return time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC) },
+	)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d; stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"apiVersion":"kontext.dev/event/v1alpha1"`) {
+		t.Fatalf("expected JSONL events: %s", stdout.String())
+	}
+	envelope := resultLine(t, stdout.String())
+	if envelope.Outcome != resultv1alpha1.OutcomeSucceeded {
+		t.Fatalf("unexpected result %#v", envelope)
+	}
+	if envelope.Execution == nil || envelope.Execution.Model != "opaque/model:id" {
+		t.Fatalf("opaque model was not preserved: %#v", envelope.Execution)
+	}
+}
+
+func TestRunEmitsFailureEnvelopeForInvalidConfiguration(t *testing.T) {
+	values := map[string]string{
+		"KONTEXT_GOAL":     "goal",
+		"KONTEXT_PROVIDER": "fake",
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := run(
+		context.Background(),
+		lookupEnv(values),
+		&stdout,
+		&stderr,
+		time.Now,
+	)
+	if exitCode == 0 {
+		t.Fatalf("expected configuration failure")
+	}
+	envelope := resultLine(t, stdout.String())
+	if envelope.Error == nil || envelope.Error.Code != "invalid_configuration" {
+		t.Fatalf("unexpected failure %#v", envelope.Error)
+	}
+	if !strings.Contains(stderr.String(), "KONTEXT_MODEL is required") {
+		t.Fatalf("expected actionable stderr, got %q", stderr.String())
+	}
+}
+
+func resultLine(t *testing.T, output string) resultv1alpha1.Envelope {
+	t.Helper()
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, resultv1alpha1.EnvelopeLinePrefix+" ") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, resultv1alpha1.EnvelopeLinePrefix))
+		parsed, err := resultv1alpha1.Parse(payload)
+		if err != nil {
+			t.Fatalf("parse result line: %v", err)
+		}
+		if parsed.Envelope == nil {
+			t.Fatalf("result line was not a versioned envelope")
+		}
+		return *parsed.Envelope
+	}
+	t.Fatalf("result line not found in %q", output)
+	return resultv1alpha1.Envelope{}
+}
+
+func lookupEnv(values map[string]string) func(string) string {
+	return func(name string) string {
+		return values[name]
+	}
+}

--- a/runtimes/reporter/capture.go
+++ b/runtimes/reporter/capture.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"bytes"
-)
 
-const KontextEnvelopePrefix = "KONTEXT_RESULT:"
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
 
 type CapturedResult struct {
 	Data          []byte
@@ -89,11 +89,9 @@ func (capture *Capture) completeLine() {
 				OriginalBytes: capture.currentTotal,
 			}
 		case CaptureFormatKontextEnvelope:
-			trimmed := bytes.TrimSpace(line)
-			if bytes.HasPrefix(trimmed, []byte(KontextEnvelopePrefix)) {
-				candidate := bytes.TrimSpace(trimmed[len(KontextEnvelopePrefix):])
+			if payload, found := resultv1alpha1.ExtractEnvelopePayload(line); found {
 				capture.candidate = CapturedResult{
-					Data:          append([]byte(nil), candidate...),
+					Data:          append([]byte(nil), payload...),
 					Found:         true,
 					Truncated:     capture.currentTruncated,
 					OriginalBytes: capture.currentTotal,

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -51,6 +51,7 @@ kubectl delete agentrun \
   stdout-envelope \
   stdout-failure \
   stdout-signal \
+  reference-fake \
   --ignore-not-found=true \
   --wait=true
 
@@ -143,6 +144,26 @@ wait_for_run_phase stdout-signal Succeeded
 signal_result="$(kubectl get agentrun stdout-signal -o jsonpath='{.status.result}')"
 if [[ "${signal_result}" != "signal reached child" ]]; then
   echo "SIGTERM did not reach child; result=${signal_result}" >&2
+  exit 1
+fi
+
+echo "==> verifying model-agnostic reference runtime"
+kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/reference-fake-run.yaml"
+wait_for_run_phase reference-fake Succeeded
+reference_result="$(kubectl get agentrun reference-fake -o jsonpath='{.status.result}')"
+reference_input_tokens="$(kubectl get agentrun reference-fake -o jsonpath='{.status.usage.inputTokens}')"
+reference_output_tokens="$(kubectl get agentrun reference-fake -o jsonpath='{.status.usage.outputTokens}')"
+reference_logs="$(kubectl logs run-reference-fake -c runtime)"
+if [[ "${reference_result}" != "Fake provider completed goal: Explain the Kontext runtime contract in one sentence." ]]; then
+  echo "unexpected reference result: ${reference_result}" >&2
+  exit 1
+fi
+if [[ "${reference_input_tokens}" != "8" || "${reference_output_tokens}" != "12" ]]; then
+  echo "unexpected reference usage: input=${reference_input_tokens} output=${reference_output_tokens}" >&2
+  exit 1
+fi
+if [[ "${reference_logs}" != *'"apiVersion":"kontext.dev/event/v1alpha1"'* ]]; then
+  echo "reference runtime did not emit versioned JSONL events" >&2
   exit 1
 fi
 

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -158,6 +158,9 @@ if [[ "${reference_result}" != "Fake provider completed goal: Explain the Kontex
   echo "unexpected reference result: ${reference_result}" >&2
   exit 1
 fi
+# The fake provider reports word counts: input = words in the goal string from
+# reference-fake-run.yaml (8), output = words in "Fake provider completed
+# goal: <goal>" (12). Adjust both if the example goal changes.
 if [[ "${reference_input_tokens}" != "8" || "${reference_output_tokens}" != "12" ]]; then
   echo "unexpected reference usage: input=${reference_input_tokens} output=${reference_output_tokens}" >&2
   exit 1

--- a/scripts/install-go-kind.sh
+++ b/scripts/install-go-kind.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Load prebuilt operator, echo, reporter, and test images into kind and install
-# the controller. Build images first with `make kind-install`.
+# Load prebuilt operator, runtime, reporter, and test images into kind and
+# install the controller. Build images first with `make kind-install`.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -8,6 +8,7 @@ CLUSTER_NAME="${KIND_CLUSTER_NAME:-kontext}"
 OPERATOR_IMAGE="${KONTEXT_OPERATOR_IMAGE:-kontext-operator:dev}"
 ECHO_IMAGE="${KONTEXT_ECHO_IMAGE:-kontext-echo:dev}"
 REPORTER_IMAGE="${KONTEXT_REPORTER_IMAGE:-kontext-reporter:dev}"
+REFERENCE_IMAGE="${KONTEXT_REFERENCE_IMAGE:-kontext-reference:dev}"
 STDOUT_FIXTURE_IMAGE="${KONTEXT_STDOUT_FIXTURE_IMAGE:-kontext-stdout-fixture:dev}"
 
 need() {
@@ -33,6 +34,10 @@ if ! docker image inspect "${REPORTER_IMAGE}" >/dev/null 2>&1; then
   echo "missing local image ${REPORTER_IMAGE}; build with: make docker-build-reporter" >&2
   exit 1
 fi
+if ! docker image inspect "${REFERENCE_IMAGE}" >/dev/null 2>&1; then
+  echo "missing local image ${REFERENCE_IMAGE}; build with: make docker-build-reference" >&2
+  exit 1
+fi
 if ! docker image inspect "${STDOUT_FIXTURE_IMAGE}" >/dev/null 2>&1; then
   echo "missing local image ${STDOUT_FIXTURE_IMAGE}; build with: make docker-build-stdout-fixture" >&2
   exit 1
@@ -49,6 +54,7 @@ echo "==> loading images into kind/${CLUSTER_NAME}"
 kind load docker-image "${OPERATOR_IMAGE}" --name "${CLUSTER_NAME}"
 kind load docker-image "${ECHO_IMAGE}" --name "${CLUSTER_NAME}"
 kind load docker-image "${REPORTER_IMAGE}" --name "${CLUSTER_NAME}"
+kind load docker-image "${REFERENCE_IMAGE}" --name "${CLUSTER_NAME}"
 kind load docker-image "${STDOUT_FIXTURE_IMAGE}" --name "${CLUSTER_NAME}"
 
 echo "==> installing v1alpha1 CRDs and Go controller"


### PR DESCRIPTION
## Summary
- add a maintained Go reference runtime with normalized provider request/response types, explicit in-memory conversation state, and a deterministic keyless fake provider
- emit versioned JSONL lifecycle, usage, output, and error events plus a compact `KONTEXT_RESULT:` envelope consumed by the bundled reporter
- preserve opaque model identifiers, keep controller-owned wallclock enforcement deterministic, and distinguish unsupported providers from invalid provider configuration
- add a minimal non-root image, dependency inventory, Docker execution smoke, Makefile/CI wiring, example manifest, and kind acceptance path

## Test plan
- [x] `make test`
- [x] `make verify`
- [x] `make vulncheck`
- [x] `go test -race ./runtimes/reference/... -count=1`
- [x] Docker fake-provider success and failure execution smokes
- [x] `make kind-install && ./scripts/e2e-kind.sh`

Closes #17