### PR TITLE
Harden kind tool and network policy acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,3 +242,71 @@ jobs:
       - name: Delete kind cluster
         if: always()
         run: kind delete cluster --name "${KIND_CLUSTER_NAME}" || true
+
+  # kindnet does not enforce NetworkPolicy. This focused job installs pinned,
+  # checksum-verified Calico before treating connectivity results as evidence.
+  network-policy-e2e:
+    name: Kind NetworkPolicy e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs:
+      - validate
+    env:
+      KIND_CLUSTER_NAME: kontext-network-policy-ci
+      KONTEXT_OPERATOR_IMAGE: kontext-operator:dev
+      KONTEXT_REPORTER_IMAGE: kontext-reporter:dev
+      KONTEXT_REFERENCE_IMAGE: kontext-reference:dev
+      KONTEXT_DIAG_DIR: ${{ github.workspace }}/.ci-diagnostics
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build operator image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
+          cache-from: type=gha,scope=network-policy-operator
+          cache-to: type=gha,mode=max,scope=network-policy-operator
+
+      - name: Build reusable reporter image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: runtimes/reporter/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
+          cache-from: type=gha,scope=network-policy-reporter
+          cache-to: type=gha,mode=max,scope=network-policy-reporter
+
+      - name: Build model-agnostic reference runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: runtimes/reference/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
+          cache-from: type=gha,scope=network-policy-reference
+          cache-to: type=gha,mode=max,scope=network-policy-reference
+
+      - name: Run Calico NetworkPolicy acceptance
+        run: ./scripts/e2e-kind-network-policy.sh
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-policy-diagnostics-${{ github.run_id }}
+          path: ${{ env.KONTEXT_DIAG_DIR }}
+          if-no-files-found: ignore
+
+      - name: Delete kind cluster
+        if: always()
+        run: kind delete cluster --name "${KIND_CLUSTER_NAME}" || true

--- a/deploy/examples/v1alpha1/reference-kind-network-policy-runs.yaml
+++ b/deploy/examples/v1alpha1/reference-kind-network-policy-runs.yaml
@@ -1,0 +1,78 @@
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-network-http
+  namespace: kontext-network-policy-e2e
+spec:
+  goal: Prove that the runtime egress policy allows DNS and only the fixture allowlist.
+  provider: fake
+  model: vendor/opaque-tool-model@2026
+  tools: [shell]
+  serviceAccountName: reference-network-reader
+  runtime:
+    image: kontext-reference:dev
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  env:
+    - name: KONTEXT_FAKE_SCENARIO
+      value: tool
+    - name: KONTEXT_FAKE_TOOL_NAME
+      value: shell
+    - name: KONTEXT_FAKE_TOOL_ARGUMENTS
+      value: >-
+        {"command":"allowed=\"$(wget -q -T 5 -O - http://network-policy-http.kontext-network-policy-e2e.svc.cluster.local:8080/allowed.txt)\" && test \"$allowed\" = allowed && if wget -q -T 3 -O /tmp/blocked.out http://network-policy-http.kontext-network-policy-e2e.svc.cluster.local:8081/blocked.txt; then printf unexpected-egress-success; exit 1; fi; printf dns-allowed-and-port-blocked","working_directory":"/tmp"}
+    - name: KONTEXT_MAX_TURNS
+      value: "3"
+    - name: KONTEXT_MAX_TOOL_CALLS
+      value: "2"
+    - name: KONTEXT_MAX_TOOL_RESULT_BYTES
+      value: "4096"
+    - name: KONTEXT_MAX_TOTAL_TOOL_OUTPUT_BYTES
+      value: "8192"
+  budget:
+    tokens: 256
+    wallclock: 1m
+---
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-network-kubernetes
+  namespace: kontext-network-policy-e2e
+spec:
+  goal: List Pods through the Kubernetes API path allowed by the egress policy.
+  provider: fake
+  model: vendor/opaque-tool-model@2026
+  tools: [kubernetes_read]
+  serviceAccountName: reference-network-reader
+  runtime:
+    image: kontext-reference:dev
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  env:
+    - name: KONTEXT_FAKE_SCENARIO
+      value: tool
+    - name: KONTEXT_FAKE_TOOL_NAME
+      value: kubernetes_read
+    - name: KONTEXT_FAKE_TOOL_ARGUMENTS
+      value: '{"operation":"list","resource":"pods"}'
+    - name: KONTEXT_MAX_TURNS
+      value: "3"
+    - name: KONTEXT_MAX_TOOL_CALLS
+      value: "2"
+    - name: KONTEXT_MAX_TOOL_RESULT_BYTES
+      value: "16384"
+    - name: KONTEXT_MAX_TOTAL_TOOL_OUTPUT_BYTES
+      value: "32768"
+  budget:
+    tokens: 256
+    wallclock: 1m

