### PR TITLE
Add protected provider tool acceptance

### DIFF
--- a/.github/workflows/provider-acceptance.yml
+++ b/.github/workflows/provider-acceptance.yml
@@ -11,12 +11,20 @@ on:
           - anthropic
           - openai
           - openai-compatible
+      scenario:
+        description: Tiny acceptance path (tool uses two provider requests)
+        required: true
+        default: tool
+        type: choice
+        options:
+          - tool
+          - text
       model:
         description: Provider model identifier (passed through unchanged)
         required: true
         type: string
       endpoint:
-        description: Optional exact Messages or Chat Completions endpoint
+        description: Optional exact endpoint (never include credentials)
         required: false
         type: string
 
@@ -24,15 +32,17 @@ permissions:
   contents: read
 
 jobs:
-  anthropic:
-    name: Anthropic request
-    if: inputs.provider == 'anthropic'
+  provider:
+    name: ${{ inputs.provider }} ${{ inputs.scenario }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
     environment: provider-acceptance
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      KONTEXT_GOAL: Reply with exactly the word kontext.
+      KIND_CLUSTER_NAME: provider-acceptance
+      KONTEXT_ACCEPTANCE_NAMESPACE: provider-acceptance
+      KONTEXT_ACCEPTANCE_SCENARIO: ${{ inputs.scenario }}
+      KONTEXT_OPERATOR_IMAGE: kontext-operator:dev
+      KONTEXT_REFERENCE_IMAGE: kontext-reference:dev
       KONTEXT_PROVIDER: ${{ inputs.provider }}
       KONTEXT_MODEL: ${{ inputs.model }}
       KONTEXT_PROVIDER_ENDPOINT: ${{ inputs.endpoint }}
@@ -40,44 +50,75 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build maintained operator image
+        uses: docker/build-push-action@v6
         with:
-          go-version-file: go.mod
-          cache: true
+          context: .
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
+          cache-from: type=gha,scope=provider-acceptance-operator
+          cache-to: type=gha,mode=max,scope=provider-acceptance-operator
 
-      - name: Run one authenticated completion
-        run: |
-          output="$(go run ./runtimes/reference)"
-          printf '%s\n' "${output}"
-          [[ "${output}" == *'"apiVersion":"kontext.dev/event/v1alpha1"'* ]]
-          [[ "${output}" == *'"outcome":"Succeeded"'* ]]
-
-  openai-compatible:
-    name: OpenAI-compatible request
-    if: inputs.provider == 'openai' || inputs.provider == 'openai-compatible'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    environment: provider-acceptance
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      KONTEXT_GOAL: Reply with exactly the word kontext.
-      KONTEXT_PROVIDER: ${{ inputs.provider }}
-      KONTEXT_MODEL: ${{ inputs.model }}
-      KONTEXT_PROVIDER_ENDPOINT: ${{ inputs.endpoint }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Build maintained reference runtime image
+        uses: docker/build-push-action@v6
         with:
-          go-version-file: go.mod
-          cache: true
+          context: .
+          file: runtimes/reference/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
+          cache-from: type=gha,scope=provider-acceptance-reference
+          cache-to: type=gha,mode=max,scope=provider-acceptance-reference
 
-      - name: Run one authenticated completion
+      - name: Create ephemeral kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          wait: 120s
+
+      - name: Load maintained images
         run: |
-          output="$(go run ./runtimes/reference)"
-          printf '%s\n' "${output}"
-          [[ "${output}" == *'"apiVersion":"kontext.dev/event/v1alpha1"'* ]]
-          [[ "${output}" == *'"outcome":"Succeeded"'* ]]
+          kind load docker-image "${KONTEXT_OPERATOR_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+          kind load docker-image "${KONTEXT_REFERENCE_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+
+      - name: Install maintained operator
+        run: |
+          kubectl apply -k config/default
+          kubectl rollout status deployment/controller-manager \
+            --namespace kontext-system \
+            --timeout=120s
+
+      - name: Run Anthropic acceptance
+        if: inputs.provider == 'anthropic'
+        env:
+          KONTEXT_PROVIDER_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: ./scripts/provider-acceptance-kind.sh
+
+      - name: Run OpenAI-compatible acceptance
+        if: inputs.provider == 'openai' || inputs.provider == 'openai-compatible'
+        env:
+          KONTEXT_PROVIDER_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: ./scripts/provider-acceptance-kind.sh
+
+      - name: Collect redacted failure diagnostics
+        if: failure()
+        run: |
+          ./scripts/collect-kind-diagnostics.sh "${RUNNER_TEMP}/provider-diagnostics"
+          rm -f "${RUNNER_TEMP}/provider-diagnostics/agent-workloads.txt"
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: provider-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/provider-diagnostics
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Delete kind cluster
+        if: always()
+        run: kind delete cluster --name "${KIND_CLUSTER_NAME}" || true

--- a/runtimes/reference/README.md
+++ b/runtimes/reference/README.md
@@ -223,6 +223,25 @@ that environment with required reviewers and store `ANTHROPIC_API_KEY` and
 `OPENAI_API_KEY` as environment secrets. Pull-request CI never receives or
 uses these credentials.
 
+Each dispatch builds the maintained operator and reference runtime, loads them
+into an ephemeral kind cluster, and injects only the selected provider key
+through a namespace-local Secret. The default `tool` scenario mounts a tiny
+ConfigMap, exposes only `read_knowledge`, and requires exactly one call before
+an exact final response. The `text` scenario preserves the ordinary one-turn
+transport check.
+
+The tool scenario permits at most two provider turns, one tool call, 256 bytes
+per tool result and in total, 2,048 cumulative measured tokens, and 90 seconds
+of wallclock time. A normal dispatch should stay below roughly 2,000 provider
+tokens, but this is not a hard billing ceiling: usage is checked only after a
+response, provider token accounting varies, and the repeated tool context can
+cross the configured budget. Before approval, select a small non-reasoning
+model, verify its current pricing and the endpoint, and do not use this
+workflow for untrusted code. Failure artifacts omit Secret objects and
+workload logs, and are retained briefly; maintainers should still review them
+before sharing. The model and endpoint inputs are visible workflow metadata;
+an endpoint must never contain a credential or signed query string.
+
 ## Dependency inventory
 
 The reference binary uses only the Go standard library and in-repository

--- a/scripts/provider-acceptance-kind.sh
+++ b/scripts/provider-acceptance-kind.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+provider="${KONTEXT_PROVIDER:?KONTEXT_PROVIDER is required}"
+model="${KONTEXT_MODEL:?KONTEXT_MODEL is required}"
+scenario="${KONTEXT_ACCEPTANCE_SCENARIO:-tool}"
+endpoint="${KONTEXT_PROVIDER_ENDPOINT:-}"
+namespace="${KONTEXT_ACCEPTANCE_NAMESPACE:-provider-acceptance}"
+runtime_image="${KONTEXT_REFERENCE_IMAGE:-kontext-reference:dev}"
+run_name="provider-${scenario}"
+secret_name="provider-acceptance-credentials"
+knowledge_name="provider-acceptance-knowledge"
+
+case "${provider}" in
+  anthropic)
+    credential_env="ANTHROPIC_API_KEY"
+    other_credential_env="OPENAI_API_KEY"
+    ;;
+  openai | openai-compatible)
+    credential_env="OPENAI_API_KEY"
+    other_credential_env="ANTHROPIC_API_KEY"
+    ;;
+  *)
+    echo "unsupported acceptance provider: ${provider}" >&2
+    exit 1
+    ;;
+esac
+
+case "${scenario}" in
+  tool)
+    goal='Call read_knowledge exactly once with {"path":"acceptance.txt"}. You must use the tool before answering. Then reply with exactly the file contents and no quotes, markdown, punctuation, or explanation.'
+    expected_result="KONTEXT_TOOL_ACCEPTANCE_OK"
+    max_turns="2"
+    ;;
+  text)
+    goal="Reply with exactly the word kontext and nothing else."
+    expected_result="kontext"
+    max_turns="1"
+    ;;
+  *)
+    echo "unsupported acceptance scenario: ${scenario}" >&2
+    exit 1
+    ;;
+esac
+
+need jq
+
+render_run_manifest() {
+  jq -n \
+    --arg endpoint "${endpoint}" \
+    --arg goal "${goal}" \
+    --arg knowledgeName "${knowledge_name}" \
+    --arg maxTurns "${max_turns}" \
+    --arg model "${model}" \
+    --arg name "${run_name}" \
+    --arg namespace "${namespace}" \
+    --arg provider "${provider}" \
+    --arg runtimeImage "${runtime_image}" \
+    --arg scenario "${scenario}" \
+    --arg secretName "${secret_name}" \
+    '{
+      apiVersion: "kontext.dev/v1alpha1",
+      kind: "AgentRun",
+      metadata: {
+        name: $name,
+        namespace: $namespace
+      },
+      spec: {
+        goal: $goal,
+        provider: $provider,
+        model: $model,
+        secretRef: {
+          name: $secretName
+        },
+        runtime: {
+          image: $runtimeImage
+        },
+        env: [
+          {
+            name: "KONTEXT_MAX_TURNS",
+            value: $maxTurns
+          },
+          {
+            name: "KONTEXT_MAX_TOOL_CALLS",
+            value: "1"
+          },
+          {
+            name: "KONTEXT_MAX_TOOL_RESULT_BYTES",
+            value: "256"
+          },
+          {
+            name: "KONTEXT_MAX_TOTAL_TOOL_OUTPUT_BYTES",
+            value: "256"
+          }
+        ],
+        budget: {
+          tokens: 2048,
+          wallclock: "90s"
+        }
+      }
+    }
+    | if $scenario == "tool" then
+        .spec.tools = ["read_knowledge"]
+        | .spec.knowledgeConfigMapRef = {name: $knowledgeName}
+      else
+        .
+      end
+    | if $endpoint != "" then
+        .spec.env += [{
+          name: "KONTEXT_PROVIDER_ENDPOINT",
+          value: $endpoint
+        }]
+      else
+        .
+      end'
+}
+
+if [[ "${KONTEXT_ACCEPTANCE_RENDER_ONLY:-false}" == "true" ]]; then
+  render_run_manifest
+  exit 0
+fi
+
+need kubectl
+
+if [[ -z "${KONTEXT_PROVIDER_API_KEY:-}" ]]; then
+  echo "the selected provider credential is empty" >&2
+  exit 1
+fi
+
+echo "==> preparing isolated namespace"
+kubectl create namespace "${namespace}" \
+  --dry-run=client \
+  -o yaml |
+  kubectl apply -f - >/dev/null
+
+# Stream the key into kubectl instead of placing it in a command argument,
+# generated manifest, checked-in file, or workflow output.
+printf '%s' "${KONTEXT_PROVIDER_API_KEY}" |
+  kubectl create secret generic "${secret_name}" \
+    --namespace "${namespace}" \
+    --from-file="${credential_env}=/dev/stdin" \
+    --dry-run=client \
+    -o yaml |
+  kubectl apply -f - >/dev/null
+
+if [[ "${scenario}" == "tool" ]]; then
+  kubectl create configmap "${knowledge_name}" \
+    --namespace "${namespace}" \
+    --from-literal="acceptance.txt=${expected_result}" \
+    --dry-run=client \
+    -o yaml |
+    kubectl apply -f - >/dev/null
+fi
+
+echo "==> creating ${provider} ${scenario} AgentRun"
+render_run_manifest | kubectl apply -f - >/dev/null
+
+echo "==> waiting for AgentRun success"
+phase=""
+for _ in $(seq 1 75); do
+  phase="$(
+    kubectl get agentrun "${run_name}" \
+      --namespace "${namespace}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || true
+  )"
+  case "${phase}" in
+    Succeeded)
+      break
+      ;;
+    Failed | BudgetExceeded)
+      echo "AgentRun reached terminal phase ${phase}" >&2
+      exit 1
+      ;;
+    "" | Pending | Running) ;;
+    *)
+      echo "AgentRun reached unexpected phase ${phase}" >&2
+      exit 1
+      ;;
+  esac
+  sleep 2
+done
+
+if [[ "${phase}" != "Succeeded" ]]; then
+  echo "timed out waiting for AgentRun; last phase=${phase}" >&2
+  exit 1
+fi
+
+run_json="$(
+  kubectl get agentrun "${run_name}" \
+    --namespace "${namespace}" \
+    -o json
+)"
+result="$(jq -r '.status.result' <<<"${run_json}")"
+if [[ "${result}" != "${expected_result}" ]]; then
+  echo "unexpected final result: ${result}" >&2
+  exit 1
+fi
+
+if ! jq -e '
+  (.status.usage.inputTokens | type == "number" and . > 0)
+  and (.status.usage.outputTokens | type == "number" and . > 0)
+' <<<"${run_json}" >/dev/null; then
+  echo "provider did not report positive measured input and output usage" >&2
+  exit 1
+fi
+
+pod_name="$(jq -r '.status.podName' <<<"${run_json}")"
+pod_json="$(
+  kubectl get pod "${pod_name}" \
+    --namespace "${namespace}" \
+    -o json
+)"
+if ! jq -e \
+  --arg envName "${credential_env}" \
+  --arg otherEnvName "${other_credential_env}" \
+  --arg secretKey "${credential_env}" \
+  --arg secretName "${secret_name}" '
+  any(
+    .spec.containers[]
+    | select(.name == "runtime")
+    | .env[];
+    .name == $envName
+    and .valueFrom.secretKeyRef.name == $secretName
+    and .valueFrom.secretKeyRef.key == $secretKey
+    and (has("value") | not)
+  )
+  and all(
+    .spec.containers[]
+    | select(.name == "runtime")
+    | .env[];
+    .name != $otherEnvName
+  )
+' <<<"${pod_json}" >/dev/null; then
+  echo "runtime Pod did not use only the selected Secret-backed credential" >&2
+  exit 1
+fi
+
+if ! kubectl get secret "${secret_name}" \
+  --namespace "${namespace}" \
+  -o json |
+  jq -e --arg key "${credential_env}" '
+    .type == "Opaque"
+    and (.data | keys == [$key])
+  ' >/dev/null; then
+  echo "provider credential Secret had unexpected keys" >&2
+  exit 1
+fi
+
+logs="$(
+  kubectl logs "${pod_name}" \
+    --namespace "${namespace}" \
+    --container runtime
+)"
+envelope="$(
+  jq -R -s -c '
+    [
+      split("\n")[]
+      | select(startswith("KONTEXT_RESULT:"))
+      | sub("^KONTEXT_RESULT:[[:space:]]*"; "")
+      | fromjson
+    ]
+    | last
+  ' <<<"${logs}"
+)"
+if [[ "${envelope}" == "null" ]]; then
+  echo "runtime logs did not contain a terminal result envelope" >&2
+  exit 1
+fi
+
+if [[ "${scenario}" == "tool" ]]; then
+  tool_event_count="$(
+    jq -R -s '
+      [
+        split("\n")[]
+        | fromjson?
+        | select(
+            .apiVersion == "kontext.dev/event/v1alpha1"
+            and .type == "tool"
+            and .data.name == "read_knowledge"
+          )
+      ]
+      | length
+    ' <<<"${logs}"
+  )"
+  if [[ "${tool_event_count}" != "1" ]] ||
+    ! jq -e '
+      .outcome == "Succeeded"
+      and .execution.turns == 2
+      and .execution.toolCalls == 1
+    ' <<<"${envelope}" >/dev/null; then
+    echo "tool scenario did not record exactly one read_knowledge call" >&2
+    exit 1
+  fi
+else
+  if ! jq -e '
+    .outcome == "Succeeded"
+    and .execution.turns == 1
+    and .execution.toolCalls == 0
+  ' <<<"${envelope}" >/dev/null; then
+    echo "text scenario had unexpected execution counts" >&2
+    exit 1
+  fi
+fi
+
+echo "provider acceptance passed: provider=${provider} scenario=${scenario}"


### PR DESCRIPTION
## Summary
- extend the dispatch-only provider workflow with text and read_knowledge tool scenarios
- run authenticated Anthropic and OpenAI-compatible acceptance through an ephemeral kind cluster, Kubernetes Secret injection, and a real AgentRun
- verify exact bounded output, measured usage, one tool call, and redacted diagnostics while exposing only the selected provider credential

## Stack
- Depends on #27
- Base branch: `feat/bounded-tool-loop-19`

## Spending and security
- Manual protected environment only
- No credentials in pull-request CI
- Tiny knowledge fixture, one tool call, finite turns and wallclock, and a 2,048-token run budget
- Live model compliance and measured usage can vary; maintainers should use capped test credentials

## Test plan
- [x] actionlint
- [x] Bash syntax and ShellCheck
- [x] Six secretless manifest variants validated
- [ ] Protected live Anthropic tool acceptance
- [ ] Protected live OpenAI tool acceptance