### PR TITLE
Add Anthropic and OpenAI-compatible transports

### DIFF
--- a/.github/workflows/provider-acceptance.yml
+++ b/.github/workflows/provider-acceptance.yml
@@ -1,0 +1,83 @@
+name: Provider acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: Maintained provider transport
+        required: true
+        type: choice
+        options:
+          - anthropic
+          - openai
+          - openai-compatible
+      model:
+        description: Provider model identifier (passed through unchanged)
+        required: true
+        type: string
+      endpoint:
+        description: Optional exact Messages or Chat Completions endpoint
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  anthropic:
+    name: Anthropic request
+    if: inputs.provider == 'anthropic'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: provider-acceptance
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      KONTEXT_GOAL: Reply with exactly the word kontext.
+      KONTEXT_PROVIDER: ${{ inputs.provider }}
+      KONTEXT_MODEL: ${{ inputs.model }}
+      KONTEXT_PROVIDER_ENDPOINT: ${{ inputs.endpoint }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run one authenticated completion
+        run: |
+          output="$(go run ./runtimes/reference)"
+          printf '%s\n' "${output}"
+          [[ "${output}" == *'"apiVersion":"kontext.dev/event/v1alpha1"'* ]]
+          [[ "${output}" == *'"outcome":"Succeeded"'* ]]
+
+  openai-compatible:
+    name: OpenAI-compatible request
+    if: inputs.provider == 'openai' || inputs.provider == 'openai-compatible'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: provider-acceptance
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      KONTEXT_GOAL: Reply with exactly the word kontext.
+      KONTEXT_PROVIDER: ${{ inputs.provider }}
+      KONTEXT_MODEL: ${{ inputs.model }}
+      KONTEXT_PROVIDER_ENDPOINT: ${{ inputs.endpoint }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run one authenticated completion
+        run: |
+          output="$(go run ./runtimes/reference)"
+          printf '%s\n' "${output}"
+          [[ "${output}" == *'"apiVersion":"kontext.dev/event/v1alpha1"'* ]]
+          [[ "${output}" == *'"outcome":"Succeeded"'* ]]

--- a/README.md
+++ b/README.md
@@ -73,11 +73,15 @@ kubectl get agentruns -w
 | Image | Purpose |
 |---|---|
 | [`runtimes/echo/`](runtimes/echo) | Keyless test runtime. Exercises the full contract (stdout thoughts, termination-log result, service heartbeat) without any API key. |
-| [`runtimes/reference/`](runtimes/reference) | Maintained model-agnostic Go runtime. Issue #17 provides a deterministic fake provider; real HTTP transports follow separately. |
+| [`runtimes/reference/`](runtimes/reference) | Maintained provider-neutral Go runtime with fake, Anthropic, and OpenAI-compatible HTTP transports. |
 | [`runtimes/python-anthropic/`](runtimes/python-anthropic) | Real runtime backed by the Anthropic Messages API. Needs an `ANTHROPIC_API_KEY` secret via `spec.secretRef`. |
 | [`runtimes/reporter/`](runtimes/reporter) | Reusable PID 1 supervisor. Preserves child logs and process semantics while producing the versioned result envelope. |
 
-Provider credentials are wired by the controller from a Kubernetes Secret into the env vars each provider expects (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, AWS credential pairs for Bedrock, and so on). See `internal/runtimepolicy/`.
+Provider credentials are wired by the controller from a Kubernetes Secret into
+the env vars each provider expects. The maintained reference transports use
+`ANTHROPIC_API_KEY` and `OPENAI_API_KEY`; see its
+[compatibility and Secret documentation](runtimes/reference/README.md).
+Credentialed acceptance is dispatch-only and protected from pull-request CI.
 
 ### Capture results from an existing image
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,7 @@ Kontext provides generic `Agent` and `AgentRun` primitives. Consumer-specific co
 ### M4 — Bring-your-own-runtime hardening
 - Echo runtime shipped (`runtimes/echo/`). Anthropic Python runner remains under `runtimes/python-anthropic/`.
 - Versioned results, the reusable reporter, and optional stdout capture support existing Linux images with explicit commands.
-- The maintained Go reference runtime has a provider-neutral core and deterministic fake-provider path.
+- The maintained Go reference runtime has a provider-neutral core, deterministic fake-provider path, and direct Anthropic and OpenAI-compatible HTTP transports.
 
 ### M5 — Governance
 - Per-agent ServiceAccount, finalizers, budget enforcement, CEL validation on the CRDs, events on transitions.
@@ -54,4 +54,4 @@ Kontext provides generic `Agent` and `AgentRun` primitives. Consumer-specific co
 
 1. M2 Task templating when a concrete consumer needs parameterized triggers.
 2. M5 governance (CEL, per-agent SA, richer events).
-3. Anthropic runtime parity on v1alpha1 `AgentRun`.
+3. Bounded tool execution in the maintained reference runtime.

--- a/SPEC.md
+++ b/SPEC.md
@@ -277,8 +277,19 @@ contract.
 
 The initial keyless `fake` provider is deterministic and exercises the same
 configuration, conversation, event, result, cancellation, and failure paths
-that real HTTP transports use. `KONTEXT_MODEL` remains opaque and is never
-aliased or rewritten.
+that real HTTP transports use. The maintained real transports are Anthropic
+Messages (`anthropic`) and OpenAI-compatible Chat Completions (`openai` or
+`openai-compatible`). They use direct non-streaming HTTP, accept an optional
+exact endpoint or base-URL override, and normalize text, function tool calls,
+stop reasons, measured usage, request IDs, and actionable transport errors.
+The OpenAI-compatible boundary is the documented Chat Completions request,
+response, bearer-auth, and function-tool-call shape; it does not imply support
+for the Responses API, streaming, Azure URL construction, or every inference
+protocol. `KONTEXT_MODEL` remains opaque and is never aliased or rewritten.
+
+Credentials come from the `AgentRun` Secret policy as `ANTHROPIC_API_KEY` or
+`OPENAI_API_KEY`. Authenticated acceptance is manual and environment-protected;
+pull-request CI remains deterministic, keyless, and network-independent.
 
 The controller remains authoritative for wallclock enforcement. The runtime
 parses `KONTEXT_BUDGET_WALLCLOCK` but does not start a competing timer; it

--- a/deploy/examples/v1alpha1/provider-secrets.example.yaml
+++ b/deploy/examples/v1alpha1/provider-secrets.example.yaml
@@ -1,0 +1,17 @@
+# Example only. Replace each value before applying, or create the Secrets with
+# kubectl so credentials never enter a file or source control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kontext-anthropic
+type: Opaque
+stringData:
+  ANTHROPIC_API_KEY: replace-me
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kontext-openai
+type: Opaque
+stringData:
+  OPENAI_API_KEY: replace-me

--- a/deploy/examples/v1alpha1/reference-anthropic-run.yaml
+++ b/deploy/examples/v1alpha1/reference-anthropic-run.yaml
@@ -1,0 +1,15 @@
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-anthropic
+spec:
+  goal: Explain the Kontext runtime contract in one sentence.
+  provider: anthropic
+  model: replace-with-anthropic-model-id
+  secretRef:
+    name: kontext-anthropic
+  runtime:
+    image: kontext-reference:dev
+  budget:
+    tokens: 512
+    wallclock: 2m

--- a/deploy/examples/v1alpha1/reference-openai-compatible-run.yaml
+++ b/deploy/examples/v1alpha1/reference-openai-compatible-run.yaml
@@ -1,0 +1,19 @@
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-openai-compatible
+spec:
+  goal: Explain the Kontext runtime contract in one sentence.
+  provider: openai-compatible
+  model: replace-with-provider-model-id
+  secretRef:
+    name: kontext-openai
+  runtime:
+    image: kontext-reference:dev
+  env:
+    # Remove this override to use OpenAI's hosted Chat Completions endpoint.
+    - name: KONTEXT_PROVIDER_BASE_URL
+      value: http://openai-compatible.default.svc:8000/v1
+  budget:
+    tokens: 512
+    wallclock: 2m

--- a/internal/podbuilder/podbuilder_test.go
+++ b/internal/podbuilder/podbuilder_test.go
@@ -130,10 +130,11 @@ func TestBuildPodInjectsProviderCredentials(t *testing.T) {
 		secretName string
 		secretKey  string
 	}{
-		"anthropic":    {provider: "anthropic", envName: "ANTHROPIC_API_KEY", secretName: "kontext-anthropic", secretKey: "ANTHROPIC_API_KEY"},
-		"openai":       {provider: "openai", envName: "OPENAI_API_KEY", secretName: "kontext-openai", secretKey: "OPENAI_API_KEY"},
-		"google":       {provider: "google", envName: "GOOGLE_API_KEY", secretName: "kontext-google", secretKey: "GOOGLE_API_KEY"},
-		"azure-openai": {provider: "azure-openai", envName: "AZURE_OPENAI_API_KEY", secretName: "kontext-azure-openai", secretKey: "AZURE_OPENAI_API_KEY"},
+		"anthropic":         {provider: "anthropic", envName: "ANTHROPIC_API_KEY", secretName: "kontext-anthropic", secretKey: "ANTHROPIC_API_KEY"},
+		"openai":            {provider: "openai", envName: "OPENAI_API_KEY", secretName: "kontext-openai", secretKey: "OPENAI_API_KEY"},
+		"openai-compatible": {provider: "openai-compatible", envName: "OPENAI_API_KEY", secretName: "kontext-openai", secretKey: "OPENAI_API_KEY"},
+		"google":            {provider: "google", envName: "GOOGLE_API_KEY", secretName: "kontext-google", secretKey: "GOOGLE_API_KEY"},
+		"azure-openai":      {provider: "azure-openai", envName: "AZURE_OPENAI_API_KEY", secretName: "kontext-azure-openai", secretKey: "AZURE_OPENAI_API_KEY"},
 	}
 
 	for name, tc := range cases {

--- a/internal/runtimepolicy/provider.go
+++ b/internal/runtimepolicy/provider.go
@@ -33,6 +33,12 @@ var providerDefinitions = map[string]providerDefinition{
 			{EnvVarName: "OPENAI_API_KEY", SecretKey: "OPENAI_API_KEY"},
 		},
 	},
+	"openai-compatible": {
+		defaultSecretName: "kontext-openai",
+		credentials: []CredentialSpec{
+			{EnvVarName: "OPENAI_API_KEY", SecretKey: "OPENAI_API_KEY"},
+		},
+	},
 	"google": {
 		defaultSecretName: "kontext-google",
 		credentials: []CredentialSpec{

--- a/internal/runtimepolicy/provider_test.go
+++ b/internal/runtimepolicy/provider_test.go
@@ -22,7 +22,7 @@ func TestNeedsAPIKey(t *testing.T) {
 			t.Fatalf("expected %s to be keyless", provider)
 		}
 	}
-	for _, provider := range []string{"anthropic", "openai", "google", "gemini", "azure-openai", "mistral", "groq", "cohere", "bedrock"} {
+	for _, provider := range []string{"anthropic", "openai", "openai-compatible", "google", "gemini", "azure-openai", "mistral", "groq", "cohere", "bedrock"} {
 		if !runtimepolicy.NeedsAPIKey(provider) {
 			t.Fatalf("expected %s to require a key", provider)
 		}
@@ -31,13 +31,14 @@ func TestNeedsAPIKey(t *testing.T) {
 
 func TestCredentialsForKnownProviders(t *testing.T) {
 	cases := map[string]string{
-		"anthropic": "ANTHROPIC_API_KEY",
-		"openai":    "OPENAI_API_KEY",
-		"google":    "GOOGLE_API_KEY",
-		"gemini":    "GOOGLE_API_KEY",
-		"mistral":   "MISTRAL_API_KEY",
-		"groq":      "GROQ_API_KEY",
-		"cohere":    "COHERE_API_KEY",
+		"anthropic":         "ANTHROPIC_API_KEY",
+		"openai":            "OPENAI_API_KEY",
+		"openai-compatible": "OPENAI_API_KEY",
+		"google":            "GOOGLE_API_KEY",
+		"gemini":            "GOOGLE_API_KEY",
+		"mistral":           "MISTRAL_API_KEY",
+		"groq":              "GROQ_API_KEY",
+		"cohere":            "COHERE_API_KEY",
 	}
 	for provider, envName := range cases {
 		creds := runtimepolicy.Credentials(provider)

--- a/runtimes/reference/README.md
+++ b/runtimes/reference/README.md
@@ -4,8 +4,8 @@ The maintained reference runtime is a small provider-neutral execution loop.
 It demonstrates how a model-backed agent behaves as a Kubernetes workload
 without adopting an agent framework.
 
-Issue #17 ships only the deterministic `fake` provider. Anthropic and
-OpenAI-compatible HTTP adapters are added separately.
+The runtime includes a deterministic `fake` provider plus direct Anthropic
+Messages and OpenAI-compatible Chat Completions HTTP transports.
 
 ## Execution model
 
@@ -28,7 +28,7 @@ No private chain-of-thought is emitted.
 | Environment variable | Required | Meaning |
 |---|---|---|
 | `KONTEXT_GOAL` | yes | Concrete task for this run |
-| `KONTEXT_PROVIDER` | yes | Provider adapter name; currently `fake` |
+| `KONTEXT_PROVIDER` | yes | `fake`, `anthropic`, `openai`, or `openai-compatible` |
 | `KONTEXT_MODEL` | yes | Opaque provider model identifier |
 | `KONTEXT_RUN_NAME` | no | Run metadata; defaults to `unknown-run` |
 | `KONTEXT_AGENT_NAME` | no | Agent metadata; defaults to run name |
@@ -36,7 +36,10 @@ No private chain-of-thought is emitted.
 | `KONTEXT_BUDGET_TOKENS` | no | Positive requested output/token limit |
 | `KONTEXT_BUDGET_WALLCLOCK` | no | Optional Go duration; omitted means disabled |
 | `KONTEXT_BUDGET_DOLLARS` | no | Optional non-negative recorded budget |
-| `KONTEXT_PROVIDER_ENDPOINT` | no | Absolute HTTP(S) endpoint for future adapters |
+| `KONTEXT_PROVIDER_ENDPOINT` | no | Exact absolute HTTP(S) request endpoint |
+| `KONTEXT_PROVIDER_BASE_URL` | no | Absolute HTTP(S) base URL; provider path is appended |
+| `ANTHROPIC_API_KEY` | Anthropic only | Anthropic API key, normally injected from a Secret |
+| `OPENAI_API_KEY` | OpenAI-compatible only | Bearer token, normally injected from a Secret |
 | `KONTEXT_FAKE_SCENARIO` | no | `success`, `failure`, `malformed`, or `delay` |
 | `KONTEXT_FAKE_DELAY` | delay only | Positive Go duration such as `250ms` |
 
@@ -46,6 +49,53 @@ parses the value but does not start a competing timer. It reacts promptly when
 the reporter forwards controller cancellation signals.
 
 Model identifiers pass through unchanged.
+
+`KONTEXT_PROVIDER_ENDPOINT` and `KONTEXT_PROVIDER_BASE_URL` are mutually
+exclusive. A base URL may contain a path prefix. The runtime appends
+`/v1/messages` for Anthropic or `/chat/completions` for OpenAI-compatible
+providers. An exact endpoint is used without modification.
+
+## Maintained HTTP compatibility
+
+### Anthropic
+
+- Sends one non-streaming `POST` to the Messages API with
+  `anthropic-version: 2023-06-01`.
+- Defaults to `https://api.anthropic.com/v1/messages`.
+- Sends `KONTEXT_BUDGET_TOKENS` as `max_tokens`. Because Anthropic requires
+  that field, the transport uses `4096` when the budget is omitted.
+- Normalizes text and client `tool_use` blocks; current documented stop
+  reasons; input/output token usage; and the `request-id` header.
+
+### OpenAI-compatible
+
+- `openai` and `openai-compatible` use the same transport.
+- Sends one non-streaming `POST` to the Chat Completions API and defaults to
+  `https://api.openai.com/v1/chat/completions`.
+- Treats the base URL as the OpenAI API root (normally ending in `/v1`) and
+  appends `/chat/completions`.
+- Sends `model`, text `messages`, and optional `max_completion_tokens`.
+- Normalizes assistant text, function `tool_calls`, documented finish reasons,
+  optional prompt/completion/total usage, and the `x-request-id` header.
+
+`OpenAI-compatible` means compatibility with that request, response, auth, and
+tool-call shape. It does not include the Responses API, streaming, embeddings,
+realtime transports, Azure deployment URL construction, or vendor-specific
+extensions. Endpoint operators are responsible for accepting a bearer token
+in `Authorization`; a non-secret placeholder may be used only when an
+in-cluster endpoint ignores auth.
+
+The runtime currently does not send declared tools or execute returned tool
+calls. Tool calls are normalized so the transport boundary remains explicit,
+but this one-turn runtime is intended for text tasks until the bounded tool
+loop is implemented.
+
+HTTP failures use stable result error codes including
+`authentication_failed`, `rate_limited`, `provider_timeout`,
+`provider_network_error`, `provider_endpoint_error`,
+`provider_request_rejected`, and `invalid_provider_response`. Retryability,
+HTTP status, and provider request IDs are retained where available. Response
+bodies are bounded to 4 MiB.
 
 ## Local fake-provider run
 
@@ -62,6 +112,32 @@ Build the production image:
 make docker-build-reference
 ```
 
+## Kubernetes credentials and examples
+
+The controller reads `spec.secretRef` and injects only the maintained
+transport's expected environment variable. Create Secrets without putting
+credentials in source control:
+
+```bash
+kubectl create secret generic kontext-anthropic \
+  --from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
+
+kubectl create secret generic kontext-openai \
+  --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY"
+```
+
+Example templates live in `deploy/examples/v1alpha1/`:
+
+- `provider-secrets.example.yaml`
+- `reference-anthropic-run.yaml`
+- `reference-openai-compatible-run.yaml`
+
+The `Provider acceptance` GitHub Actions workflow is dispatch-only and uses
+the `provider-acceptance` environment. Repository maintainers must protect
+that environment with required reviewers and store `ANTHROPIC_API_KEY` and
+`OPENAI_API_KEY` as environment secrets. Pull-request CI never receives or
+uses these credentials.
+
 ## Dependency inventory
 
 The reference binary uses only the Go standard library and in-repository
@@ -72,13 +148,13 @@ for Linux process supervision. The production image contains:
 - `/kontext-reporter`
 - `/kontext-reference`
 
-It contains no shell, package manager, CA bundle requirement for the fake
-provider, agent framework, retrieval system, or persistent storage.
+It contains no shell, package manager, agent framework, retrieval system, or
+persistent storage.
 
 ## Explicit limits
 
 - One provider completion per run.
 - Conversation state exists only in memory for that run.
 - Tools are declared but not executed.
-- No retries, planning, memory, retrieval, subagents, or background work.
-- No real provider credentials or network calls in issue #17.
+- No retries, planning, memory, retrieval, subagents, background work, or
+  provider-specific model aliases.

--- a/runtimes/reference/internal/config/config.go
+++ b/runtimes/reference/internal/config/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	DollarBudget    *float64
 
 	ProviderEndpoint string
+	ProviderBaseURL  string
+	AnthropicAPIKey  string
+	OpenAIAPIKey     string
 	FakeScenario     string
 	FakeDelay        time.Duration
 }
@@ -58,9 +61,24 @@ func Load(getenv func(string) string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	endpoint, err := optionalEndpoint(getenv("KONTEXT_PROVIDER_ENDPOINT"))
+	endpoint, err := optionalEndpoint(
+		getenv("KONTEXT_PROVIDER_ENDPOINT"),
+		"KONTEXT_PROVIDER_ENDPOINT",
+	)
 	if err != nil {
 		return Config{}, err
+	}
+	baseURL, err := optionalEndpoint(
+		getenv("KONTEXT_PROVIDER_BASE_URL"),
+		"KONTEXT_PROVIDER_BASE_URL",
+	)
+	if err != nil {
+		return Config{}, err
+	}
+	if endpoint != "" && baseURL != "" {
+		return Config{}, fmt.Errorf(
+			"KONTEXT_PROVIDER_ENDPOINT and KONTEXT_PROVIDER_BASE_URL are mutually exclusive",
+		)
 	}
 
 	runName := strings.TrimSpace(getenv("KONTEXT_RUN_NAME"))
@@ -95,6 +113,9 @@ func Load(getenv func(string) string) (Config, error) {
 		WallclockBudget:  wallclockBudget,
 		DollarBudget:     dollarBudget,
 		ProviderEndpoint: endpoint,
+		ProviderBaseURL:  baseURL,
+		AnthropicAPIKey:  getenv("ANTHROPIC_API_KEY"),
+		OpenAIAPIKey:     getenv("OPENAI_API_KEY"),
 		FakeScenario:     fakeScenario,
 		FakeDelay:        fakeDelay,
 	}, nil
@@ -152,14 +173,19 @@ func optionalNonNegativeFloat(value string, name string) (*float64, error) {
 	return &parsed, nil
 }
 
-func optionalEndpoint(value string) (string, error) {
+func optionalEndpoint(value string, name string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return "", nil
 	}
 	parsed, err := url.Parse(value)
-	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-		return "", fmt.Errorf("KONTEXT_PROVIDER_ENDPOINT must be an absolute HTTP(S) URL")
+	if err != nil ||
+		parsed.Host == "" ||
+		(parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", fmt.Errorf("%s must be an absolute HTTP(S) URL", name)
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("%s must not contain embedded credentials", name)
 	}
 	return value, nil
 }

--- a/runtimes/reference/internal/config/config_test.go
+++ b/runtimes/reference/internal/config/config_test.go
@@ -20,6 +20,8 @@ func TestLoadPreservesOpaqueModelAndParsesOptionalInputs(t *testing.T) {
 		"KONTEXT_BUDGET_WALLCLOCK":  "1m30s",
 		"KONTEXT_BUDGET_DOLLARS":    "0",
 		"KONTEXT_PROVIDER_ENDPOINT": "http://provider.default.svc:8080/v1",
+		"ANTHROPIC_API_KEY":         "anthropic-secret",
+		"OPENAI_API_KEY":            "openai-secret",
 	}
 	loaded, err := config.Load(lookup(values))
 	if err != nil {
@@ -45,6 +47,10 @@ func TestLoadPreservesOpaqueModelAndParsesOptionalInputs(t *testing.T) {
 	}
 	if loaded.ProviderEndpoint != "http://provider.default.svc:8080/v1" {
 		t.Fatalf("unexpected endpoint %q", loaded.ProviderEndpoint)
+	}
+	if loaded.AnthropicAPIKey != "anthropic-secret" ||
+		loaded.OpenAIAPIKey != "openai-secret" {
+		t.Fatalf("provider credentials were not loaded")
 	}
 }
 
@@ -72,6 +78,14 @@ func TestLoadValidatesRequiredAndOptionalConfiguration(t *testing.T) {
 		{name: "NaN dollars", change: func(values map[string]string) { values["KONTEXT_BUDGET_DOLLARS"] = "NaN" }},
 		{name: "infinite dollars", change: func(values map[string]string) { values["KONTEXT_BUDGET_DOLLARS"] = "+Inf" }},
 		{name: "invalid endpoint", change: func(values map[string]string) { values["KONTEXT_PROVIDER_ENDPOINT"] = "localhost:8080" }},
+		{name: "invalid base URL", change: func(values map[string]string) { values["KONTEXT_PROVIDER_BASE_URL"] = "localhost:8080" }},
+		{name: "embedded endpoint credentials", change: func(values map[string]string) {
+			values["KONTEXT_PROVIDER_ENDPOINT"] = "https://user:password@provider.example/messages"
+		}},
+		{name: "endpoint and base URL", change: func(values map[string]string) {
+			values["KONTEXT_PROVIDER_ENDPOINT"] = "https://provider.example/messages"
+			values["KONTEXT_PROVIDER_BASE_URL"] = "https://provider.example"
+		}},
 		{name: "invalid fake delay", change: func(values map[string]string) { values["KONTEXT_FAKE_DELAY"] = "-3s" }},
 	}
 	for _, test := range tests {
@@ -82,6 +96,18 @@ func TestLoadValidatesRequiredAndOptionalConfiguration(t *testing.T) {
 				t.Fatalf("expected configuration error")
 			}
 		})
+	}
+}
+
+func TestLoadParsesProviderBaseURL(t *testing.T) {
+	values := requiredValues()
+	values["KONTEXT_PROVIDER_BASE_URL"] = "http://provider.default.svc:8080/openai"
+	loaded, err := config.Load(lookup(values))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.ProviderBaseURL != "http://provider.default.svc:8080/openai" {
+		t.Fatalf("unexpected base URL %q", loaded.ProviderBaseURL)
 	}
 }
 

--- a/runtimes/reference/internal/engine/engine.go
+++ b/runtimes/reference/internal/engine/engine.go
@@ -72,7 +72,10 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 		code := "unsupported_provider"
 		var configurationError *provider.ConfigurationError
 		if errors.As(err, &configurationError) {
-			code = "invalid_provider_configuration"
+			code = configurationError.Code
+			if code == "" {
+				code = "invalid_provider_configuration"
+			}
 		}
 		runner.emitError(code, err.Error(), nil)
 		return failed(code, err.Error(), nil, metadata(""))
@@ -111,6 +114,14 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 	})
 	if usage := envelopeUsage(response.Usage); usage != nil {
 		runner.emit(events.TypeUsage, usage)
+	}
+	for _, toolCall := range runtimeapi.MessageToolCalls(response.Message) {
+		runner.emit(events.TypeTool, map[string]any{
+			"id":        toolCall.ID,
+			"name":      toolCall.Name,
+			"arguments": toolCall.Arguments,
+			"executed":  false,
+		})
 	}
 	runner.emit(events.TypeOutput, map[string]any{
 		"mediaType": resultv1alpha1.DefaultMediaType,
@@ -168,6 +179,14 @@ func normalizeError(
 			providerError.Message,
 			providerError.Retryable,
 			providerError.RequestID
+	}
+	var configurationError *provider.ConfigurationError
+	if errors.As(err, &configurationError) {
+		code := configurationError.Code
+		if code == "" {
+			code = "invalid_provider_configuration"
+		}
+		return code, configurationError.Error(), nil, ""
 	}
 	return "provider_error", err.Error(), nil, ""
 }

--- a/runtimes/reference/internal/engine/engine_test.go
+++ b/runtimes/reference/internal/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/kontext-dev/kontext/runtimes/reference/internal/engine"
 	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
 	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
 )
 
 func TestRunnerCompletesFakeConversation(t *testing.T) {
@@ -90,6 +92,62 @@ func TestRunnerDistinguishesInvalidProviderConfiguration(t *testing.T) {
 	}
 }
 
+func TestRunnerReportsMissingProviderCredentials(t *testing.T) {
+	for _, providerName := range []string{"anthropic", "openai", "openai-compatible"} {
+		t.Run(providerName, func(t *testing.T) {
+			runtimeConfig := baseConfig()
+			runtimeConfig.Provider = providerName
+			result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+				context.Background(),
+				runtimeConfig,
+			)
+			if result.Envelope.Error == nil ||
+				result.Envelope.Error.Code != "missing_provider_credentials" {
+				t.Fatalf("unexpected error %#v", result.Envelope.Error)
+			}
+		})
+	}
+}
+
+func TestRunnerRecordsNormalizedToolCallsWithoutExecutingThem(t *testing.T) {
+	emitter := &recordingEmitter{}
+	response := runtimeapi.CompletionResponse{
+		Message: runtimeapi.Message{
+			Role: runtimeapi.RoleAssistant,
+			Content: []runtimeapi.ContentBlock{
+				{Type: runtimeapi.ContentTypeText, Text: "tool requested"},
+				{
+					Type: runtimeapi.ContentTypeToolCall,
+					ToolCall: &runtimeapi.ToolCall{
+						ID:        "call-1",
+						Name:      "lookup",
+						Arguments: json.RawMessage(`{"query":"status"}`),
+					},
+				},
+			},
+		},
+		StopReason: runtimeapi.StopReasonToolUse,
+	}
+	runner := engine.Runner{
+		Emitter: emitter,
+		Resolve: func(config.Config) (provider.Provider, error) {
+			return staticProvider{response: response}, nil
+		},
+	}
+	result := runner.Run(context.Background(), baseConfig())
+	if result.ExitCode != 0 {
+		t.Fatalf("unexpected failure %#v", result.Envelope.Error)
+	}
+	if result.Envelope.Execution == nil ||
+		result.Envelope.Execution.ToolCalls == nil ||
+		*result.Envelope.Execution.ToolCalls != 1 {
+		t.Fatalf("unexpected execution metadata %#v", result.Envelope.Execution)
+	}
+	if !emitter.has(events.TypeTool) {
+		t.Fatalf("expected tool event, got %#v", emitter.types)
+	}
+}
+
 func TestRunnerHasNoImplicitWallclockDeadline(t *testing.T) {
 	runtimeConfig := baseConfig()
 	runtimeConfig.FakeScenario = provider.FakeScenarioDelay
@@ -164,6 +222,21 @@ func baseConfig() config.Config {
 
 type recordingEmitter struct {
 	types []events.Type
+}
+
+type staticProvider struct {
+	response runtimeapi.CompletionResponse
+}
+
+func (static staticProvider) Name() string {
+	return "static"
+}
+
+func (static staticProvider) Complete(
+	context.Context,
+	runtimeapi.CompletionRequest,
+) (runtimeapi.CompletionResponse, error) {
+	return static.response, nil
 }
 
 func (emitter *recordingEmitter) Emit(eventType events.Type, _ any) {

--- a/runtimes/reference/internal/engine/envelope.go
+++ b/runtimes/reference/internal/engine/envelope.go
@@ -20,7 +20,7 @@ func Success(response runtimeapi.CompletionResponse, metadata Metadata) resultv1
 	text := runtimeapi.MessageText(response.Message)
 	value, _ := json.Marshal(text)
 	turns := int32(1)
-	toolCalls := int32(0)
+	toolCalls := int32(len(runtimeapi.MessageToolCalls(response.Message)))
 	durationMillis := metadata.CompletedAt.Sub(metadata.StartedAt).Milliseconds()
 
 	return resultv1alpha1.Envelope{

--- a/runtimes/reference/internal/events/emitter.go
+++ b/runtimes/reference/internal/events/emitter.go
@@ -16,6 +16,7 @@ const (
 	TypeLifecycle Type = "lifecycle"
 	TypeOutput    Type = "output"
 	TypeUsage     Type = "usage"
+	TypeTool      Type = "tool"
 	TypeError     Type = "error"
 )
 

--- a/runtimes/reference/internal/provider/anthropic.go
+++ b/runtimes/reference/internal/provider/anthropic.go
@@ -1,0 +1,268 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+const (
+	DefaultAnthropicEndpoint  = "https://api.anthropic.com/v1/messages"
+	anthropicMessagesPath     = "v1/messages"
+	anthropicVersion          = "2023-06-01"
+	anthropicDefaultMaxTokens = int64(4096)
+)
+
+type AnthropicConfig struct {
+	APIKey   string
+	Endpoint string
+	BaseURL  string
+	Client   HTTPClient
+}
+
+type Anthropic struct {
+	apiKey   string
+	endpoint string
+	client   HTTPClient
+}
+
+func NewAnthropic(config AnthropicConfig) (*Anthropic, error) {
+	if err := validateAPIKey("anthropic", config.APIKey); err != nil {
+		return nil, err
+	}
+	endpoint, err := providerEndpoint(
+		"anthropic",
+		config.Endpoint,
+		config.BaseURL,
+		DefaultAnthropicEndpoint,
+		anthropicMessagesPath,
+	)
+	if err != nil {
+		return nil, err
+	}
+	client := config.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Anthropic{
+		apiKey:   config.APIKey,
+		endpoint: endpoint,
+		client:   client,
+	}, nil
+}
+
+func (anthropic *Anthropic) Name() string {
+	return "anthropic"
+}
+
+func (anthropic *Anthropic) Complete(
+	ctx context.Context,
+	request runtimeapi.CompletionRequest,
+) (runtimeapi.CompletionResponse, error) {
+	payload, err := anthropicRequest(request)
+	if err != nil {
+		return runtimeapi.CompletionResponse{}, err
+	}
+	headers := make(http.Header)
+	headers.Set("x-api-key", anthropic.apiKey)
+	headers.Set("anthropic-version", anthropicVersion)
+	result, err := sendJSON(ctx, anthropic.client, anthropic.endpoint, headers, payload)
+	if err != nil {
+		return runtimeapi.CompletionResponse{}, err
+	}
+
+	responseRequestID := requestID(result.Header, "request-id")
+	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
+		var failure anthropicErrorResponse
+		_ = json.Unmarshal(result.Body, &failure)
+		if responseRequestID == "" {
+			responseRequestID = strings.TrimSpace(failure.RequestID)
+		}
+		return runtimeapi.CompletionResponse{}, providerHTTPError(
+			"anthropic",
+			result.StatusCode,
+			failure.Error.Message,
+			responseRequestID,
+		)
+	}
+
+	var response anthropicResponse
+	if err := json.Unmarshal(result.Body, &response); err != nil {
+		return runtimeapi.CompletionResponse{}, invalidResponse(
+			fmt.Sprintf("anthropic returned malformed JSON: %v", err),
+			result.StatusCode,
+			responseRequestID,
+		)
+	}
+	normalized, err := normalizeAnthropicResponse(response, responseRequestID)
+	if err != nil {
+		return runtimeapi.CompletionResponse{}, invalidResponse(
+			fmt.Sprintf("anthropic returned an invalid response: %v", err),
+			result.StatusCode,
+			responseRequestID,
+		)
+	}
+	return normalized, nil
+}
+
+type anthropicRequestPayload struct {
+	Model     string                    `json:"model"`
+	MaxTokens int64                     `json:"max_tokens"`
+	Messages  []anthropicRequestMessage `json:"messages"`
+}
+
+type anthropicRequestMessage struct {
+	Role    string                    `json:"role"`
+	Content []anthropicRequestContent `json:"content"`
+}
+
+type anthropicRequestContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func anthropicRequest(request runtimeapi.CompletionRequest) (anthropicRequestPayload, error) {
+	maxTokens := anthropicDefaultMaxTokens
+	if request.MaxTokens != nil {
+		maxTokens = *request.MaxTokens
+	}
+	payload := anthropicRequestPayload{
+		Model:     request.Model,
+		MaxTokens: maxTokens,
+		Messages:  make([]anthropicRequestMessage, 0, len(request.Messages)),
+	}
+	for messageIndex, message := range request.Messages {
+		if message.Role != runtimeapi.RoleUser && message.Role != runtimeapi.RoleAssistant {
+			return anthropicRequestPayload{}, fmt.Errorf(
+				"message %d has unsupported role %q",
+				messageIndex,
+				message.Role,
+			)
+		}
+		normalized := anthropicRequestMessage{
+			Role:    string(message.Role),
+			Content: make([]anthropicRequestContent, 0, len(message.Content)),
+		}
+		for blockIndex, block := range message.Content {
+			if block.Type != runtimeapi.ContentTypeText {
+				return anthropicRequestPayload{}, fmt.Errorf(
+					"message %d content block %d has unsupported type %q",
+					messageIndex,
+					blockIndex,
+					block.Type,
+				)
+			}
+			normalized.Content = append(normalized.Content, anthropicRequestContent{
+				Type: "text",
+				Text: block.Text,
+			})
+		}
+		payload.Messages = append(payload.Messages, normalized)
+	}
+	return payload, nil
+}
+
+type anthropicResponse struct {
+	Role       string                     `json:"role"`
+	Content    []anthropicResponseContent `json:"content"`
+	StopReason string                     `json:"stop_reason"`
+	Usage      anthropicUsage             `json:"usage"`
+}
+
+type anthropicResponseContent struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+type anthropicUsage struct {
+	InputTokens  *int64 `json:"input_tokens"`
+	OutputTokens *int64 `json:"output_tokens"`
+}
+
+type anthropicErrorResponse struct {
+	RequestID string `json:"request_id"`
+	Error     struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func normalizeAnthropicResponse(
+	response anthropicResponse,
+	responseRequestID string,
+) (runtimeapi.CompletionResponse, error) {
+	if response.Role != string(runtimeapi.RoleAssistant) {
+		return runtimeapi.CompletionResponse{}, fmt.Errorf(
+			"unexpected message role %q",
+			response.Role,
+		)
+	}
+	content := make([]runtimeapi.ContentBlock, 0, len(response.Content))
+	for index, block := range response.Content {
+		switch block.Type {
+		case "text":
+			content = append(content, runtimeapi.ContentBlock{
+				Type: runtimeapi.ContentTypeText,
+				Text: block.Text,
+			})
+		case "tool_use":
+			content = append(content, runtimeapi.ContentBlock{
+				Type: runtimeapi.ContentTypeToolCall,
+				ToolCall: &runtimeapi.ToolCall{
+					ID:        block.ID,
+					Name:      block.Name,
+					Arguments: append(json.RawMessage(nil), block.Input...),
+				},
+			})
+		default:
+			return runtimeapi.CompletionResponse{}, fmt.Errorf(
+				"content block %d has unsupported type %q",
+				index,
+				block.Type,
+			)
+		}
+	}
+	stopReason, err := normalizeAnthropicStopReason(response.StopReason)
+	if err != nil {
+		return runtimeapi.CompletionResponse{}, err
+	}
+	return runtimeapi.CompletionResponse{
+		Message: runtimeapi.Message{
+			Role:    runtimeapi.RoleAssistant,
+			Content: content,
+		},
+		Usage: runtimeapi.Usage{
+			InputTokens:  response.Usage.InputTokens,
+			OutputTokens: response.Usage.OutputTokens,
+		},
+		StopReason: stopReason,
+		RequestID:  responseRequestID,
+	}, nil
+}
+
+func normalizeAnthropicStopReason(value string) (runtimeapi.StopReason, error) {
+	switch value {
+	case "end_turn":
+		return runtimeapi.StopReasonEndTurn, nil
+	case "max_tokens":
+		return runtimeapi.StopReasonMaxTokens, nil
+	case "stop_sequence":
+		return runtimeapi.StopReasonStopSequence, nil
+	case "tool_use":
+		return runtimeapi.StopReasonToolUse, nil
+	case "pause_turn":
+		return runtimeapi.StopReasonPauseTurn, nil
+	case "refusal":
+		return runtimeapi.StopReasonRefusal, nil
+	case "model_context_window_exceeded":
+		return runtimeapi.StopReasonModelContextWindowExceeded, nil
+	default:
+		return "", fmt.Errorf("unsupported stop reason %q", value)
+	}
+}

--- a/runtimes/reference/internal/provider/anthropic_test.go
+++ b/runtimes/reference/internal/provider/anthropic_test.go
@@ -1,0 +1,280 @@
+package provider_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+func TestAnthropicCompletesAndNormalizesResponse(t *testing.T) {
+	var received struct {
+		Model     string `json:"model"`
+		MaxTokens int64  `json:"max_tokens"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/proxy/v1/messages" {
+			t.Errorf("unexpected request path %q", request.URL.Path)
+		}
+		if request.Header.Get("x-api-key") != "anthropic-test-key" {
+			t.Errorf("missing Anthropic API key header")
+		}
+		if request.Header.Get("anthropic-version") != "2023-06-01" {
+			t.Errorf("missing Anthropic version header")
+		}
+		if err := json.NewDecoder(request.Body).Decode(&received); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writer.Header().Set("request-id", "req-anthropic-1")
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{
+			"role":"assistant",
+			"content":[
+				{"type":"text","text":"calling a tool"},
+				{"type":"tool_use","id":"tool-1","name":"lookup","input":{"query":"status"}}
+			],
+			"stop_reason":"tool_use",
+			"usage":{"input_tokens":0,"output_tokens":12}
+		}`))
+	}))
+	defer server.Close()
+
+	selected, err := provider.NewAnthropic(provider.AnthropicConfig{
+		APIKey:  "anthropic-test-key",
+		BaseURL: server.URL + "/proxy",
+		Client:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	response, err := selected.Complete(
+		context.Background(),
+		completionRequest("claude/model@opaque"),
+	)
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if received.Model != "claude/model@opaque" {
+		t.Fatalf("model identifier changed: %q", received.Model)
+	}
+	if received.MaxTokens != 4096 {
+		t.Fatalf("unexpected default max tokens %d", received.MaxTokens)
+	}
+	if response.RequestID != "req-anthropic-1" {
+		t.Fatalf("unexpected request id %q", response.RequestID)
+	}
+	if response.StopReason != runtimeapi.StopReasonToolUse {
+		t.Fatalf("unexpected stop reason %q", response.StopReason)
+	}
+	if response.Usage.InputTokens == nil || *response.Usage.InputTokens != 0 {
+		t.Fatalf("measured zero input tokens were lost: %#v", response.Usage)
+	}
+	if response.Usage.OutputTokens == nil || *response.Usage.OutputTokens != 12 {
+		t.Fatalf("unexpected output usage: %#v", response.Usage)
+	}
+	if response.Usage.TotalTokens != nil {
+		t.Fatalf("unreported total tokens must remain absent: %#v", response.Usage)
+	}
+	if len(response.Message.Content) != 2 ||
+		response.Message.Content[1].ToolCall == nil ||
+		response.Message.Content[1].ToolCall.Name != "lookup" ||
+		string(response.Message.Content[1].ToolCall.Arguments) != `{"query":"status"}` {
+		t.Fatalf("unexpected normalized content %#v", response.Message.Content)
+	}
+	if err := runtimeapi.ValidateResponse(response); err != nil {
+		t.Fatalf("validate normalized response: %v", err)
+	}
+}
+
+func TestAnthropicUsesExactEndpointAndRequestedTokenLimit(t *testing.T) {
+	var maxTokens int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/custom/messages" {
+			t.Errorf("unexpected exact endpoint path %q", request.URL.Path)
+		}
+		var payload struct {
+			MaxTokens int64 `json:"max_tokens"`
+		}
+		_ = json.NewDecoder(request.Body).Decode(&payload)
+		maxTokens = payload.MaxTokens
+		_, _ = writer.Write([]byte(`{
+			"role":"assistant",
+			"content":[{"type":"text","text":"ok"}],
+			"stop_reason":"end_turn"
+		}`))
+	}))
+	defer server.Close()
+
+	selected, err := provider.NewAnthropic(provider.AnthropicConfig{
+		APIKey:   "key",
+		Endpoint: server.URL + "/custom/messages",
+		Client:   server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	request := completionRequest("model")
+	limit := int64(77)
+	request.MaxTokens = &limit
+	response, err := selected.Complete(context.Background(), request)
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if maxTokens != limit {
+		t.Fatalf("expected max tokens %d, got %d", limit, maxTokens)
+	}
+	if response.Usage.InputTokens != nil ||
+		response.Usage.OutputTokens != nil ||
+		response.Usage.TotalTokens != nil {
+		t.Fatalf("absent usage must remain absent: %#v", response.Usage)
+	}
+}
+
+func TestAnthropicNormalizesHTTPFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		errorBody string
+		code      string
+		retryable bool
+	}{
+		{
+			name:      "authentication",
+			status:    http.StatusUnauthorized,
+			errorBody: `{"error":{"message":"invalid key"},"request_id":"body-request"}`,
+			code:      "authentication_failed",
+		},
+		{
+			name:      "rate limit",
+			status:    http.StatusTooManyRequests,
+			errorBody: `{"error":{"message":"slow down"}}`,
+			code:      "rate_limited",
+			retryable: true,
+		},
+		{
+			name:      "endpoint failure",
+			status:    http.StatusServiceUnavailable,
+			errorBody: `{"error":{"message":"temporarily unavailable"}}`,
+			code:      "provider_endpoint_error",
+			retryable: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("request-id", "header-request")
+				writer.WriteHeader(test.status)
+				_, _ = writer.Write([]byte(test.errorBody))
+			}))
+			defer server.Close()
+			selected, err := provider.NewAnthropic(provider.AnthropicConfig{
+				APIKey:   "key",
+				Endpoint: server.URL,
+				Client:   server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("create provider: %v", err)
+			}
+			_, err = selected.Complete(context.Background(), completionRequest("model"))
+			var providerError *runtimeapi.ProviderError
+			if !errors.As(err, &providerError) {
+				t.Fatalf("expected provider error, got %v", err)
+			}
+			if providerError.Code != test.code {
+				t.Fatalf("expected code %q, got %q", test.code, providerError.Code)
+			}
+			if providerError.Retryable == nil || *providerError.Retryable != test.retryable {
+				t.Fatalf("unexpected retryability %#v", providerError.Retryable)
+			}
+			if providerError.RequestID != "header-request" {
+				t.Fatalf("unexpected request id %q", providerError.RequestID)
+			}
+		})
+	}
+}
+
+func TestAnthropicRejectsInvalidResponsesAndTimesOut(t *testing.T) {
+	t.Run("malformed JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`{"role":`))
+		}))
+		defer server.Close()
+		selected, err := provider.NewAnthropic(provider.AnthropicConfig{
+			APIKey:   "key",
+			Endpoint: server.URL,
+			Client:   server.Client(),
+		})
+		if err != nil {
+			t.Fatalf("create provider: %v", err)
+		}
+		_, err = selected.Complete(context.Background(), completionRequest("model"))
+		assertProviderErrorCode(t, err, "invalid_provider_response")
+	})
+
+	t.Run("partial response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			_, _ = writer.Write([]byte(`{"role":"assistant","content":[],"stop_reason":"end_turn"}`))
+		}))
+		defer server.Close()
+		selected, err := provider.NewAnthropic(provider.AnthropicConfig{
+			APIKey:   "key",
+			Endpoint: server.URL,
+			Client:   server.Client(),
+		})
+		if err != nil {
+			t.Fatalf("create provider: %v", err)
+		}
+		response, err := selected.Complete(context.Background(), completionRequest("model"))
+		if err != nil {
+			t.Fatalf("transport normalization: %v", err)
+		}
+		if err := runtimeapi.ValidateResponse(response); err == nil {
+			t.Fatal("expected response validation failure")
+		}
+	})
+
+	t.Run("HTTP client timeout", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			time.Sleep(100 * time.Millisecond)
+			_, _ = writer.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+		selected, err := provider.NewAnthropic(provider.AnthropicConfig{
+			APIKey:   "key",
+			Endpoint: server.URL,
+			Client:   &http.Client{Timeout: 10 * time.Millisecond},
+		})
+		if err != nil {
+			t.Fatalf("create provider: %v", err)
+		}
+		_, err = selected.Complete(context.Background(), completionRequest("model"))
+		assertProviderErrorCode(t, err, "provider_timeout")
+	})
+}
+
+func TestAnthropicRequiresWellFormedCredentials(t *testing.T) {
+	for _, apiKey := range []string{"", " key-with-spaces ", "key\ninjected"} {
+		_, err := provider.NewAnthropic(provider.AnthropicConfig{APIKey: apiKey})
+		var configurationError *provider.ConfigurationError
+		if !errors.As(err, &configurationError) {
+			t.Fatalf("expected credential configuration error for %q, got %v", apiKey, err)
+		}
+	}
+}
+
+func assertProviderErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+	var providerError *runtimeapi.ProviderError
+	if !errors.As(err, &providerError) {
+		t.Fatalf("expected provider error %q, got %v", code, err)
+	}
+	if providerError.Code != code {
+		t.Fatalf("expected provider error %q, got %q", code, providerError.Code)
+	}
+}

--- a/runtimes/reference/internal/provider/http.go
+++ b/runtimes/reference/internal/provider/http.go
@@ -250,12 +250,21 @@ func validateHTTPURL(value string) error {
 }
 
 func requestID(header http.Header, names ...string) string {
+	tried := make(map[string]struct{}, len(names))
 	for _, name := range names {
+		canonicalName := http.CanonicalHeaderKey(name)
+		if _, found := tried[canonicalName]; found {
+			continue
+		}
+		tried[canonicalName] = struct{}{}
 		if value := strings.TrimSpace(header.Get(name)); value != "" {
 			return value
 		}
 	}
 	for _, name := range []string{"request-id", "x-request-id"} {
+		if _, found := tried[http.CanonicalHeaderKey(name)]; found {
+			continue
+		}
 		if value := strings.TrimSpace(header.Get(name)); value != "" {
 			return value
 		}

--- a/runtimes/reference/internal/provider/http.go
+++ b/runtimes/reference/internal/provider/http.go
@@ -1,0 +1,264 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"unicode"
+
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+const maxProviderResponseBytes = 4 << 20
+
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type httpResult struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+func sendJSON(
+	ctx context.Context,
+	client HTTPClient,
+	endpoint string,
+	headers http.Header,
+	payload any,
+) (httpResult, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return httpResult{}, fmt.Errorf("encode provider request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		endpoint,
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return httpResult{}, &ConfigurationError{
+			Code:    "invalid_provider_endpoint",
+			Message: fmt.Sprintf("cannot create request for configured endpoint: %v", err),
+		}
+	}
+	request.Header.Set("Content-Type", "application/json")
+	for name, values := range headers {
+		for _, value := range values {
+			request.Header.Add(name, value)
+		}
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return httpResult{}, normalizeRequestError(ctx, err)
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(io.LimitReader(response.Body, maxProviderResponseBytes+1))
+	if err != nil {
+		retryable := true
+		return httpResult{}, &runtimeapi.ProviderError{
+			Code:      "provider_response_read_failed",
+			Message:   fmt.Sprintf("could not read provider response: %v", err),
+			Retryable: &retryable,
+			RequestID: requestID(response.Header),
+		}
+	}
+	if len(responseBody) > maxProviderResponseBytes {
+		retryable := false
+		status := response.StatusCode
+		return httpResult{}, &runtimeapi.ProviderError{
+			Code:       "invalid_provider_response",
+			Message:    fmt.Sprintf("provider response exceeded %d bytes", maxProviderResponseBytes),
+			Retryable:  &retryable,
+			HTTPStatus: &status,
+			RequestID:  requestID(response.Header),
+		}
+	}
+	return httpResult{
+		StatusCode: response.StatusCode,
+		Header:     response.Header.Clone(),
+		Body:       responseBody,
+	}, nil
+}
+
+func normalizeRequestError(ctx context.Context, err error) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return context.Canceled
+	}
+	var networkError net.Error
+	if errors.Is(err, context.DeadlineExceeded) ||
+		(errors.As(err, &networkError) && networkError.Timeout()) {
+		retryable := true
+		return &runtimeapi.ProviderError{
+			Code:      "provider_timeout",
+			Message:   "provider request timed out",
+			Retryable: &retryable,
+		}
+	}
+	if errors.Is(err, context.Canceled) {
+		return context.Canceled
+	}
+	retryable := true
+	return &runtimeapi.ProviderError{
+		Code:      "provider_network_error",
+		Message:   fmt.Sprintf("provider endpoint request failed: %v", err),
+		Retryable: &retryable,
+	}
+}
+
+func providerHTTPError(
+	providerName string,
+	status int,
+	message string,
+	requestIDValue string,
+) error {
+	code := "provider_endpoint_error"
+	retryable := false
+	switch {
+	case status == http.StatusUnauthorized || status == http.StatusForbidden:
+		code = "authentication_failed"
+	case status == http.StatusRequestTimeout || status == http.StatusGatewayTimeout:
+		code = "provider_timeout"
+		retryable = true
+	case status == http.StatusTooManyRequests:
+		code = "rate_limited"
+		retryable = true
+	case status >= 500:
+		code = "provider_endpoint_error"
+		retryable = true
+	case status >= 400 && status < 500:
+		code = "provider_request_rejected"
+	}
+	if strings.TrimSpace(message) == "" {
+		message = fmt.Sprintf("%s endpoint returned HTTP %d", providerName, status)
+	}
+	return &runtimeapi.ProviderError{
+		Code:       code,
+		Message:    message,
+		Retryable:  &retryable,
+		HTTPStatus: &status,
+		RequestID:  requestIDValue,
+	}
+}
+
+func invalidResponse(
+	message string,
+	status int,
+	requestIDValue string,
+) error {
+	retryable := false
+	return &runtimeapi.ProviderError{
+		Code:       "invalid_provider_response",
+		Message:    message,
+		Retryable:  &retryable,
+		HTTPStatus: &status,
+		RequestID:  requestIDValue,
+	}
+}
+
+func validateAPIKey(providerName string, apiKey string) error {
+	if apiKey == "" {
+		return &ConfigurationError{
+			Provider: providerName,
+			Code:     "missing_provider_credentials",
+			Message:  fmt.Sprintf("%s_API_KEY is required", strings.ToUpper(providerName)),
+		}
+	}
+	if strings.TrimSpace(apiKey) != apiKey ||
+		strings.IndexFunc(apiKey, unicode.IsControl) >= 0 {
+		return &ConfigurationError{
+			Provider: providerName,
+			Code:     "invalid_provider_credentials",
+			Message:  fmt.Sprintf("%s_API_KEY must not contain surrounding whitespace or control characters", strings.ToUpper(providerName)),
+		}
+	}
+	return nil
+}
+
+func providerEndpoint(
+	providerName string,
+	explicitEndpoint string,
+	baseURL string,
+	defaultEndpoint string,
+	path string,
+) (string, error) {
+	if explicitEndpoint != "" && baseURL != "" {
+		return "", &ConfigurationError{
+			Provider: providerName,
+			Code:     "invalid_provider_endpoint",
+			Message:  "provider endpoint and base URL are mutually exclusive",
+		}
+	}
+	if explicitEndpoint != "" {
+		if err := validateHTTPURL(explicitEndpoint); err != nil {
+			return "", &ConfigurationError{
+				Provider: providerName,
+				Code:     "invalid_provider_endpoint",
+				Message:  fmt.Sprintf("invalid provider endpoint: %v", err),
+			}
+		}
+		return explicitEndpoint, nil
+	}
+	if baseURL == "" {
+		return defaultEndpoint, nil
+	}
+	if err := validateHTTPURL(baseURL); err != nil {
+		return "", &ConfigurationError{
+			Provider: providerName,
+			Code:     "invalid_provider_endpoint",
+			Message:  fmt.Sprintf("invalid provider base URL: %v", err),
+		}
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", &ConfigurationError{
+			Provider: providerName,
+			Code:     "invalid_provider_endpoint",
+			Message:  fmt.Sprintf("invalid provider base URL: %v", err),
+		}
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/" + strings.TrimLeft(path, "/")
+	return parsed.String(), nil
+}
+
+func validateHTTPURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return err
+	}
+	if parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return errors.New("must be an absolute HTTP(S) URL")
+	}
+	if parsed.User != nil {
+		return errors.New("must not contain embedded credentials")
+	}
+	return nil
+}
+
+func requestID(header http.Header, names ...string) string {
+	for _, name := range names {
+		if value := strings.TrimSpace(header.Get(name)); value != "" {
+			return value
+		}
+	}
+	for _, name := range []string{"request-id", "x-request-id"} {
+		if value := strings.TrimSpace(header.Get(name)); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/runtimes/reference/internal/provider/openai.go
+++ b/runtimes/reference/internal/provider/openai.go
@@ -1,0 +1,277 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+const (
+	DefaultOpenAIEndpoint = "https://api.openai.com/v1/chat/completions"
+	openAIChatPath        = "chat/completions"
+)
+
+type OpenAIConfig struct {
+	Name     string
+	APIKey   string
+	Endpoint string
+	BaseURL  string
+	Client   HTTPClient
+}
+
+type OpenAI struct {
+	name     string
+	apiKey   string
+	endpoint string
+	client   HTTPClient
+}
+
+func NewOpenAI(config OpenAIConfig) (*OpenAI, error) {
+	if err := validateAPIKey("openai", config.APIKey); err != nil {
+		return nil, err
+	}
+	endpoint, err := providerEndpoint(
+		"openai",
+		config.Endpoint,
+		config.BaseURL,
+		DefaultOpenAIEndpoint,
+		openAIChatPath,
+	)
+	if err != nil {
+		return nil, err
+	}
+	name := strings.TrimSpace(config.Name)
+	if name == "" {
+		name = "openai"
+	}
+	client := config.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &OpenAI{
+		name:     name,
+		apiKey:   config.APIKey,
+		endpoint: endpoint,
+		client:   client,
+	}, nil
+}
+
+func (openAI *OpenAI) Name() string {
+	return openAI.name
+}
+
+func (openAI *OpenAI) Complete(
+	ctx context.Context,
+	request runtimeapi.CompletionRequest,
+) (runtimeapi.CompletionResponse, error) {
+	payload, err := openAIRequest(request)
+	if err != nil {
+		return runtimeapi.CompletionResponse{}, err
+	}
+	headers := make(http.Header)
+	headers.Set("Authorization", "Bearer "+openAI.apiKey)
+	result, err := sendJSON(ctx, openAI.client, openAI.endpoint, headers, payload)
+	if err != nil {
+		return runtimeapi.CompletionResponse{}, err
+	}
+
+	responseRequestID := requestID(result.Header, "x-request-id")
+	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
+		var failure openAIErrorResponse
+		_ = json.Unmarshal(result.Body, &failure)
+		return runtimeapi.CompletionResponse{}, providerHTTPError(
+			openAI.name,
+			result.StatusCode,
+			failure.Error.Message,
+			responseRequestID,
+		)
+	}
+
+	var response openAIResponse
+	if err := json.Unmarshal(result.Body, &response); err != nil {
+		return runtimeapi.CompletionResponse{}, invalidResponse(
+			fmt.Sprintf("%s returned malformed JSON: %v", openAI.name, err),
+			result.StatusCode,
+			responseRequestID,
+		)
+	}
+	normalized, err := normalizeOpenAIResponse(response, responseRequestID)
+	if err != nil {
+		return runtimeapi.CompletionResponse{}, invalidResponse(
+			fmt.Sprintf("%s returned an invalid response: %v", openAI.name, err),
+			result.StatusCode,
+			responseRequestID,
+		)
+	}
+	return normalized, nil
+}
+
+type openAIRequestPayload struct {
+	Model               string                 `json:"model"`
+	Messages            []openAIRequestMessage `json:"messages"`
+	MaxCompletionTokens *int64                 `json:"max_completion_tokens,omitempty"`
+}
+
+type openAIRequestMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+func openAIRequest(request runtimeapi.CompletionRequest) (openAIRequestPayload, error) {
+	payload := openAIRequestPayload{
+		Model:               request.Model,
+		Messages:            make([]openAIRequestMessage, 0, len(request.Messages)),
+		MaxCompletionTokens: request.MaxTokens,
+	}
+	for index, message := range request.Messages {
+		if message.Role != runtimeapi.RoleUser && message.Role != runtimeapi.RoleAssistant {
+			return openAIRequestPayload{}, fmt.Errorf(
+				"message %d has unsupported role %q",
+				index,
+				message.Role,
+			)
+		}
+		for blockIndex, block := range message.Content {
+			if block.Type != runtimeapi.ContentTypeText {
+				return openAIRequestPayload{}, fmt.Errorf(
+					"message %d content block %d has unsupported type %q",
+					index,
+					blockIndex,
+					block.Type,
+				)
+			}
+		}
+		payload.Messages = append(payload.Messages, openAIRequestMessage{
+			Role:    string(message.Role),
+			Content: runtimeapi.MessageText(message),
+		})
+	}
+	return payload, nil
+}
+
+type openAIResponse struct {
+	Choices []openAIChoice `json:"choices"`
+	Usage   openAIUsage    `json:"usage"`
+}
+
+type openAIChoice struct {
+	Message      openAIResponseMessage `json:"message"`
+	FinishReason string                `json:"finish_reason"`
+}
+
+type openAIResponseMessage struct {
+	Role      string           `json:"role"`
+	Content   *string          `json:"content"`
+	Refusal   *string          `json:"refusal"`
+	ToolCalls []openAIToolCall `json:"tool_calls"`
+}
+
+type openAIToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type openAIUsage struct {
+	PromptTokens     *int64 `json:"prompt_tokens"`
+	CompletionTokens *int64 `json:"completion_tokens"`
+	TotalTokens      *int64 `json:"total_tokens"`
+}
+
+type openAIErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func normalizeOpenAIResponse(
+	response openAIResponse,
+	responseRequestID string,
+) (runtimeapi.CompletionResponse, error) {
+	if len(response.Choices) == 0 {
+		return runtimeapi.CompletionResponse{}, fmt.Errorf("response has no choices")
+	}
+	choice := response.Choices[0]
+	if choice.Message.Role != string(runtimeapi.RoleAssistant) {
+		return runtimeapi.CompletionResponse{}, fmt.Errorf(
+			"unexpected message role %q",
+			choice.Message.Role,
+		)
+	}
+
+	content := make([]runtimeapi.ContentBlock, 0, 1+len(choice.Message.ToolCalls))
+	if choice.Message.Content != nil && strings.TrimSpace(*choice.Message.Content) != "" {
+		content = append(content, runtimeapi.ContentBlock{
+			Type: runtimeapi.ContentTypeText,
+			Text: *choice.Message.Content,
+		})
+	} else if choice.Message.Refusal != nil && strings.TrimSpace(*choice.Message.Refusal) != "" {
+		content = append(content, runtimeapi.ContentBlock{
+			Type: runtimeapi.ContentTypeText,
+			Text: *choice.Message.Refusal,
+		})
+	}
+	for index, toolCall := range choice.Message.ToolCalls {
+		if toolCall.Type != "function" {
+			return runtimeapi.CompletionResponse{}, fmt.Errorf(
+				"tool call %d has unsupported type %q",
+				index,
+				toolCall.Type,
+			)
+		}
+		arguments := json.RawMessage(toolCall.Function.Arguments)
+		if !json.Valid(arguments) {
+			return runtimeapi.CompletionResponse{}, fmt.Errorf(
+				"tool call %d has malformed JSON arguments",
+				index,
+			)
+		}
+		content = append(content, runtimeapi.ContentBlock{
+			Type: runtimeapi.ContentTypeToolCall,
+			ToolCall: &runtimeapi.ToolCall{
+				ID:        toolCall.ID,
+				Name:      toolCall.Function.Name,
+				Arguments: append(json.RawMessage(nil), arguments...),
+			},
+		})
+	}
+	stopReason, err := normalizeOpenAIStopReason(choice.FinishReason)
+	if err != nil {
+		return runtimeapi.CompletionResponse{}, err
+	}
+	return runtimeapi.CompletionResponse{
+		Message: runtimeapi.Message{
+			Role:    runtimeapi.RoleAssistant,
+			Content: content,
+		},
+		Usage: runtimeapi.Usage{
+			InputTokens:  response.Usage.PromptTokens,
+			OutputTokens: response.Usage.CompletionTokens,
+			TotalTokens:  response.Usage.TotalTokens,
+		},
+		StopReason: stopReason,
+		RequestID:  responseRequestID,
+	}, nil
+}
+
+func normalizeOpenAIStopReason(value string) (runtimeapi.StopReason, error) {
+	switch value {
+	case "stop":
+		return runtimeapi.StopReasonEndTurn, nil
+	case "length":
+		return runtimeapi.StopReasonMaxTokens, nil
+	case "tool_calls", "function_call":
+		return runtimeapi.StopReasonToolUse, nil
+	case "content_filter":
+		return runtimeapi.StopReasonContentFilter, nil
+	default:
+		return "", fmt.Errorf("unsupported finish reason %q", value)
+	}
+}

--- a/runtimes/reference/internal/provider/openai.go
+++ b/runtimes/reference/internal/provider/openai.go
@@ -271,6 +271,8 @@ func normalizeOpenAIStopReason(value string) (runtimeapi.StopReason, error) {
 		return runtimeapi.StopReasonToolUse, nil
 	case "content_filter":
 		return runtimeapi.StopReasonContentFilter, nil
+	case "refusal":
+		return runtimeapi.StopReasonRefusal, nil
 	default:
 		return "", fmt.Errorf("unsupported finish reason %q", value)
 	}

--- a/runtimes/reference/internal/provider/openai_test.go
+++ b/runtimes/reference/internal/provider/openai_test.go
@@ -1,0 +1,247 @@
+package provider_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+)
+
+func TestOpenAICompletesAgainstCompatibleBaseURL(t *testing.T) {
+	var received struct {
+		Model               string `json:"model"`
+		MaxCompletionTokens *int64 `json:"max_completion_tokens"`
+		Messages            []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/openai/v1/chat/completions" {
+			t.Errorf("unexpected request path %q", request.URL.Path)
+		}
+		if request.Header.Get("Authorization") != "Bearer openai-test-key" {
+			t.Errorf("missing OpenAI bearer token")
+		}
+		if err := json.NewDecoder(request.Body).Decode(&received); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writer.Header().Set("x-request-id", "req-openai-1")
+		_, _ = writer.Write([]byte(`{
+			"choices":[{
+				"message":{
+					"role":"assistant",
+					"content":"working",
+					"tool_calls":[{
+						"id":"call-1",
+						"type":"function",
+						"function":{"name":"lookup","arguments":"{\"query\":\"status\"}"}
+					}]
+				},
+				"finish_reason":"tool_calls"
+			}],
+			"usage":{"prompt_tokens":9,"completion_tokens":0,"total_tokens":9}
+		}`))
+	}))
+	defer server.Close()
+
+	selected, err := provider.NewOpenAI(provider.OpenAIConfig{
+		Name:    "openai-compatible",
+		APIKey:  "openai-test-key",
+		BaseURL: server.URL + "/openai/v1",
+		Client:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	request := completionRequest("vendor/model:opaque")
+	limit := int64(50)
+	request.MaxTokens = &limit
+	response, err := selected.Complete(context.Background(), request)
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if selected.Name() != "openai-compatible" {
+		t.Fatalf("unexpected provider name %q", selected.Name())
+	}
+	if received.Model != "vendor/model:opaque" {
+		t.Fatalf("model identifier changed: %q", received.Model)
+	}
+	if received.MaxCompletionTokens == nil || *received.MaxCompletionTokens != limit {
+		t.Fatalf("unexpected token limit %#v", received.MaxCompletionTokens)
+	}
+	if len(received.Messages) != 1 ||
+		received.Messages[0].Role != "user" ||
+		received.Messages[0].Content != "test goal" {
+		t.Fatalf("unexpected messages %#v", received.Messages)
+	}
+	if response.RequestID != "req-openai-1" ||
+		response.StopReason != runtimeapi.StopReasonToolUse {
+		t.Fatalf("unexpected normalized response %#v", response)
+	}
+	if response.Usage.OutputTokens == nil || *response.Usage.OutputTokens != 0 {
+		t.Fatalf("measured zero output tokens were lost: %#v", response.Usage)
+	}
+	if len(response.Message.Content) != 2 ||
+		response.Message.Content[1].ToolCall == nil ||
+		response.Message.Content[1].ToolCall.ID != "call-1" {
+		t.Fatalf("unexpected content %#v", response.Message.Content)
+	}
+	if err := runtimeapi.ValidateResponse(response); err != nil {
+		t.Fatalf("validate normalized response: %v", err)
+	}
+}
+
+func TestOpenAILeavesOptionalRequestAndUsageFieldsAbsent(t *testing.T) {
+	var hasTokenLimit bool
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		var payload map[string]json.RawMessage
+		_ = json.NewDecoder(request.Body).Decode(&payload)
+		_, hasTokenLimit = payload["max_completion_tokens"]
+		_, _ = writer.Write([]byte(`{
+			"choices":[{
+				"message":{"role":"assistant","content":"ok"},
+				"finish_reason":"stop"
+			}]
+		}`))
+	}))
+	defer server.Close()
+	selected, err := provider.NewOpenAI(provider.OpenAIConfig{
+		APIKey:   "key",
+		Endpoint: server.URL,
+		Client:   server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	response, err := selected.Complete(context.Background(), completionRequest("model"))
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if hasTokenLimit {
+		t.Fatal("omitted token budget must not be sent as zero")
+	}
+	if response.Usage.InputTokens != nil ||
+		response.Usage.OutputTokens != nil ||
+		response.Usage.TotalTokens != nil {
+		t.Fatalf("absent usage must remain absent: %#v", response.Usage)
+	}
+}
+
+func TestOpenAINormalizesHTTPFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		code      string
+		retryable bool
+	}{
+		{
+			name:   "authentication",
+			status: http.StatusForbidden,
+			code:   "authentication_failed",
+		},
+		{
+			name:      "rate limit",
+			status:    http.StatusTooManyRequests,
+			code:      "rate_limited",
+			retryable: true,
+		},
+		{
+			name:   "bad compatible endpoint",
+			status: http.StatusNotFound,
+			code:   "provider_request_rejected",
+		},
+		{
+			name:      "server failure",
+			status:    http.StatusBadGateway,
+			code:      "provider_endpoint_error",
+			retryable: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("x-request-id", "openai-error-request")
+				writer.WriteHeader(test.status)
+				_, _ = writer.Write([]byte(`{"error":{"message":"provider rejected request"}}`))
+			}))
+			defer server.Close()
+			selected, err := provider.NewOpenAI(provider.OpenAIConfig{
+				APIKey:   "key",
+				Endpoint: server.URL,
+				Client:   server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("create provider: %v", err)
+			}
+			_, err = selected.Complete(context.Background(), completionRequest("model"))
+			var providerError *runtimeapi.ProviderError
+			if !errors.As(err, &providerError) {
+				t.Fatalf("expected provider error, got %v", err)
+			}
+			if providerError.Code != test.code {
+				t.Fatalf("expected code %q, got %q", test.code, providerError.Code)
+			}
+			if providerError.Retryable == nil || *providerError.Retryable != test.retryable {
+				t.Fatalf("unexpected retryability %#v", providerError.Retryable)
+			}
+			if providerError.RequestID != "openai-error-request" {
+				t.Fatalf("unexpected request id %q", providerError.RequestID)
+			}
+		})
+	}
+}
+
+func TestOpenAIRejectsInvalidAndPartialResponses(t *testing.T) {
+	responses := map[string]string{
+		"malformed JSON":  `{"choices":`,
+		"missing choices": `{"usage":{"prompt_tokens":1}}`,
+		"invalid tool arguments": `{
+			"choices":[{
+				"message":{
+					"role":"assistant",
+					"content":null,
+					"tool_calls":[{
+						"id":"call-1",
+						"type":"function",
+						"function":{"name":"lookup","arguments":"{"}
+					}]
+				},
+				"finish_reason":"tool_calls"
+			}]
+		}`,
+	}
+	for name, body := range responses {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				_, _ = writer.Write([]byte(body))
+			}))
+			defer server.Close()
+			selected, err := provider.NewOpenAI(provider.OpenAIConfig{
+				APIKey:   "key",
+				Endpoint: server.URL,
+				Client:   server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("create provider: %v", err)
+			}
+			_, err = selected.Complete(context.Background(), completionRequest("model"))
+			assertProviderErrorCode(t, err, "invalid_provider_response")
+		})
+	}
+}
+
+func TestOpenAIRequiresWellFormedCredentials(t *testing.T) {
+	for _, apiKey := range []string{"", " key-with-spaces ", "key\r\ninjected"} {
+		_, err := provider.NewOpenAI(provider.OpenAIConfig{APIKey: apiKey})
+		var configurationError *provider.ConfigurationError
+		if !errors.As(err, &configurationError) {
+			t.Fatalf("expected credential configuration error for %q, got %v", apiKey, err)
+		}
+	}
+}

--- a/runtimes/reference/internal/provider/openai_test.go
+++ b/runtimes/reference/internal/provider/openai_test.go
@@ -31,6 +31,7 @@ func TestOpenAICompletesAgainstCompatibleBaseURL(t *testing.T) {
 		if err := json.NewDecoder(request.Body).Decode(&received); err != nil {
 			t.Errorf("decode request: %v", err)
 		}
+		writer.Header().Set("request-id", "req-generic-1")
 		writer.Header().Set("x-request-id", "req-openai-1")
 		_, _ = writer.Write([]byte(`{
 			"choices":[{
@@ -233,6 +234,40 @@ func TestOpenAIRejectsInvalidAndPartialResponses(t *testing.T) {
 			_, err = selected.Complete(context.Background(), completionRequest("model"))
 			assertProviderErrorCode(t, err, "invalid_provider_response")
 		})
+	}
+}
+
+func TestOpenAINormalizesRefusalFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte(`{
+			"choices":[{
+				"message":{
+					"role":"assistant",
+					"content":null,
+					"refusal":"request refused"
+				},
+				"finish_reason":"refusal"
+			}]
+		}`))
+	}))
+	defer server.Close()
+	selected, err := provider.NewOpenAI(provider.OpenAIConfig{
+		APIKey:   "key",
+		Endpoint: server.URL,
+		Client:   server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("create provider: %v", err)
+	}
+	response, err := selected.Complete(context.Background(), completionRequest("model"))
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if response.StopReason != runtimeapi.StopReasonRefusal {
+		t.Fatalf("unexpected stop reason %q", response.StopReason)
+	}
+	if got := runtimeapi.MessageText(response.Message); got != "request refused" {
+		t.Fatalf("unexpected refusal text %q", got)
 	}
 }
 

--- a/runtimes/reference/internal/provider/provider.go
+++ b/runtimes/reference/internal/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -33,10 +34,14 @@ func (err *UnsupportedError) Error() string {
 
 type ConfigurationError struct {
 	Provider string
+	Code     string
 	Message  string
 }
 
 func (err *ConfigurationError) Error() string {
+	if err.Provider == "" {
+		return fmt.Sprintf("provider configuration is invalid: %s", err.Message)
+	}
 	return fmt.Sprintf("%s provider configuration is invalid: %s", err.Provider, err.Message)
 }
 
@@ -44,6 +49,21 @@ func Resolve(runtimeConfig config.Config) (Provider, error) {
 	switch runtimeConfig.Provider {
 	case "fake":
 		return resolveFake(runtimeConfig)
+	case "anthropic":
+		return NewAnthropic(AnthropicConfig{
+			APIKey:   runtimeConfig.AnthropicAPIKey,
+			Endpoint: runtimeConfig.ProviderEndpoint,
+			BaseURL:  runtimeConfig.ProviderBaseURL,
+			Client:   http.DefaultClient,
+		})
+	case "openai", "openai-compatible":
+		return NewOpenAI(OpenAIConfig{
+			Name:     runtimeConfig.Provider,
+			APIKey:   runtimeConfig.OpenAIAPIKey,
+			Endpoint: runtimeConfig.ProviderEndpoint,
+			BaseURL:  runtimeConfig.ProviderBaseURL,
+			Client:   http.DefaultClient,
+		})
 	default:
 		return nil, &UnsupportedError{Name: runtimeConfig.Provider}
 	}

--- a/runtimes/reference/internal/provider/provider_test.go
+++ b/runtimes/reference/internal/provider/provider_test.go
@@ -29,6 +29,61 @@ func TestResolveSelectsFakeProvider(t *testing.T) {
 	}
 }
 
+func TestResolveSelectsMaintainedHTTPProviders(t *testing.T) {
+	tests := []struct {
+		name   string
+		config config.Config
+	}{
+		{
+			name: "anthropic",
+			config: config.Config{
+				Provider:        "anthropic",
+				AnthropicAPIKey: "anthropic-key",
+			},
+		},
+		{
+			name: "openai",
+			config: config.Config{
+				Provider:     "openai",
+				OpenAIAPIKey: "openai-key",
+			},
+		},
+		{
+			name: "openai-compatible",
+			config: config.Config{
+				Provider:     "openai-compatible",
+				OpenAIAPIKey: "openai-key",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			selected, err := provider.Resolve(test.config)
+			if err != nil {
+				t.Fatalf("resolve provider: %v", err)
+			}
+			if selected.Name() != test.config.Provider {
+				t.Fatalf("expected provider %q, got %q", test.config.Provider, selected.Name())
+			}
+		})
+	}
+}
+
+func TestResolveReportsMissingProviderCredentials(t *testing.T) {
+	for _, name := range []string{"anthropic", "openai", "openai-compatible"} {
+		t.Run(name, func(t *testing.T) {
+			_, err := provider.Resolve(config.Config{Provider: name})
+			var configurationError *provider.ConfigurationError
+			if !errors.As(err, &configurationError) {
+				t.Fatalf("expected configuration error, got %v", err)
+			}
+			if configurationError.Code != "missing_provider_credentials" {
+				t.Fatalf("unexpected error code %q", configurationError.Code)
+			}
+		})
+	}
+}
+
 func TestResolveValidatesFakeScenarios(t *testing.T) {
 	if _, err := provider.Resolve(config.Config{
 		Provider:     "fake",

--- a/runtimes/reference/internal/runtimeapi/types.go
+++ b/runtimes/reference/internal/runtimeapi/types.go
@@ -1,6 +1,7 @@
 package runtimeapi
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -16,12 +17,20 @@ const (
 type ContentType string
 
 const (
-	ContentTypeText ContentType = "text"
+	ContentTypeText     ContentType = "text"
+	ContentTypeToolCall ContentType = "tool_call"
 )
 
 type ContentBlock struct {
-	Type ContentType
-	Text string
+	Type     ContentType
+	Text     string
+	ToolCall *ToolCall
+}
+
+type ToolCall struct {
+	ID        string
+	Name      string
+	Arguments json.RawMessage
 }
 
 type Message struct {
@@ -38,9 +47,14 @@ type Usage struct {
 type StopReason string
 
 const (
-	StopReasonEndTurn      StopReason = "end_turn"
-	StopReasonMaxTokens    StopReason = "max_tokens"
-	StopReasonStopSequence StopReason = "stop_sequence"
+	StopReasonEndTurn                    StopReason = "end_turn"
+	StopReasonMaxTokens                  StopReason = "max_tokens"
+	StopReasonStopSequence               StopReason = "stop_sequence"
+	StopReasonToolUse                    StopReason = "tool_use"
+	StopReasonContentFilter              StopReason = "content_filter"
+	StopReasonPauseTurn                  StopReason = "pause_turn"
+	StopReasonRefusal                    StopReason = "refusal"
+	StopReasonModelContextWindowExceeded StopReason = "model_context_window_exceeded"
 )
 
 type CompletionRequest struct {
@@ -75,19 +89,49 @@ func ValidateResponse(response CompletionResponse) error {
 	if response.Message.Role != RoleAssistant {
 		return fmt.Errorf("assistant response has invalid role %q", response.Message.Role)
 	}
-	if len(response.Message.Content) == 0 {
+	if len(response.Message.Content) == 0 &&
+		response.StopReason != StopReasonContentFilter &&
+		response.StopReason != StopReasonRefusal {
 		return errors.New("assistant response has no content")
 	}
 	for index, block := range response.Message.Content {
-		if block.Type != ContentTypeText {
+		switch block.Type {
+		case ContentTypeText:
+			if strings.TrimSpace(block.Text) == "" {
+				return fmt.Errorf("assistant content block %d has empty text", index)
+			}
+			if block.ToolCall != nil {
+				return fmt.Errorf("assistant text block %d unexpectedly contains a tool call", index)
+			}
+		case ContentTypeToolCall:
+			if block.ToolCall == nil {
+				return fmt.Errorf("assistant tool-call block %d has no tool call", index)
+			}
+			if strings.TrimSpace(block.ToolCall.ID) == "" {
+				return fmt.Errorf("assistant tool-call block %d has no id", index)
+			}
+			if strings.TrimSpace(block.ToolCall.Name) == "" {
+				return fmt.Errorf("assistant tool-call block %d has no name", index)
+			}
+			if len(block.ToolCall.Arguments) == 0 || !json.Valid(block.ToolCall.Arguments) {
+				return fmt.Errorf("assistant tool-call block %d has invalid arguments", index)
+			}
+			if block.Text != "" {
+				return fmt.Errorf("assistant tool-call block %d unexpectedly contains text", index)
+			}
+		default:
 			return fmt.Errorf("assistant content block %d has unsupported type %q", index, block.Type)
-		}
-		if strings.TrimSpace(block.Text) == "" {
-			return fmt.Errorf("assistant content block %d has empty text", index)
 		}
 	}
 	switch response.StopReason {
-	case StopReasonEndTurn, StopReasonMaxTokens, StopReasonStopSequence:
+	case StopReasonEndTurn,
+		StopReasonMaxTokens,
+		StopReasonStopSequence,
+		StopReasonToolUse,
+		StopReasonContentFilter,
+		StopReasonPauseTurn,
+		StopReasonRefusal,
+		StopReasonModelContextWindowExceeded:
 	default:
 		return fmt.Errorf("assistant response has unsupported stop reason %q", response.StopReason)
 	}
@@ -102,4 +146,17 @@ func MessageText(message Message) string {
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+func MessageToolCalls(message Message) []ToolCall {
+	var calls []ToolCall
+	for _, block := range message.Content {
+		if block.Type != ContentTypeToolCall || block.ToolCall == nil {
+			continue
+		}
+		call := *block.ToolCall
+		call.Arguments = append(json.RawMessage(nil), block.ToolCall.Arguments...)
+		calls = append(calls, call)
+	}
+	return calls
 }

--- a/runtimes/reference/internal/runtimeapi/types_test.go
+++ b/runtimes/reference/internal/runtimeapi/types_test.go
@@ -1,6 +1,7 @@
 package runtimeapi_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
@@ -55,6 +56,58 @@ func TestValidateResponse(t *testing.T) {
 	}
 }
 
+func TestValidateResponseAcceptsToolCallsAndFilteredEmptyContent(t *testing.T) {
+	toolCall := runtimeapi.CompletionResponse{
+		Message: runtimeapi.Message{
+			Role: runtimeapi.RoleAssistant,
+			Content: []runtimeapi.ContentBlock{
+				{
+					Type: runtimeapi.ContentTypeToolCall,
+					ToolCall: &runtimeapi.ToolCall{
+						ID:        "call-1",
+						Name:      "lookup",
+						Arguments: json.RawMessage(`{"query":"status"}`),
+					},
+				},
+			},
+		},
+		StopReason: runtimeapi.StopReasonToolUse,
+	}
+	if err := runtimeapi.ValidateResponse(toolCall); err != nil {
+		t.Fatalf("validate tool call: %v", err)
+	}
+
+	filtered := runtimeapi.CompletionResponse{
+		Message:    runtimeapi.Message{Role: runtimeapi.RoleAssistant},
+		StopReason: runtimeapi.StopReasonContentFilter,
+	}
+	if err := runtimeapi.ValidateResponse(filtered); err != nil {
+		t.Fatalf("validate filtered response: %v", err)
+	}
+}
+
+func TestValidateResponseRejectsMalformedToolCall(t *testing.T) {
+	response := runtimeapi.CompletionResponse{
+		Message: runtimeapi.Message{
+			Role: runtimeapi.RoleAssistant,
+			Content: []runtimeapi.ContentBlock{
+				{
+					Type: runtimeapi.ContentTypeToolCall,
+					ToolCall: &runtimeapi.ToolCall{
+						ID:        "call-1",
+						Name:      "lookup",
+						Arguments: json.RawMessage(`{`),
+					},
+				},
+			},
+		},
+		StopReason: runtimeapi.StopReasonToolUse,
+	}
+	if err := runtimeapi.ValidateResponse(response); err == nil {
+		t.Fatal("expected invalid tool arguments")
+	}
+}
+
 func TestMessageTextJoinsTextBlocks(t *testing.T) {
 	message := runtimeapi.Message{
 		Role: runtimeapi.RoleAssistant,
@@ -65,5 +118,29 @@ func TestMessageTextJoinsTextBlocks(t *testing.T) {
 	}
 	if got := runtimeapi.MessageText(message); got != "first\nsecond" {
 		t.Fatalf("unexpected text %q", got)
+	}
+}
+
+func TestMessageToolCallsReturnsIndependentArguments(t *testing.T) {
+	message := runtimeapi.Message{
+		Role: runtimeapi.RoleAssistant,
+		Content: []runtimeapi.ContentBlock{
+			{
+				Type: runtimeapi.ContentTypeToolCall,
+				ToolCall: &runtimeapi.ToolCall{
+					ID:        "call-1",
+					Name:      "lookup",
+					Arguments: json.RawMessage(`{"query":"status"}`),
+				},
+			},
+		},
+	}
+	calls := runtimeapi.MessageToolCalls(message)
+	if len(calls) != 1 || calls[0].Name != "lookup" {
+		t.Fatalf("unexpected tool calls %#v", calls)
+	}
+	calls[0].Arguments[0] = '['
+	if string(message.Content[0].ToolCall.Arguments) != `{"query":"status"}` {
+		t.Fatal("tool-call arguments were not cloned")
 	}
 }


### PR DESCRIPTION
## Summary
- add direct Anthropic Messages and OpenAI-compatible Chat Completions adapters to the maintained reference runtime
- normalize text, tool calls, stop reasons, usage, request IDs, endpoint overrides, and actionable provider errors
- wire Secret credentials, examples, compatibility docs, and a protected manual acceptance workflow while keeping PR CI keyless

## Test plan
- [x] `make verify`
- [x] `make test`
- [x] `make vulncheck`
- [x] `make docker-build-reference`
- [x] reference runtime image smoke test with the fake provider
- [x] `actionlint .github/workflows/provider-acceptance.yml`

Closes #18