--- a/deploy/examples/v1alpha1/reference-kind-network-policy.yaml
+++ b/deploy/examples/v1alpha1/reference-kind-network-policy.yaml
@@ -146,14 +146,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
-    # Runtime clients use the kubernetes Service on 443. Some CNIs evaluate
-    # the post-DNAT kind control-plane endpoint on 6443, so both API ports are
-    # explicit while all other destinations and ports remain denied.
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-      ports:
-        - protocol: TCP
-          port: 443
-        - protocol: TCP
-          port: 6443
+    # The acceptance script appends exact /32 rules for the Kubernetes Service
+    # and kind control-plane IPs after cluster creation. Keeping dynamic API
+    # endpoints out of this static fixture avoids broad external HTTPS egress.

--- a/deploy/examples/v1alpha1/reference-kind-network-policy.yaml
+++ b/deploy/examples/v1alpha1/reference-kind-network-policy.yaml
@@ -1,0 +1,159 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kontext-network-policy-e2e
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reference-network-reader
+  namespace: kontext-network-policy-e2e
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: reference-network-pod-reader
+  namespace: kontext-network-policy-e2e
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: reference-network-pod-reader
+  namespace: kontext-network-policy-e2e
+subjects:
+  - kind: ServiceAccount
+    name: reference-network-reader
+    namespace: kontext-network-policy-e2e
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: reference-network-pod-reader
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-policy-http-content
+  namespace: kontext-network-policy-e2e
+data:
+  allowed.txt: |
+    allowed
+  blocked.txt: |
+    blocked
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: network-policy-http
+  namespace: kontext-network-policy-e2e
+  labels:
+    app.kubernetes.io/name: network-policy-http
+spec:
+  automountServiceAccountToken: false
+  restartPolicy: Always
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: allowed
+      image: kontext-reference:dev
+      command: ["/bin/httpd"]
+      args: ["-f", "-p", "8080", "-h", "/www"]
+      ports:
+        - name: allowed
+          containerPort: 8080
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+      volumeMounts:
+        - name: content
+          mountPath: /www
+          readOnly: true
+    - name: blocked
+      image: kontext-reference:dev
+      command: ["/bin/httpd"]
+      args: ["-f", "-p", "8081", "-h", "/www"]
+      ports:
+        - name: blocked
+          containerPort: 8081
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+      volumeMounts:
+        - name: content
+          mountPath: /www
+          readOnly: true
+  volumes:
+    - name: content
+      configMap:
+        name: network-policy-http-content
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: network-policy-http
+  namespace: kontext-network-policy-e2e
+spec:
+  selector:
+    app.kubernetes.io/name: network-policy-http
+  ports:
+    - name: allowed
+      port: 8080
+      targetPort: allowed
+    - name: blocked
+      port: 8081
+      targetPort: blocked
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: reference-runtime-egress
+  namespace: kontext-network-policy-e2e
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kontext-agentrun
+  policyTypes: ["Egress"]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: network-policy-http
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Runtime clients use the kubernetes Service on 443. Some CNIs evaluate
+    # the post-DNAT kind control-plane endpoint on 6443, so both API ports are
+    # explicit while all other destinations and ports remain denied.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443

--- a/deploy/examples/v1alpha1/reference-kind-policy-runs.yaml
+++ b/deploy/examples/v1alpha1/reference-kind-policy-runs.yaml
@@ -1,0 +1,239 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kontext-e2e-tools
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reference-kubernetes-reader
+  namespace: kontext-e2e-tools
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reference-shell
+  namespace: kontext-e2e-tools
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: reference-pod-reader
+  namespace: kontext-e2e-tools
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: reference-pod-reader
+  namespace: kontext-e2e-tools
+subjects:
+  - kind: ServiceAccount
+    name: reference-kubernetes-reader
+    namespace: kontext-e2e-tools
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: reference-pod-reader
+---
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-kubernetes-pods
+  namespace: kontext-e2e-tools
+spec:
+  goal: List Pods in the current namespace.
+  provider: fake
+  model: vendor/opaque-tool-model@2026
+  tools: [kubernetes_read]
+  serviceAccountName: reference-kubernetes-reader
+  runtime:
+    image: kontext-reference:dev
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  env:
+    - name: KONTEXT_FAKE_SCENARIO
+      value: tool
+    - name: KONTEXT_FAKE_TOOL_NAME
+      value: kubernetes_read
+    - name: KONTEXT_FAKE_TOOL_ARGUMENTS
+      value: '{"operation":"list","resource":"pods"}'
+    - name: KONTEXT_MAX_TURNS
+      value: "3"
+    - name: KONTEXT_MAX_TOOL_CALLS
+      value: "2"
+    - name: KONTEXT_MAX_TOOL_RESULT_BYTES
+      value: "16384"
+    - name: KONTEXT_MAX_TOTAL_TOOL_OUTPUT_BYTES
+      value: "32768"
+  budget:
+    tokens: 256
+    wallclock: 1m
+---
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-kubernetes-secrets
+  namespace: kontext-e2e-tools
+spec:
+  goal: Demonstrate that Secrets are outside the runtime resource allowlist.
+  provider: fake
+  model: vendor/opaque-tool-model@2026
+  tools: [kubernetes_read]
+  serviceAccountName: reference-kubernetes-reader
+  runtime:
+    image: kontext-reference:dev
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  env:
+    - name: KONTEXT_FAKE_SCENARIO
+      value: tool
+    - name: KONTEXT_FAKE_TOOL_NAME
+      value: kubernetes_read
+    - name: KONTEXT_FAKE_TOOL_ARGUMENTS
+      value: '{"operation":"list","resource":"secrets"}'
+    - name: KONTEXT_MAX_TURNS
+      value: "3"
+    - name: KONTEXT_MAX_TOOL_CALLS
+      value: "2"
+    - name: KONTEXT_MAX_TOOL_RESULT_BYTES
+      value: "4096"
+    - name: KONTEXT_MAX_TOTAL_TOOL_OUTPUT_BYTES
+      value: "8192"
+  budget:
+    tokens: 256
+    wallclock: 1m
+---
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-kubernetes-configmaps
+  namespace: kontext-e2e-tools
+spec:
+  goal: Demonstrate that Kubernetes RBAC rejects an ungranted ConfigMap list.
+  provider: fake
+  model: vendor/opaque-tool-model@2026
+  tools: [kubernetes_read]
+  serviceAccountName: reference-kubernetes-reader
+  runtime:
+    image: kontext-reference:dev
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  env:
+    - name: KONTEXT_FAKE_SCENARIO
+      value: tool
+    - name: KONTEXT_FAKE_TOOL_NAME
+      value: kubernetes_read
+    - name: KONTEXT_FAKE_TOOL_ARGUMENTS
+      value: '{"operation":"list","resource":"configmaps"}'
+    - name: KONTEXT_MAX_TURNS
+      value: "3"
+    - name: KONTEXT_MAX_TOOL_CALLS
+      value: "2"
+    - name: KONTEXT_MAX_TOOL_RESULT_BYTES
+      value: "4096"
+    - name: KONTEXT_MAX_TOTAL_TOOL_OUTPUT_BYTES
+      value: "8192"
+  budget:
+    tokens: 256
+    wallclock: 1m
+---
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-restricted-shell
+  namespace: kontext-e2e-tools
+spec:
+  goal: Run a shell command under the restricted Pod Security profile.
+  provider: fake
+  model: vendor/opaque-tool-model@2026
+  tools: [shell]
+  serviceAccountName: reference-shell
+  runtime:
+    image: kontext-reference:dev
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  env:
+    - name: KONTEXT_FAKE_SCENARIO
+      value: tool
+    - name: KONTEXT_FAKE_TOOL_NAME
+      value: shell
+    - name: KONTEXT_FAKE_TOOL_ARGUMENTS
+      value: '{"command":"printf restricted-shell-ok","working_directory":"/tmp"}'
+    - name: KONTEXT_MAX_TURNS
+      value: "3"
+    - name: KONTEXT_MAX_TOOL_CALLS
+      value: "2"
+    - name: KONTEXT_MAX_TOOL_RESULT_BYTES
+      value: "4096"
+    - name: KONTEXT_MAX_TOTAL_TOOL_OUTPUT_BYTES
+      value: "8192"
+  budget:
+    tokens: 256
+    wallclock: 1m
+---
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: reference-wallclock-shell
+  namespace: kontext-e2e-tools
+spec:
+  goal: Cancel a long-running shell command at the controller wallclock.
+  provider: fake
+  model: vendor/opaque-tool-model@2026
+  tools: [shell]
+  serviceAccountName: reference-shell
+  runtime:
+    image: kontext-reference:dev
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  env:
+    - name: KONTEXT_FAKE_SCENARIO
+      value: tool
+    - name: KONTEXT_FAKE_TOOL_NAME
+      value: shell
+    - name: KONTEXT_FAKE_TOOL_ARGUMENTS
+      value: '{"command":"sleep 30","working_directory":"/tmp"}'
+    - name: KONTEXT_MAX_TURNS
+      value: "3"
+    - name: KONTEXT_MAX_TOOL_CALLS
+      value: "2"
+    - name: KONTEXT_MAX_TOOL_RESULT_BYTES
+      value: "4096"
+    - name: KONTEXT_MAX_TOTAL_TOOL_OUTPUT_BYTES
+      value: "8192"
+  budget:
+    tokens: 256
+    wallclock: 3s

--- a/scripts/e2e-kind-network-policy.sh
+++ b/scripts/e2e-kind-network-policy.sh
@@ -51,6 +51,15 @@ verify_sha256() {
   fi
 }
 
+require_ipv4() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "${value}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    echo "${name} is not a single IPv4 address: ${value}" >&2
+    return 1
+  fi
+}
+
 wait_for_run_phase() {
   local name="$1"
   local expected="$2"
@@ -160,6 +169,42 @@ KONTEXT_KIND_IMAGE_SET=network-policy \
 echo "==> applying NetworkPolicy fixture and policy"
 kubectl apply -f \
   "${ROOT_DIR}/deploy/examples/v1alpha1/reference-kind-network-policy.yaml"
+kubernetes_service_ip="$(
+  kubectl get service kubernetes -n default -o jsonpath='{.spec.clusterIP}'
+)"
+control_plane_ip="$(
+  docker inspect \
+    --format '{{(index .NetworkSettings.Networks "kind").IPAddress}}' \
+    "${CLUSTER_NAME}-control-plane"
+)"
+require_ipv4 "Kubernetes Service IP" "${kubernetes_service_ip}"
+require_ipv4 "kind control-plane IP" "${control_plane_ip}"
+api_egress_patch="$(
+  cat <<EOF
+[
+  {
+    "op": "add",
+    "path": "/spec/egress/-",
+    "value": {
+      "to": [{"ipBlock": {"cidr": "${kubernetes_service_ip}/32"}}],
+      "ports": [{"protocol": "TCP", "port": 443}]
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/egress/-",
+    "value": {
+      "to": [{"ipBlock": {"cidr": "${control_plane_ip}/32"}}],
+      "ports": [{"protocol": "TCP", "port": 6443}]
+    }
+  }
+]
+EOF
+)"
+kubectl patch networkpolicy reference-runtime-egress \
+  -n "${NAMESPACE}" \
+  --type=json \
+  --patch "${api_egress_patch}"
 kubectl wait --for=condition=Ready pod/network-policy-http \
   -n "${NAMESPACE}" \
   --timeout=120s

--- a/scripts/e2e-kind-network-policy.sh
+++ b/scripts/e2e-kind-network-policy.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# NetworkPolicy acceptance needs an enforcing CNI; kindnet does not implement
+# NetworkPolicy. Calico is pinned and checksum-verified so this evidence cannot
+# silently change with a mutable remote manifest.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-kontext-network-policy}"
+NAMESPACE="kontext-network-policy-e2e"
+DIAG_DIR="${KONTEXT_DIAG_DIR:-${ROOT_DIR}/.ci-diagnostics}"
+CALICO_VERSION="v3.30.3"
+CALICO_MANIFEST_URL="https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml"
+CALICO_MANIFEST_SHA256="9382d2b27a76f40c170454b408653e6d71e2205ef0aef069e942bb690e7381d0"
+KIND_CONFIG=""
+CALICO_MANIFEST=""
+CLUSTER_CREATED=false
+PREVIOUS_CONTEXT=""
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+cluster_exists() {
+  local cluster
+  while read -r cluster; do
+    if [[ "${cluster}" == "${CLUSTER_NAME}" ]]; then
+      return 0
+    fi
+  done < <(kind get clusters)
+  return 1
+}
+
+verify_sha256() {
+  local file="$1"
+  local actual=""
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "${file}")"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "${file}")"
+  else
+    echo "missing required command: sha256sum or shasum" >&2
+    return 1
+  fi
+  actual="${actual%% *}"
+  if [[ "${actual}" != "${CALICO_MANIFEST_SHA256}" ]]; then
+    echo "Calico manifest checksum mismatch: expected ${CALICO_MANIFEST_SHA256}, got ${actual}" >&2
+    return 1
+  fi
+}
+
+wait_for_run_phase() {
+  local name="$1"
+  local expected="$2"
+  local phase=""
+  for _ in $(seq 1 90); do
+    phase="$(
+      kubectl get agentrun "${name}" -n "${NAMESPACE}" \
+        -o jsonpath='{.status.phase}' 2>/dev/null || true
+    )"
+    if [[ "${phase}" == "${expected}" ]]; then
+      return 0
+    fi
+    case "${phase}" in
+      ""|Pending|Running) ;;
+      *)
+        echo "expected ${name} phase=${expected}, got phase=${phase}" >&2
+        return 1
+        ;;
+    esac
+    sleep 2
+  done
+  echo "timed out waiting for ${name} phase=${expected}; last phase=${phase}" >&2
+  return 1
+}
+
+collect_network_diagnostics() {
+  mkdir -p "${DIAG_DIR}"
+  "${ROOT_DIR}/scripts/collect-kind-diagnostics.sh" "${DIAG_DIR}" || true
+  {
+    echo "# network policies"
+    kubectl get networkpolicies -A -o yaml || true
+    echo
+    echo "# Calico workloads"
+    kubectl get pods -n kube-system -l k8s-app=calico-node -o wide || true
+    kubectl describe daemonset -n kube-system calico-node || true
+    kubectl logs -n kube-system -l k8s-app=calico-node \
+      --all-containers --tail=300 || true
+    echo
+    echo "# fixture endpoints"
+    kubectl get pod,service,endpoints -n "${NAMESPACE}" -o wide || true
+  } >"${DIAG_DIR}/network-policy.txt" 2>&1
+}
+
+on_exit() {
+  local status=$?
+  trap - EXIT
+  set +e
+  if [[ "${status}" -ne 0 && "${CLUSTER_CREATED}" == "true" ]]; then
+    echo "==> collecting NetworkPolicy diagnostics" >&2
+    collect_network_diagnostics
+  fi
+  if [[ "${CLUSTER_CREATED}" == "true" ]]; then
+    echo "==> deleting kind cluster ${CLUSTER_NAME}"
+    kind delete cluster --name "${CLUSTER_NAME}"
+  fi
+  if [[ -n "${PREVIOUS_CONTEXT}" ]]; then
+    kubectl config use-context "${PREVIOUS_CONTEXT}" >/dev/null || true
+  fi
+  [[ -z "${KIND_CONFIG}" ]] || rm -f "${KIND_CONFIG}"
+  [[ -z "${CALICO_MANIFEST}" ]] || rm -f "${CALICO_MANIFEST}"
+  exit "${status}"
+}
+
+need curl
+need docker
+need kind
+need kubectl
+trap on_exit EXIT
+PREVIOUS_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
+
+if cluster_exists; then
+  echo "kind cluster ${CLUSTER_NAME} already exists; choose a disposable KIND_CLUSTER_NAME" >&2
+  exit 1
+fi
+
+KIND_CONFIG="$(mktemp)"
+CALICO_MANIFEST="$(mktemp)"
+cat >"${KIND_CONFIG}" <<'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: 192.168.0.0/16
+nodes:
+  - role: control-plane
+EOF
+
+echo "==> creating CNI-less kind cluster ${CLUSTER_NAME}"
+CLUSTER_CREATED=true
+kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}"
+
+echo "==> installing checksum-verified Calico ${CALICO_VERSION}"
+curl --fail --location --silent --show-error --retry 3 \
+  "${CALICO_MANIFEST_URL}" \
+  --output "${CALICO_MANIFEST}"
+verify_sha256 "${CALICO_MANIFEST}"
+kubectl apply -f "${CALICO_MANIFEST}"
+kubectl rollout status daemonset/calico-node -n kube-system --timeout=300s
+kubectl rollout status deployment/calico-kube-controllers -n kube-system --timeout=300s
+kubectl wait --for=condition=Ready nodes --all --timeout=300s
+
+echo "==> installing focused Kontext images"
+KONTEXT_KIND_IMAGE_SET=network-policy \
+  KIND_CLUSTER_NAME="${CLUSTER_NAME}" \
+  "${ROOT_DIR}/scripts/install-go-kind.sh"
+
+echo "==> applying NetworkPolicy fixture and policy"
+kubectl apply -f \
+  "${ROOT_DIR}/deploy/examples/v1alpha1/reference-kind-network-policy.yaml"
+kubectl wait --for=condition=Ready pod/network-policy-http \
+  -n "${NAMESPACE}" \
+  --timeout=120s
+
+echo "==> starting policy-selected runtime probes"
+kubectl apply -f \
+  "${ROOT_DIR}/deploy/examples/v1alpha1/reference-kind-network-policy-runs.yaml"
+wait_for_run_phase reference-network-http Succeeded
+wait_for_run_phase reference-network-kubernetes Succeeded
+
+http_logs="$(
+  kubectl logs run-reference-network-http -n "${NAMESPACE}" -c runtime
+)"
+kubernetes_logs="$(
+  kubectl logs run-reference-network-kubernetes -n "${NAMESPACE}" -c runtime
+)"
+selected_runtime_count="$(
+  kubectl get pods -n "${NAMESPACE}" \
+    -l app.kubernetes.io/name=kontext-agentrun \
+    -o name | wc -l | tr -d ' '
+)"
+
+if [[ "${selected_runtime_count}" != "2" ||
+  "${http_logs}" != *"dns-allowed-and-port-blocked"* ||
+  "${http_logs}" == *"unexpected-egress-success"* ]]; then
+  echo "runtime HTTP probe did not prove allowed DNS/8080 and denied 8081" >&2
+  exit 1
+fi
+if [[ "${kubernetes_logs}" != *'"name":"kubernetes_read"'* ||
+  "${kubernetes_logs}" != *'"errorCode":"","isError":false'* ||
+  "${kubernetes_logs}" == *"kubernetes_request_failed"* ]]; then
+  echo "kubernetes_read could not use the policy-allowed Kubernetes API path" >&2
+  exit 1
+fi
+
+echo "NetworkPolicy acceptance passed with Calico ${CALICO_VERSION}"

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOLS_NAMESPACE="kontext-e2e-tools"
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -22,9 +23,13 @@ is_terminal_failure_phase() {
 wait_for_run_phase() {
   local name="$1"
   local expected="$2"
+  local namespace="${3:-default}"
   local phase=""
   for _ in $(seq 1 60); do
-    phase="$(kubectl get agentrun "${name}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    phase="$(
+      kubectl get agentrun "${name}" -n "${namespace}" \
+        -o jsonpath='{.status.phase}' 2>/dev/null || true
+    )"
     if [[ "${phase}" == "${expected}" ]]; then
       return 0
     fi
@@ -41,21 +46,47 @@ wait_for_run_phase() {
   return 1
 }
 
+cleanup_e2e_resources() {
+  local status=0
+  kubectl delete agent echo-service --ignore-not-found=true --wait=true || status=1
+  kubectl delete agentrun \
+    echo-review \
+    stdout-last-line \
+    stdout-envelope \
+    stdout-failure \
+    stdout-signal \
+    reference-fake \
+    reference-fake-tool \
+    --ignore-not-found=true \
+    --wait=true || status=1
+  kubectl delete configmap reference-tool-knowledge \
+    --ignore-not-found=true || status=1
+  kubectl delete namespace "${TOOLS_NAMESPACE}" \
+    --ignore-not-found=true \
+    --wait=true \
+    --timeout=60s || status=1
+  return "${status}"
+}
+
+on_exit() {
+  local status=$?
+  if [[ "${status}" -eq 0 ]]; then
+    echo "==> cleaning completed e2e resources"
+    set +e
+    cleanup_e2e_resources
+    status=$?
+    set -e
+  else
+    echo "==> preserving failed e2e resources for diagnostics" >&2
+  fi
+  return "${status}"
+}
+
 need kubectl
+trap on_exit EXIT
 
 echo "==> cleaning previous e2e resources"
-kubectl delete agent echo-service --ignore-not-found=true --wait=true
-kubectl delete agentrun \
-  echo-review \
-  stdout-last-line \
-  stdout-envelope \
-  stdout-failure \
-  stdout-signal \
-  reference-fake \
-  reference-fake-tool \
-  --ignore-not-found=true \
-  --wait=true
-kubectl delete configmap reference-tool-knowledge --ignore-not-found=true
+cleanup_e2e_resources
 
 echo "==> applying standalone echo task run"
 kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/echo-task-run.yaml"
@@ -184,6 +215,95 @@ fi
 if [[ "${tool_logs}" != *'"type":"tool"'* ||
   "${tool_logs}" != *'"name":"read_knowledge"'* ]]; then
   echo "tool loop did not emit the expected execution event" >&2
+  exit 1
+fi
+
+echo "==> verifying Kubernetes read policy and restricted shell execution"
+kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/reference-kind-policy-runs.yaml"
+
+wait_for_run_phase reference-kubernetes-pods Succeeded "${TOOLS_NAMESPACE}"
+pods_logs="$(
+  kubectl logs run-reference-kubernetes-pods -n "${TOOLS_NAMESPACE}" -c runtime
+)"
+pods_service_account="$(
+  kubectl get pod run-reference-kubernetes-pods -n "${TOOLS_NAMESPACE}" \
+    -o jsonpath='{.spec.serviceAccountName}'
+)"
+if [[ "${pods_logs}" != *'"name":"kubernetes_read"'* ||
+  "${pods_logs}" != *'"errorCode":"","isError":false'* ||
+  "${pods_service_account}" != "reference-kubernetes-reader" ]]; then
+  echo "current-namespace Pod list did not succeed through kubernetes_read" >&2
+  exit 1
+fi
+
+wait_for_run_phase reference-kubernetes-secrets Succeeded "${TOOLS_NAMESPACE}"
+secrets_logs="$(
+  kubectl logs run-reference-kubernetes-secrets -n "${TOOLS_NAMESPACE}" -c runtime
+)"
+if [[ "${secrets_logs}" != *'"name":"kubernetes_read"'* ||
+  "${secrets_logs}" != *'"errorCode":"kubernetes_resource_denied"'* ]]; then
+  echo "Secrets were not rejected by the runtime resource allowlist" >&2
+  exit 1
+fi
+
+wait_for_run_phase reference-kubernetes-configmaps Succeeded "${TOOLS_NAMESPACE}"
+configmaps_logs="$(
+  kubectl logs run-reference-kubernetes-configmaps -n "${TOOLS_NAMESPACE}" -c runtime
+)"
+if [[ "${configmaps_logs}" != *'"name":"kubernetes_read"'* ||
+  "${configmaps_logs}" != *'"errorCode":"kubernetes_rbac_denied"'* ]]; then
+  echo "ungranted ConfigMap list did not reach Kubernetes RBAC" >&2
+  exit 1
+fi
+
+wait_for_run_phase reference-restricted-shell Succeeded "${TOOLS_NAMESPACE}"
+shell_result="$(
+  kubectl get agentrun reference-restricted-shell -n "${TOOLS_NAMESPACE}" \
+    -o jsonpath='{.status.result}'
+)"
+shell_pod="run-reference-restricted-shell"
+shell_run_as_non_root="$(
+  kubectl get pod "${shell_pod}" -n "${TOOLS_NAMESPACE}" \
+    -o jsonpath='{.spec.containers[?(@.name=="runtime")].securityContext.runAsNonRoot}'
+)"
+shell_allow_privilege_escalation="$(
+  kubectl get pod "${shell_pod}" -n "${TOOLS_NAMESPACE}" \
+    -o jsonpath='{.spec.containers[?(@.name=="runtime")].securityContext.allowPrivilegeEscalation}'
+)"
+shell_dropped_capabilities="$(
+  kubectl get pod "${shell_pod}" -n "${TOOLS_NAMESPACE}" \
+    -o jsonpath='{.spec.containers[?(@.name=="runtime")].securityContext.capabilities.drop[*]}'
+)"
+shell_seccomp_profile="$(
+  kubectl get pod "${shell_pod}" -n "${TOOLS_NAMESPACE}" \
+    -o jsonpath='{.spec.containers[?(@.name=="runtime")].securityContext.seccompProfile.type}'
+)"
+shell_volume_names="$(
+  kubectl get pod "${shell_pod}" -n "${TOOLS_NAMESPACE}" \
+    -o jsonpath='{.spec.volumes[*].name}'
+)"
+if [[ "${shell_result}" != *"restricted-shell-ok"* ||
+  "${shell_run_as_non_root}" != "true" ||
+  "${shell_allow_privilege_escalation}" != "false" ||
+  "${shell_dropped_capabilities}" != "ALL" ||
+  "${shell_seccomp_profile}" != "RuntimeDefault" ||
+  "${shell_volume_names}" == *"kube-api-access-"* ]]; then
+  echo "restricted shell Pod did not preserve the required security settings" >&2
+  exit 1
+fi
+
+wait_for_run_phase reference-wallclock-shell BudgetExceeded "${TOOLS_NAMESPACE}"
+sleep 5
+wallclock_phase="$(
+  kubectl get agentrun reference-wallclock-shell -n "${TOOLS_NAMESPACE}" \
+    -o jsonpath='{.status.phase}'
+)"
+wallclock_pod="$(
+  kubectl get pod run-reference-wallclock-shell -n "${TOOLS_NAMESPACE}" \
+    -o name 2>/dev/null || true
+)"
+if [[ "${wallclock_phase}" != "BudgetExceeded" || -n "${wallclock_pod}" ]]; then
+  echo "wallclock cancellation did not remain terminally BudgetExceeded" >&2
   exit 1
 fi
 

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -74,7 +74,6 @@ on_exit() {
     echo "==> cleaning completed e2e resources"
     set +e
     cleanup_e2e_resources
-    status=$?
     set -e
   else
     echo "==> preserving failed e2e resources for diagnostics" >&2

--- a/scripts/install-go-kind.sh
+++ b/scripts/install-go-kind.sh
@@ -26,6 +26,7 @@ if ! docker image inspect "${OPERATOR_IMAGE}" >/dev/null 2>&1; then
   echo "missing local image ${OPERATOR_IMAGE}; build with: make docker-build" >&2
   exit 1
 fi
+OPERATOR_IMAGE_ID="$(docker image inspect "${OPERATOR_IMAGE}" --format '{{.Id}}')"
 if ! docker image inspect "${ECHO_IMAGE}" >/dev/null 2>&1; then
   echo "missing local image ${ECHO_IMAGE}; build with: make docker-build-echo" >&2
   exit 1
@@ -58,6 +59,15 @@ kind load docker-image "${REFERENCE_IMAGE}" --name "${CLUSTER_NAME}"
 kind load docker-image "${STDOUT_FIXTURE_IMAGE}" --name "${CLUSTER_NAME}"
 
 echo "==> installing v1alpha1 CRDs and Go controller"
+CONTROLLER_POD_UID_BEFORE="$(
+  kubectl get pods -n kontext-system -l control-plane=controller-manager \
+    -o jsonpath='{.items[0].metadata.uid}' 2>/dev/null || true
+)"
+DEPLOYED_IMAGE_ID_BEFORE="$(
+  kubectl get deployment controller-manager -n kontext-system \
+    -o jsonpath='{.spec.template.metadata.annotations.kontext\.dev/local-operator-image-id}' \
+    2>/dev/null || true
+)"
 if kubectl get crd agents.kontext.dev >/dev/null 2>&1; then
   STORED_VERSION="$(kubectl get crd agents.kontext.dev -o jsonpath='{.spec.versions[?(@.storage==true)].name}' 2>/dev/null || true)"
   if [[ "${STORED_VERSION}" == "v1" ]]; then
@@ -70,10 +80,36 @@ kubectl delete deployment kontext-controller -n default --ignore-not-found=true
 kubectl apply -k "${ROOT_DIR}/config/default"
 kubectl set env deployment/controller-manager -n kontext-system \
   "KONTEXT_REPORTER_IMAGE=${REPORTER_IMAGE}"
+kubectl patch deployment/controller-manager -n kontext-system --type=merge -p \
+  "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kontext.dev/local-operator-image-id\":\"${OPERATOR_IMAGE_ID}\"}}}}}"
 
 echo "==> waiting for controller rollout"
 kubectl rollout status deployment/controller-manager -n kontext-system --timeout=120s
 
+if [[ -n "${CONTROLLER_POD_UID_BEFORE}" &&
+  "${DEPLOYED_IMAGE_ID_BEFORE}" != "${OPERATOR_IMAGE_ID}" ]]; then
+  CONTROLLER_POD_UID_AFTER=""
+  for _ in $(seq 1 30); do
+    CONTROLLER_POD_UID_AFTER="$(
+      kubectl get pods -n kontext-system -l control-plane=controller-manager \
+        -o jsonpath='{range .items[*]}{.metadata.uid}{"\n"}{end}'
+    )"
+    if [[ -n "${CONTROLLER_POD_UID_AFTER}" &&
+      "${CONTROLLER_POD_UID_AFTER}" != *"${CONTROLLER_POD_UID_BEFORE}"* ]]; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "${CONTROLLER_POD_UID_AFTER}" ||
+    "${CONTROLLER_POD_UID_AFTER}" == *"${CONTROLLER_POD_UID_BEFORE}"* ]]; then
+    echo "controller image changed but no new ready Pod was observed" >&2
+    exit 1
+  fi
+fi
+
 echo "==> ready"
 kubectl get crd agents.kontext.dev agentruns.kontext.dev
 kubectl get deploy -n kontext-system controller-manager
+echo "controller local image identity: ${OPERATOR_IMAGE_ID}"
+kubectl get pods -n kontext-system -l control-plane=controller-manager \
+  -o custom-columns='NAME:.metadata.name,IMAGE:.spec.containers[0].image,IMAGE_ID:.status.containerStatuses[0].imageID,READY:.status.containerStatuses[0].ready'

--- a/scripts/install-go-kind.sh
+++ b/scripts/install-go-kind.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLUSTER_NAME="${KIND_CLUSTER_NAME:-kontext}"
+IMAGE_SET="${KONTEXT_KIND_IMAGE_SET:-full}"
 OPERATOR_IMAGE="${KONTEXT_OPERATOR_IMAGE:-kontext-operator:dev}"
 ECHO_IMAGE="${KONTEXT_ECHO_IMAGE:-kontext-echo:dev}"
 REPORTER_IMAGE="${KONTEXT_REPORTER_IMAGE:-kontext-reporter:dev}"
@@ -22,15 +23,19 @@ need docker
 need kind
 need kubectl
 
+case "${IMAGE_SET}" in
+  full|network-policy) ;;
+  *)
+    echo "unsupported KONTEXT_KIND_IMAGE_SET: ${IMAGE_SET}" >&2
+    exit 1
+    ;;
+esac
+
 if ! docker image inspect "${OPERATOR_IMAGE}" >/dev/null 2>&1; then
   echo "missing local image ${OPERATOR_IMAGE}; build with: make docker-build" >&2
   exit 1
 fi
 OPERATOR_IMAGE_ID="$(docker image inspect "${OPERATOR_IMAGE}" --format '{{.Id}}')"
-if ! docker image inspect "${ECHO_IMAGE}" >/dev/null 2>&1; then
-  echo "missing local image ${ECHO_IMAGE}; build with: make docker-build-echo" >&2
-  exit 1
-fi
 if ! docker image inspect "${REPORTER_IMAGE}" >/dev/null 2>&1; then
   echo "missing local image ${REPORTER_IMAGE}; build with: make docker-build-reporter" >&2
   exit 1
@@ -39,9 +44,15 @@ if ! docker image inspect "${REFERENCE_IMAGE}" >/dev/null 2>&1; then
   echo "missing local image ${REFERENCE_IMAGE}; build with: make docker-build-reference" >&2
   exit 1
 fi
-if ! docker image inspect "${STDOUT_FIXTURE_IMAGE}" >/dev/null 2>&1; then
-  echo "missing local image ${STDOUT_FIXTURE_IMAGE}; build with: make docker-build-stdout-fixture" >&2
-  exit 1
+if [[ "${IMAGE_SET}" == "full" ]]; then
+  if ! docker image inspect "${ECHO_IMAGE}" >/dev/null 2>&1; then
+    echo "missing local image ${ECHO_IMAGE}; build with: make docker-build-echo" >&2
+    exit 1
+  fi
+  if ! docker image inspect "${STDOUT_FIXTURE_IMAGE}" >/dev/null 2>&1; then
+    echo "missing local image ${STDOUT_FIXTURE_IMAGE}; build with: make docker-build-stdout-fixture" >&2
+    exit 1
+  fi
 fi
 
 if ! kind get clusters | grep -qx "${CLUSTER_NAME}"; then
@@ -53,10 +64,12 @@ fi
 
 echo "==> loading images into kind/${CLUSTER_NAME}"
 kind load docker-image "${OPERATOR_IMAGE}" --name "${CLUSTER_NAME}"
-kind load docker-image "${ECHO_IMAGE}" --name "${CLUSTER_NAME}"
 kind load docker-image "${REPORTER_IMAGE}" --name "${CLUSTER_NAME}"
 kind load docker-image "${REFERENCE_IMAGE}" --name "${CLUSTER_NAME}"
-kind load docker-image "${STDOUT_FIXTURE_IMAGE}" --name "${CLUSTER_NAME}"
+if [[ "${IMAGE_SET}" == "full" ]]; then
+  kind load docker-image "${ECHO_IMAGE}" --name "${CLUSTER_NAME}"
+  kind load docker-image "${STDOUT_FIXTURE_IMAGE}" --name "${CLUSTER_NAME}"
+fi
 
 echo "==> installing v1alpha1 CRDs and Go controller"
 CONTROLLER_POD_UID_BEFORE="$(


### PR DESCRIPTION
## Summary
- force local controller rollouts when changed development images are loaded into kind
- verify kubernetes_read success, runtime Secret exclusion, real RBAC denial, restricted tokenless shell execution, and wallclock BudgetExceeded behavior
- add a checksum-pinned Calico v3.30.3 job that proves DNS and explicitly allowed egress work while a denied port is blocked and Kubernetes API access remains available only through exact cluster endpoint addresses

## Dependency
- #27 is merged; this PR now targets `main`

## Test plan
- [x] Bash syntax and manifest validation
- [x] Targeted controller and Pod-builder tests
- [x] Full keyless kind e2e
- [x] actionlint
- [x] Calico-backed NetworkPolicy scenario, run twice during implementation
- [x] Calico-backed scenario rerun after narrowing API egress to exact /32 addresses