### PR TITLE
Add external evals and release acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,7 @@ jobs:
           name: keyless-evals-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ env.KONTEXT_EVAL_DIR }}
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: 5
 
       - name: Collect diagnostics on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,38 @@ jobs:
       KONTEXT_REFERENCE_IMAGE: kontext-reference:dev
       KONTEXT_STDOUT_FIXTURE_IMAGE: kontext-stdout-fixture:dev
       KONTEXT_DIAG_DIR: ${{ github.workspace }}/.ci-diagnostics
+      KONTEXT_EVAL_DIR: ${{ github.workspace }}/.ci-evals
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Initialize keyless evaluation artifact
+        run: |
+          mkdir -p "${KONTEXT_EVAL_DIR}"
+          marker="${KONTEXT_EVAL_DIR}/not-run.json"
+          temporary="${marker}.tmp"
+          jq -n \
+            --arg commitSHA "${GITHUB_SHA:0:64}" \
+            --arg runAttempt "${GITHUB_RUN_ATTEMPT:0:32}" \
+            --arg runID "${GITHUB_RUN_ID:0:128}" \
+            '{
+              apiVersion: "kontext.dev/eval/v1alpha1",
+              kind: "EvalRunMarker",
+              suite: "keyless",
+              state: "NotRun",
+              failureStage: "workflow_not_started",
+              commitSHA: $commitSHA,
+              runID: $runID,
+              runAttempt: $runAttempt,
+              pass: false
+            }' >"${temporary}"
+          mv "${temporary}" "${marker}"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -226,6 +255,18 @@ jobs:
 
       - name: Run keyless kind end-to-end scenarios
         run: ./scripts/e2e-kind.sh
+
+      - name: Run keyless evaluation acceptance
+        run: ./scripts/eval-kind.sh
+
+      - name: Upload keyless evaluation records
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: keyless-evals-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.KONTEXT_EVAL_DIR }}
+          if-no-files-found: error
+          retention-days: 5
 
       - name: Collect diagnostics on failure
         if: failure()

--- a/.github/workflows/provider-acceptance.yml
+++ b/.github/workflows/provider-acceptance.yml
@@ -46,9 +46,15 @@ jobs:
       KONTEXT_PROVIDER: ${{ inputs.provider }}
       KONTEXT_MODEL: ${{ inputs.model }}
       KONTEXT_PROVIDER_ENDPOINT: ${{ inputs.endpoint }}
+      KONTEXT_ACCEPTANCE_RECORD: ${{ runner.temp }}/provider-evals/acceptance.json
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Initialize provider acceptance record
+        env:
+          KONTEXT_ACCEPTANCE_INITIALIZE_ONLY: "true"
+        run: ./scripts/provider-acceptance-kind.sh
 
       - name: Validate provider selection
         run: |
@@ -113,6 +119,15 @@ jobs:
         env:
           KONTEXT_PROVIDER_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: ./scripts/provider-acceptance-kind.sh
+
+      - name: Upload provider acceptance record
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: provider-acceptance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.KONTEXT_ACCEPTANCE_RECORD }}
+          if-no-files-found: error
+          retention-days: 3
 
       - name: Collect redacted failure diagnostics
         if: failure()

--- a/EVALS.md
+++ b/EVALS.md
@@ -1,0 +1,117 @@
+# External evaluations
+
+`kontext-eval` runs evaluation cases from outside the workload. It creates
+ordinary typed `AgentRun` resources, waits for terminal status, collects the
+runtime Pod's logs and exit code while the Pod exists, grades the observation,
+and then deletes only the runs it created.
+
+Build and inspect the CLI:
+
+```sh
+make build-eval
+./bin/kontext-eval -help
+```
+
+Run a suite:
+
+```sh
+./bin/kontext-eval \
+  --suite evals/suites/keyless.yaml \
+  --records tmp/keyless.jsonl \
+  --summary tmp/keyless-summary.json
+```
+
+`--kubeconfig` selects an explicit file; otherwise the standard client-go
+loading rules apply. `KONTEXT_EVAL_RUNTIME_IMAGE` is the environment equivalent
+of `--runtime-image`. The flag wins when both are set. Runs are removed after
+collection unless `--keep-runs` is set.
+
+## Suite schema
+
+Suites are strict YAML. Unknown fields and invalid grader values are rejected.
+The runtime image may come from the case, suite defaults, or the CLI override.
+Model comparisons are represented as explicit cases with the same goal and
+different models; there is no implicit matrix expansion.
+
+```yaml
+apiVersion: kontext.dev/eval/v1alpha1
+kind: EvalSuite
+metadata:
+  name: keyless
+spec:
+  defaults:
+    namespace: kontext-system
+    timeout: 2m
+    runtimeImage: kontext-reference:dev
+  cases:
+    - id: fake-success-model-a
+      description: Deterministic reference-runtime success
+      agentRun:
+        goal: Return the expected answer
+        provider: fake
+        model: model-a
+        runtime: {}
+      graders:
+        - type: terminalPhase
+          phase: Succeeded
+        - type: statusResult
+          statusResult:
+            contains: expected
+        - type: structuredOutput
+          structuredOutput:
+            present: true
+            valid: true
+            mediaType: text/plain
+        - type: usageFields
+          usageFields: [tokens, inputTokens, outputTokens]
+        - type: envelopeOutcome
+          outcome: Succeeded
+        - type: executionModel
+          model: model-a
+        - type: eventCount
+          event: {type: tool, count: 0}
+        - type: duration
+          maxDuration: 30s
+        - type: podExitCode
+          exitCode: 0
+```
+
+Other deterministic graders are `envelopeErrorCode`, `envelopeTurns`,
+`envelopeToolCalls`, and `toolEvents`. A `toolEvents` expectation accepts
+`name`, `count`, and optional `isError`, `errorCode`, and `truncated` filters.
+Status-result matching supports exactly one of `exact`, `contains`, or
+`notContains`.
+
+The JSONL record contains only grader-requested status/model output, projected
+envelope fields, collection errors, and bounded event metadata rather than raw
+logs or `status.message`. The runner never automatically reads Pod environments
+or Secret values. Optional usage fields retain the distinction between missing
+and measured zero. A summary JSON file reports pass/fail totals and the record
+path.
+
+Artifact collection is grader-driven. Only fields named by deterministic
+graders are retained in a record. Phase and duration graders do not require a
+Pod that the wallclock controller has already deleted. Envelope graders parse
+the runtime container's authoritative termination message, event graders read
+only a bounded log tail, and exit-code graders require a terminated Pod.
+Missing or incomplete required artifacts fail the case.
+
+`scripts/eval-kind.sh` runs the complete keyless suite against the existing
+kind cluster, validates the records, checks controller timeout cleanup, and
+separately proves the no-wallclock Service example remains Running and
+recasts. See [`docs/evals.md`](docs/evals.md) for comparison guidance,
+privacy boundaries, and the protected pre-alpha provider acceptance step.
+
+## Optional judge
+
+`--judge-command` runs only after deterministic grading. The command receives a
+bounded observation on stdin and must return:
+
+```json
+{"pass":true,"score":0.9,"rationale":"brief explanation"}
+```
+
+The judge process receives a minimal environment and no kubeconfig, Pod
+environment, Secret values, raw logs, or private reasoning. A command failure,
+invalid response, or failing judge result is recorded separately and makes the
+CLI exit non-zero. Without the option, no model judge runs.

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ vulncheck: $(GOVULNCHECK) ## Scan for known Go vulnerabilities in reachable code
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
+.PHONY: build-eval
+build-eval: fmt vet ## Build the external evaluation runner.
+	go build -o bin/kontext-eval ./cmd/kontext-eval
+
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ Kontext adds two custom resources under `kontext.dev/v1alpha1`, deliberately mir
 
 An `AgentRun` can also be created standalone, without any owning `Agent` — useful for ad-hoc dispatch and demos.
 
-Agents themselves are **bring-your-own-runtime**: any container image that reads a few `KONTEXT_*` env vars, streams ordinary logs, and writes a JSON result to `/dev/termination-log` is a valid agent. Kontext never inspects what the agent does — only that I/O boundary. Structured consumers should read `.status.output`; `.status.result` remains its backward-compatible text projection. The full versioned contract is in [`SPEC.md`](SPEC.md).
+Agents themselves are **bring-your-own-runtime**. A plain Linux image can run
+with ordinary logs and no structured result; images that need result status can
+write the termination envelope natively or opt into stdout capture. Kontext
+never inspects what the agent does beyond that I/O boundary. Structured
+consumers should read `.status.output`; `.status.result` remains its
+backward-compatible text projection. The full versioned contract is in
+[`SPEC.md`](SPEC.md).
 
 ## Quickstart on kind
 
@@ -35,6 +41,7 @@ Requires Docker, [kind](https://kind.sigs.k8s.io/), and kubectl.
 ```bash
 make kind-install       # build operator + echo images, load into kind, install controller
 ./scripts/e2e-kind.sh   # end-to-end verification
+./scripts/eval-kind.sh  # deterministic evals against the same cluster
 ```
 
 The e2e script proves the two core behaviors:
@@ -72,9 +79,9 @@ kubectl get agentruns -w
 
 | Image | Purpose |
 |---|---|
-| [`runtimes/echo/`](runtimes/echo) | Keyless test runtime. Exercises the full contract (stdout thoughts, termination-log result, service heartbeat) without any API key. |
+| [`runtimes/echo/`](runtimes/echo) | Keyless control-plane conformance oracle. It still emits the accepted legacy termination payload during the v1alpha1 transition. |
 | [`runtimes/reference/`](runtimes/reference) | Maintained provider-neutral Go runtime with fake, Anthropic, and OpenAI-compatible transports plus a bounded built-in tool loop. |
-| [`runtimes/python-anthropic/`](runtimes/python-anthropic) | Real runtime backed by the Anthropic Messages API. Needs an `ANTHROPIC_API_KEY` secret via `spec.secretRef`. |
+| [`runtimes/python-anthropic/`](runtimes/python-anthropic) | Legacy Anthropic behavior oracle retained for compatibility; not the maintained primary runtime. |
 | [`runtimes/reporter/`](runtimes/reporter) | Reusable PID 1 supervisor. Preserves child logs and process semantics while producing the versioned result envelope. |
 
 Provider credentials are wired by the controller from a Kubernetes Secret into
@@ -103,6 +110,10 @@ only in that disposable Calico cluster. See
 [`runtimes/reference/README.md`](runtimes/reference/README.md) for the pinned
 image, command, resource checkpoint, and sandbox caveat.
 
+Mounted `knowledgeConfigMapRef` data is static context, not production RAG.
+Making a tool available does not guarantee model use; versioned tool events
+are the execution evidence. See [`docs/runtimes.md`](docs/runtimes.md).
+
 ### Capture results from an existing image
 
 An existing Linux container can opt into stdout result capture without adding
@@ -125,11 +136,36 @@ non-empty stdout line as text; `KontextEnvelope` accepts a
 installations must configure `KONTEXT_REPORTER_IMAGE`; `make kind-install`
 wires the locally built reporter automatically.
 
+The complete four-path example index (plain logs, final-line capture,
+structured capture, and native envelope) is in
+[`deploy/examples/v1alpha1/README.md`](deploy/examples/v1alpha1/README.md).
+
+## Evaluations
+
+`kontext-eval` evaluates workloads from outside the Pod. Deterministic graders
+run before any optional model judge. JSONL records retain only explicitly
+graded status/model output, projected envelope fields, bounded failure
+messages, and requested event metadata—never raw logs, Pod environments, or
+Secret values:
+
+```bash
+make build-eval
+./bin/kontext-eval --suite evals/suites/keyless.yaml
+```
+
+Pull-request CI runs the keyless suite in the existing kind cluster and uploads
+its machine-readable records. Authenticated transport acceptance remains a
+dispatch-only, environment-protected workflow; its short-lived artifact is the
+release evidence. A keyless or render-only run is not an authenticated
+provider acceptance. See [`docs/evals.md`](docs/evals.md).
+
 ## Governance
 
-Every run is bounded and auditable:
+Each `AgentRun` is isolated and auditable. Budgets and runtime limits are
+optional: task examples configure finite limits, while a long-running Service
+may intentionally omit `budget.wallclock`.
 
-- **Budgets** — `spec.budget.wallclock` is enforced by the controller (the Pod is killed and the run marked `BudgetExceeded`); token and dollar usage are reported by the runtime and recorded in `.status.usage`. The reference runtime checks token budgets against cumulative measured usage across provider requests. Tool follow-ups resend conversation context, and reasoning usage can exceed the visible output, so live model budgets need provider-specific headroom.
+- **Optional budgets** — when configured, `spec.budget.wallclock` is enforced by the controller (the Pod is killed and the run marked `BudgetExceeded`); token and dollar usage are reported by the runtime and recorded in `.status.usage`. The reference runtime checks configured token budgets against cumulative measured usage across provider requests. Tool follow-ups resend conversation context, and reasoning usage can exceed the visible output, so live model budgets need provider-specific headroom.
 - **Immutable run specs** — an `AgentRun` snapshots its configuration at creation, so history doesn't drift when the `Agent` changes.
 - **Standard lifecycle** — owner references give you GC cascade, conditions record transitions, and `kubectl` is the debugging surface.
 
@@ -143,6 +179,7 @@ make docker-build-all  # operator + all maintained runtime images
 make docker-build-reporter  # build the reusable result reporter image
 make docker-build-reference # build the model-agnostic reference runtime
 make kind-install      # build operator + echo, load into kind, install controller
+make build-eval        # compile the external evaluation runner
 make build             # compile operator binary to bin/manager
 make run               # run the controller locally against your kubeconfig
 ```
@@ -171,11 +208,17 @@ scripts/                   kind install + e2e
 |---|---|
 | [`SPEC.md`](SPEC.md) | API and runtime-image contract |
 | [`ROADMAP.md`](ROADMAP.md) | Milestones and locked decisions |
+| [`docs/runtimes.md`](docs/runtimes.md) | Runtime roles, result paths, static context, and tools |
+| [`docs/evals.md`](docs/evals.md) | Deterministic evals and provider acceptance records |
+| [`docs/operations.md`](docs/operations.md) | Infrastructure dependencies and failure modes |
+| [`docs/when-not-to-use-agents.md`](docs/when-not-to-use-agents.md) | Choosing a deterministic Job or script instead |
 | [`DEPRECATED.md`](DEPRECATED.md) | The earlier Python prototype, preserved on `deprecated/hackathon-python` |
 
 ## Status
 
 `v1alpha1` is alpha on purpose: the API shape is allowed to evolve. `Service` mode and standalone `AgentRun`s are implemented and covered by envtest and kind e2e; `Task` and `Scheduled` modes exist in the schema but are not reconciled yet.
+
+Publishing immutable versioned images remains separate release work.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,15 +35,29 @@ Kontext provides generic `Agent` and `AgentRun` primitives. Consumer-specific co
 - Service reconciler keeps one live child `AgentRun` and re-casts with backoff.
 - **Done when:** deleting the live Pod mints a replacement run (`scripts/e2e-kind.sh`).
 
-### M4 — Bring-your-own-runtime hardening
-- Echo runtime shipped (`runtimes/echo/`). Anthropic Python runner remains under `runtimes/python-anthropic/`.
+### M4 — Bring-your-own-runtime hardening (implementation complete)
+- The echo conformance oracle remains keyless and uses the accepted legacy
+  payload during the v1alpha1 transition. The Python Anthropic image is a
+  legacy behavior oracle, not the maintained primary runtime.
 - Versioned results, the reusable reporter, and optional stdout capture support existing Linux images with explicit commands.
 - The maintained Go reference runtime has a provider-neutral core, deterministic fake-provider path, and direct Anthropic and OpenAI-compatible HTTP transports.
 - The maintained runtime has a bounded provider-neutral loop with allowlisted knowledge, Kubernetes-read, and shell tools.
+- Issue #20's implementation adds allowlisted stdio/HTTP MCP tools and the
+  isolated Playwright acceptance path without adding MCP vocabulary to the
+  CRDs.
+- Issue #21 adds external deterministic evals, all four bring-your-own result
+  paths, keyless failure acceptance, operations guidance, and bounded provider
+  acceptance records. A protected authenticated provider dispatch is still a
+  required pre-alpha release action, not evidence produced by keyless CI.
 
-### M5 — Governance
-- Per-agent ServiceAccount, finalizers, budget enforcement, CEL validation on the CRDs, events on transitions.
-- **Done when:** demo: "capped at $2, ran under this SA, failed on budget, Kubernetes recorded the lifecycle."
+### M5 — Governance (remaining)
+- Expand CEL/admission validation beyond the shipped immutable-run and
+  restricted-security checks.
+- Add richer Kubernetes Events and metrics for budget decisions, failures, and
+  Service recasts.
+- Decide whether authoritative dollar-limit enforcement and finalizer-backed
+  cleanup belong in the alpha contract, then implement only the retained
+  behavior.
 
 ### M6 — Packaging + observability
 - Kustomize install exists under `config/default`. Helm/metrics still open.
@@ -54,5 +68,6 @@ Kontext provides generic `Agent` and `AgentRun` primitives. Consumer-specific co
 ## Immediate next actions
 
 1. M2 Task templating when a concrete consumer needs parameterized triggers.
-2. M5 governance (CEL, per-agent SA, richer events).
-3. Publish immutable maintained runtime images and run protected provider acceptance.
+2. M5 governance (remaining CEL/admission coverage, Events, and metrics).
+3. Dispatch and retain the protected provider acceptance record before alpha.
+4. Publish immutable maintained runtime images as separately tracked release work.

--- a/SPEC.md
+++ b/SPEC.md
@@ -51,6 +51,7 @@ The reusable definition. Cluster-namespaced. Has a status subresource.
 | `budget.wallclock`   | duration string                       | no  | e.g. `5m`. Enforced by controller.                             |
 | `budget.dollars`     | number ≥ 0                            | no  |                                                                |
 | `secretRef.name`     | string                                | no  | Provider credentials Secret.                                   |
+| `knowledgeConfigMapRef.name` | string                       | no  | Static ConfigMap context mounted read-only at `/kontext/knowledge`. |
 | `serviceAccountName` | string                                | no  | Per-agent identity.                                            |
 | `env`                | []EnvVar                              | no  | Extra literal or Secret-backed env passed to the Pod.          |
 | `schedule`           | string (cron)                         | no  | Only for `Scheduled`.                                          |
@@ -90,6 +91,7 @@ One bounded execution. Maps to exactly one Pod. **Spec is immutable after creati
 | `tools`              | []string | no  |                                                  |
 | `budget`             | object   | no  | Resolved snapshot.                               |
 | `secretRef.name`     | string   | no  |                                                  |
+| `knowledgeConfigMapRef.name` | string | no | Static ConfigMap context mounted read-only at `/kontext/knowledge`. |
 | `serviceAccountName` | string   | no  |                                                  |
 | `env`                | []EnvVar | no  | Resolved literal or Secret-backed env snapshot.  |
 | `runtime.image`      | string   | yes | Resolved from Agent.                             |
@@ -139,8 +141,10 @@ Any container can be a Kontext agent if it follows this. Kontext never inspects 
 The controller injects, on the Pod:
 
 - Env vars: `KONTEXT_GOAL`, `KONTEXT_MODEL`, `KONTEXT_PROVIDER`, `KONTEXT_TOOLS` (comma-separated), `KONTEXT_BUDGET_TOKENS`, `KONTEXT_BUDGET_WALLCLOCK`, `KONTEXT_BUDGET_DOLLARS`, `KONTEXT_AGENT_NAME`, `KONTEXT_RUN_NAME`.
-- Optionally a mounted `/kontext/input.json` with the same data (richer/structured payloads).
 - Provider credentials mounted from `secretRef` as env (e.g. `ANTHROPIC_API_KEY`).
+- Optional static ConfigMap context from `knowledgeConfigMapRef`, mounted
+  read-only at `/kontext/knowledge`. This is not RAG: the control plane does no
+  ingestion, embedding, ranking, or retrieval.
 - Generic `spec.env` entries. Each entry selects exactly one literal `value` or
   `valueFrom.secretKeyRef{name,key}`. Controller-managed variables cannot be
   overridden through either form. Secret values remain Kubernetes Secret data;
@@ -161,8 +165,15 @@ The controller injects, on the Pod:
 
 ### Output — result
 
-- On completion, write a compact versioned envelope to
-  `/dev/termination-log` (and optionally `/kontext/result.json`):
+The terminal envelope is optional at the control-plane boundary. An unchanged
+plain image that exits `0` without writing `/dev/termination-log` succeeds with
+absent `status.output` and an empty `status.result`. Native runtimes and images
+using injected stdout capture write richer structured output, usage, timing,
+and execution metadata.
+
+On completion, a runtime that provides a structured result writes a compact
+versioned envelope to `/dev/termination-log` (and may also write
+`/kontext/result.json`):
 
 ```json
 {
@@ -238,10 +249,11 @@ recorded only when they are present in the payload. For compatibility, the
 process exit code remains authoritative for legacy payloads; a legacy `error`
 field is retained as diagnostic text but does not turn exit `0` into failure.
 
-Exit `0` plus a successful envelope means success. A non-zero process exit
-always fails the run. A failed envelope also fails the run even if the process
-exits zero. Malformed or partially written JSON is an actionable failure, not
-a successful plain-text result.
+Exit `0` with no termination payload or with a successful envelope means
+success. A non-zero process exit always fails the run. A failed envelope also
+fails the run even if the process exits zero. If a JSON-looking termination
+payload is present, malformed or partially written JSON remains an actionable
+failure rather than silently becoming a successful plain-text result.
 
 ### Optional result reporter
 
@@ -287,13 +299,23 @@ otherwise empty shared volume; it drops capabilities, disables privilege
 escalation, and uses a read-only root filesystem. The workload container's own
 user and security context remain unchanged.
 
+### Runtime roles
+
+`runtimes/echo` is the deterministic control-plane conformance oracle. During
+the v1alpha1 transition it intentionally writes the legacy termination payload
+documented above. `runtimes/reference` is the maintained model-backed runtime.
+`runtimes/python-anthropic` is retained only as a legacy behavior oracle.
+Arbitrary conforming images remain supported and need not use any of these
+implementations.
+
 ### Maintained reference runtime
 
 `runtimes/reference` is the optional maintained Go runtime. It owns a small
 provider-neutral completion loop behind a normalized provider interface; it is
 not an agent framework. The runtime image bundles the reporter as PID 1 and
-emits its final versioned envelope through the `KONTEXT_RESULT:` stream
-contract.
+uses the internal `KONTEXT_RESULT:` capture protocol so the reporter can write
+the authoritative versioned envelope to the runtime container's termination
+message. Raw logs remain an event and diagnostic stream.
 
 The initial keyless `fake` provider is deterministic and exercises the same
 configuration, conversation, event, result, cancellation, and failure paths

--- a/cmd/kontext-eval/main.go
+++ b/cmd/kontext-eval/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/kontext-dev/kontext/internal/eval"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	os.Exit(eval.Execute(ctx, os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/deploy/examples/v1alpha1/README.md
+++ b/deploy/examples/v1alpha1/README.md
@@ -1,0 +1,47 @@
+# v1alpha1 examples
+
+These manifests assume the Kontext CRDs and controller are installed. The kind
+quickstart builds and loads the local `kontext-*:dev` images; provider examples
+additionally require the named
+namespace-local Secret. Apply namespaced manifests with `kubectl apply -f`.
+
+## Bring your own image
+
+| Path | Manifest | Prerequisite | Expected observation |
+|---|---|---|---|
+| Plain image, logs only | `plain-logs-run.yaml` | `kontext-stdout-fixture:dev` | `Succeeded`; ordinary `kubectl logs`; empty `status.result` and no `status.output`. No reporter is injected. |
+| Injected final-line capture | `stdout-last-line-run.yaml` | Fixture and configured `KONTEXT_REPORTER_IMAGE` | `Succeeded`; logs remain available; `status.result` is `final answer from busybox`. |
+| Injected structured capture | `stdout-envelope-run.yaml` | Fixture and configured reporter image | `Succeeded`; the prefixed envelope supplies JSON output and measured usage. |
+| Native versioned envelope | `native-envelope-run.yaml` | Fixture image | `Succeeded`; the process writes `kontext.dev/result/v1alpha1` to `/dev/termination-log` itself. `runtime.result` is omitted, so the controller does not inject a reporter. |
+
+`stdout-failure-run.yaml` and `stdout-signal-run.yaml` demonstrate that injected
+capture preserves a child exit code and forwards termination. A plain image is
+still a valid workload when it only needs lifecycle and logs; structured
+results are opt-in.
+
+## Runtime and tool examples
+
+- `reference-fake-run.yaml` and `reference-fake-tool-run.yaml` are deterministic
+  keyless reference-runtime paths.
+- `reference-tools-run.yaml` demonstrates built-in tools. A listed tool is
+  available to the model, not guaranteed to be called.
+- `reference-kind-policy-runs.yaml` exercises runtime allowlists, namespace
+  RBAC, restricted Pod security, and wallclock cleanup.
+- `reference-playwright-*.yaml` exercises a separately deployed MCP server;
+  the Calico-backed script is required before treating NetworkPolicy behavior
+  as evidence.
+- `reference-anthropic-run.yaml` and
+  `reference-openai-compatible-run.yaml` require provider credentials created
+  from `provider-secrets.example.yaml` or an equivalent Secret.
+
+`knowledgeConfigMapRef` mounts static, versioned context at
+`/kontext/knowledge`. It is useful for small fixtures and operating
+instructions; it is not production retrieval or RAG.
+
+## Service mode
+
+`echo-service-agent.yaml` is intentionally long-running. It omits
+`spec.budget.wallclock`, so the controller does not set a wallclock deadline.
+The Pod remains `Running`; deleting it causes the Service controller to mint a
+fresh `AgentRun` with backoff. `scripts/eval-kind.sh` checks both the omitted
+deadline and recast behavior.

--- a/deploy/examples/v1alpha1/echo-service-agent.yaml
+++ b/deploy/examples/v1alpha1/echo-service-agent.yaml
@@ -13,6 +13,8 @@ spec:
   env:
     - name: KONTEXT_MODE
       value: service
+  # Long-running Service: budget.wallclock is intentionally omitted. The
+  # controller must not impose a task-style deadline.
   backoff:
     initialSeconds: 3
     maxSeconds: 15

--- a/deploy/examples/v1alpha1/native-envelope-run.yaml
+++ b/deploy/examples/v1alpha1/native-envelope-run.yaml
@@ -1,0 +1,17 @@
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: native-envelope
+spec:
+  goal: Write a native versioned termination envelope.
+  provider: echo
+  model: fixture-model
+  runtime:
+    image: kontext-stdout-fixture:dev
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        echo "ordinary native workload log"
+        printf '%s' '{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","output":{"mediaType":"application/json","value":{"answer":"native"}},"usage":{"inputTokens":0,"outputTokens":1,"totalTokens":1}}' > /dev/termination-log
+  budget:
+    wallclock: 2m

--- a/deploy/examples/v1alpha1/plain-logs-run.yaml
+++ b/deploy/examples/v1alpha1/plain-logs-run.yaml
@@ -1,0 +1,17 @@
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: plain-logs
+spec:
+  goal: Run an ordinary Linux process without structured result capture.
+  provider: echo
+  model: fixture-model
+  runtime:
+    image: kontext-stdout-fixture:dev
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        echo "ordinary image log"
+        echo "no result reporter is injected"
+  budget:
+    wallclock: 2m

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -1,0 +1,93 @@
+# Evaluations
+
+Evaluations run outside agent Pods. `kontext-eval` creates ordinary
+`AgentRun`s, waits for terminal status, collects only the artifacts required
+by configured graders, writes bounded JSONL records, and removes the runs it
+created.
+
+## Deterministic first
+
+Deterministic graders always run before an optional model judge. They can
+check terminal phase, status output, measured usage presence, versioned
+envelope fields, event/tool counts, duration, and process exit code. A judge
+cannot turn a failed deterministic grade into a pass; judge errors also fail
+the case.
+
+Artifact requirements follow the grader:
+
+- phase and duration graders can pass after a controller has deleted the Pod;
+- result, output, and usage are read from `AgentRun` status only when requested;
+- envelope graders parse the runtime container's termination message;
+- event graders read a bounded runtime-log tail;
+- exit-code graders require the terminated runtime Pod.
+
+This is why the wallclock case can grade `BudgetExceeded` after Pod cleanup,
+while a missing tool event or result envelope remains a collection failure.
+
+## Comparing cases
+
+Represent a comparison as explicit cases with the same goal and controlled
+configuration. Change one variable, such as the opaque model ID, and grade the
+same stable output plus each case's `execution.model`. Do not infer model
+quality from one changing live response. First repeat the same prompt and model
+to estimate ordinary variance; then compare another model with the same prompt,
+limits, tools, context, and grader. Retain normalized usage and duration, and
+compare against a deterministic Job/script baseline for the same task.
+
+The keyless suite at `evals/suites/keyless.yaml` covers:
+
+- one goal through two opaque fake model IDs;
+- tool used once and tool available but unused;
+- namespace-RBAC denial;
+- empty provider credential after Pod startup;
+- unreachable provider endpoint;
+- controller wallclock cancellation and Pod cleanup;
+- malformed provider response;
+- reporter-preserved process crash.
+
+Run it against the already-installed local kind cluster:
+
+```bash
+KONTEXT_EVAL_DIR="$PWD/eval-results/kind" ./scripts/eval-kind.sh
+```
+
+The script also proves the no-wallclock Service example remains Running and
+recasts after Pod deletion. Pull-request CI uses no provider credentials or
+external provider endpoint.
+
+## Records and privacy
+
+Eval records use `kontext.dev/eval/v1alpha1`. They may contain status/model
+output only when a grader explicitly requests it. They do not retain
+`status.message`; failure evidence is the phase, projected envelope error code,
+grades, and collection errors. Envelope records are projections limited to the
+requested outcome, error code, model, turn count, or tool-call count. The runner
+never automatically reads Pod environments, Secret values, raw logs, artifacts,
+extensions, request IDs, or private reasoning. Optional usage retains missing
+versus measured-zero semantics.
+
+The dispatch-only provider workflow writes a separate bounded
+`ProviderAcceptanceRecord` with provider, opaque model, scenario, commit/run
+identity, phase, duration, measured usage, turns, tool calls, and pass/fail.
+It initializes a `NotStarted` failed record before image or cluster work and
+atomically replaces it when the acceptance script runs, so infrastructure
+failures still leave non-secret evidence. Its short-lived artifact is the
+acceptance record; failure diagnostics remain redacted separately.
+
+Keyless CI similarly creates a small `EvalRunMarker` before image builds. A
+successful `scripts/eval-kind.sh` removes the marker after writing and
+validating JSONL/summary output; an earlier failure leaves the marker visible
+in the always-uploaded artifact.
+
+## Protected pre-alpha acceptance
+
+Before an alpha release, a maintainer must dispatch `.github/workflows/provider-acceptance.yml`
+against the protected `provider-acceptance` environment for each maintained
+transport being released. Select a small supported model, review endpoint and
+pricing, approve the environment, and require the workflow to pass. Download
+the `provider-acceptance-<run>-<attempt>` artifact and retain
+`acceptance.json` with the release evidence.
+
+A local render or keyless run is not an authenticated provider acceptance.
+Without the protected credentials, record that the dispatch remains pending;
+do not claim a live run happened.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,69 @@
+# Operations and failure boundaries
+
+An `AgentRun` depends on more than its prompt. Treat these dependencies as
+part of the workload specification and evaluation environment.
+
+## Images and startup
+
+- Every node must be able to pull the runtime image, and reporter injection
+  additionally requires the operator-configured reporter image.
+- Pin production images by immutable digest and publish versioned images as a
+  separate release step. Local `:dev` tags are only for kind.
+- A missing image, incompatible architecture, invalid command, failed init
+  container, eviction, or unschedulable Pod can leave a run Pending or Failed
+  before runtime code starts.
+- Plain images keep logs but have no structured output unless they write a
+  termination payload or opt into reporter capture.
+
+## Identity, secrets, and network
+
+- Provider credentials are namespace-local Kubernetes Secrets. An absent
+  Secret/key prevents Pod startup; an existing empty key lets the Pod start
+  and the reference runtime reports `missing_provider_credentials`.
+- Use a dedicated ServiceAccount. Runtime tool allowlists do not bypass RBAC;
+  `kubernetes_read` can still return `kubernetes_rbac_denied`.
+- NetworkPolicy behavior depends on an enforcing CNI. kindnet does not enforce
+  policy, so the policy acceptance installs Calico. DNS, provider endpoints,
+  proxies, certificates, and cloud-metadata routes are separate dependencies.
+- Provider outages, authentication changes, quotas, and rate limits normalize
+  to stable codes where possible. Provider messages and HTTP behavior can
+  still change independently of Kontext.
+
+## Budgets, retries, and interruption
+
+The controller is authoritative for `budget.wallclock`: after expiry it marks
+the run `BudgetExceeded` and deletes the Pod. Omission means no controller
+deadline. Token and dollar fields depend on runtime/provider measurements and
+may be absent.
+
+The reference runtime does not retry provider requests or failed tool calls.
+That avoids duplicating side effects. MCP transport reconnection can prepare a
+later call but never repeats the failed call. If an application adds retries,
+bound them, use idempotency controls, and include repeated usage in budgets.
+
+Node loss, eviction, controller restart, and Pod deletion can interrupt work.
+Service mode recasts a fresh run; it does not restore in-memory conversation.
+Task callers must decide whether a new run is safe.
+
+## Logs, status, and retention
+
+`kubectl logs` is the detailed operational stream. `AgentRun.status` is a
+bounded terminal summary. Kubernetes termination messages have a 4096-byte
+limit, so envelopes are compacted and may carry truncation metadata. Do not
+put transcripts or large artifacts in status/etcd; store them externally and
+place bounded references in the envelope.
+
+Logs may disappear with Pod cleanup or retention. Collect them before deleting
+a run when an event/envelope/exit grader requires them. Status-only evaluation
+can remain valid after the wallclock controller removes the Pod. Redact and
+bound diagnostics before sharing because provider/runtime errors can contain
+workload-specific values.
+
+Useful first checks:
+
+```bash
+kubectl get agentrun,pod -n <namespace> -o wide
+kubectl describe agentrun <name> -n <namespace>
+kubectl logs <pod> -n <namespace> -c runtime
+kubectl get events -n <namespace> --sort-by=.lastTimestamp
+```

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -1,0 +1,63 @@
+# Runtime choices
+
+Kontext controls Pods; the container controls agent behavior. Choose the
+smallest integration that supplies the result semantics you need.
+
+## Three runtime roles
+
+- The echo image is the deterministic control-plane conformance oracle. It
+  proves Pod lifecycle, status projection, and Service recast without a
+  provider. During the v1alpha1 transition it still writes the accepted legacy
+  `{result,tokensUsed,dollarsUsed}` termination payload.
+- `runtimes/reference` is the maintained model-backed Go runtime. Its fake
+  provider is keyless; its Anthropic and OpenAI-compatible transports require
+  Secrets. It emits versioned events and a
+  `kontext.dev/result/v1alpha1` envelope.
+- Bring-your-own images are first-class. Kontext does not require the
+  maintained runtime. `runtimes/python-anthropic` is retained as a legacy
+  behavior oracle, not the maintained primary runtime.
+
+## Result capture
+
+An image can use one of four paths:
+
+1. Run unchanged with ordinary logs and no structured result.
+2. Request injected `Stdout`/`LastLine` capture for an explicit command.
+3. Request injected `Stdout`/`KontextEnvelope` capture when the child emits a
+   prefixed versioned envelope.
+4. Write a native versioned envelope to `/dev/termination-log`; omit
+   `runtime.result` so no control-plane reporter is injected.
+
+Last-line capture is heuristic and cannot infer usage. Envelope capture
+preserves typed output, usage, timing, and execution metadata. The termination
+message is limited to 4096 bytes, so it is a summary rather than a transcript;
+keep full events and diagnostics outside Kubernetes status. The Pod termination
+message and its `AgentRun.status` projection are authoritative for terminal
+output; raw logs are only the event/diagnostic stream.
+
+See `deploy/examples/v1alpha1/README.md` for one manifest for each path.
+
+## Context and tools
+
+`knowledgeConfigMapRef` mounts static ConfigMap data at
+`/kontext/knowledge`. This is useful for small, versioned instructions and
+deterministic fixtures. It is not production RAG: there is no ingestion,
+embedding, ranking, freshness policy, authorization-aware retrieval, or
+source-quality measurement.
+
+Putting a tool in `spec.tools` makes it available to the runtime/model. It does
+not guarantee a model will call it. Tool events are the execution evidence:
+inspect the tool name, count, error flag, stable error code, timing, and
+truncation metadata. Kubernetes RBAC, ServiceAccounts, mounts, container
+security, and enforced NetworkPolicy remain authoritative even when the
+runtime allows a tool.
+
+## Service workloads
+
+A Service image must stay alive. Omit `budget.wallclock` when the service has
+no intended lifetime; the controller then does not apply a wallclock deadline.
+If its Pod exits or is deleted, the Service controller creates a fresh
+`AgentRun` with backoff. `echo-service-agent.yaml` is the keyless example.
+
+Versioned image publication is release work, separate from this runtime
+contract and its source-level acceptance tests.

--- a/docs/when-not-to-use-agents.md
+++ b/docs/when-not-to-use-agents.md
@@ -1,0 +1,34 @@
+# When not to use an agent
+
+Use an agent when the task genuinely needs model judgment over variable input
+and the extra latency, cost, nondeterminism, and operational dependencies are
+acceptable. Kubernetes makes those dependencies visible; it does not remove
+them.
+
+A deterministic Job, controller, or script is usually better when:
+
+- the input and desired transformation have a complete, testable rule;
+- exact repeatability or byte-for-byte output is required;
+- a command/API call already performs the task directly;
+- retries could duplicate a destructive side effect;
+- the task is on a latency-critical path;
+- provider network access, quota, or credential handling is unjustified;
+- success cannot be checked more reliably than asking another model;
+- the workload needs durable workflow state that the runtime does not provide.
+
+Start with a deterministic baseline. Measure correctness, wall time, resource
+use, and failure recovery on the same inputs. Add a model only where it
+improves a named metric enough to justify provider usage and new failure modes.
+Run deterministic graders before any optional model judge.
+
+For mixed workflows, keep parsing, validation, authorization, and irreversible
+actions deterministic. Give the agent a bounded proposal step, validate its
+structured output, and let ordinary code apply approved changes. A tool being
+available is not evidence that it ran; require tool events or downstream
+state as proof.
+
+Kontext is also not a workflow engine, retrieval platform, or durable memory
+store. Mounted ConfigMap knowledge is static context, not RAG. If the product
+needs fresh authorization-aware retrieval, checkpoints, compensation, or
+multi-step durable orchestration, use systems designed for those concerns and
+run only the model-dependent step as an `AgentRun`.

--- a/evals/fixtures/keyless-setup.yaml
+++ b/evals/fixtures/keyless-setup.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eval-knowledge
+data:
+  guide.txt: keyless knowledge fixture
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eval-no-rbac
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: eval-empty-anthropic
+type: Opaque
+stringData:
+  ANTHROPIC_API_KEY: ""
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: eval-dummy-openai
+type: Opaque
+stringData:
+  OPENAI_API_KEY: keyless-placeholder

--- a/evals/suites/keyless.yaml
+++ b/evals/suites/keyless.yaml
@@ -1,0 +1,273 @@
+apiVersion: kontext.dev/eval/v1alpha1
+kind: EvalSuite
+metadata:
+  name: keyless
+spec:
+  defaults:
+    namespace: kontext-eval
+    timeout: 45s
+    runtimeImage: kontext-reference:dev
+  cases:
+    - id: same-goal-model-a
+      description: Same deterministic goal through the first opaque model identifier
+      agentRun:
+        goal: Return stable keyless output.
+        provider: fake
+        model: opaque/vendor-model-a@eval
+        runtime: {}
+        env:
+          - name: KONTEXT_FAKE_SCENARIO
+            value: success
+        budget:
+          wallclock: 30s
+      graders:
+        - type: terminalPhase
+          phase: Succeeded
+        - type: statusResult
+          statusResult:
+            exact: "Fake provider completed goal: Return stable keyless output."
+        - type: executionModel
+          model: opaque/vendor-model-a@eval
+        - type: envelopeOutcome
+          outcome: Succeeded
+        - type: podExitCode
+          exitCode: 0
+
+    - id: same-goal-model-b
+      description: Same deterministic goal through a different opaque model identifier
+      agentRun:
+        goal: Return stable keyless output.
+        provider: fake
+        model: opaque/vendor-model-b@eval
+        runtime: {}
+        env:
+          - name: KONTEXT_FAKE_SCENARIO
+            value: success
+        budget:
+          wallclock: 30s
+      graders:
+        - type: terminalPhase
+          phase: Succeeded
+        - type: statusResult
+          statusResult:
+            exact: "Fake provider completed goal: Return stable keyless output."
+        - type: executionModel
+          model: opaque/vendor-model-b@eval
+        - type: envelopeOutcome
+          outcome: Succeeded
+        - type: podExitCode
+          exitCode: 0
+
+    - id: read-knowledge-used
+      description: An allowlisted knowledge tool is called exactly once
+      agentRun:
+        goal: Read guide.txt exactly once.
+        provider: fake
+        model: opaque/tool-model@eval
+        tools: [read_knowledge]
+        knowledgeConfigMapRef:
+          name: eval-knowledge
+        runtime: {}
+        env:
+          - name: KONTEXT_FAKE_SCENARIO
+            value: tool
+          - name: KONTEXT_FAKE_TOOL_NAME
+            value: read_knowledge
+          - name: KONTEXT_FAKE_TOOL_ARGUMENTS
+            value: '{"path":"guide.txt"}'
+          - name: KONTEXT_MAX_TURNS
+            value: "3"
+          - name: KONTEXT_MAX_TOOL_CALLS
+            value: "1"
+        budget:
+          wallclock: 30s
+      graders:
+        - type: terminalPhase
+          phase: Succeeded
+        - type: statusResult
+          statusResult:
+            exact: "Fake provider received read_knowledge result: keyless knowledge fixture"
+        - type: envelopeTurns
+          turns: 2
+        - type: envelopeToolCalls
+          toolCalls: 1
+        - type: toolEvents
+          tool:
+            name: read_knowledge
+            count: 1
+            isError: false
+        - type: podExitCode
+          exitCode: 0
+
+    - id: read-knowledge-available-not-used
+      description: Tool availability does not imply that the provider calls it
+      agentRun:
+        goal: Complete without calling the available tool.
+        provider: fake
+        model: opaque/no-tool-model@eval
+        tools: [read_knowledge]
+        knowledgeConfigMapRef:
+          name: eval-knowledge
+        runtime: {}
+        env:
+          - name: KONTEXT_FAKE_SCENARIO
+            value: success
+        budget:
+          wallclock: 30s
+      graders:
+        - type: terminalPhase
+          phase: Succeeded
+        - type: envelopeTurns
+          turns: 1
+        - type: envelopeToolCalls
+          toolCalls: 0
+        - type: eventCount
+          event:
+            type: tool
+            count: 0
+
+    - id: kubernetes-read-rbac-denied
+      description: The runtime allows ConfigMaps but the namespace ServiceAccount does not
+      agentRun:
+        goal: Attempt one ConfigMap list.
+        provider: fake
+        model: opaque/rbac-model@eval
+        tools: [kubernetes_read]
+        serviceAccountName: eval-no-rbac
+        runtime: {}
+        env:
+          - name: KONTEXT_FAKE_SCENARIO
+            value: tool
+          - name: KONTEXT_FAKE_TOOL_NAME
+            value: kubernetes_read
+          - name: KONTEXT_FAKE_TOOL_ARGUMENTS
+            value: '{"operation":"list","resource":"configmaps"}'
+          - name: KONTEXT_MAX_TURNS
+            value: "3"
+          - name: KONTEXT_MAX_TOOL_CALLS
+            value: "1"
+        budget:
+          wallclock: 30s
+      graders:
+        - type: terminalPhase
+          phase: Succeeded
+        - type: envelopeToolCalls
+          toolCalls: 1
+        - type: toolEvents
+          tool:
+            name: kubernetes_read
+            count: 1
+            isError: true
+            errorCode: kubernetes_rbac_denied
+
+    - id: missing-provider-credential
+      description: An existing Secret key resolves to an empty provider credential
+      agentRun:
+        goal: Fail after the Pod starts and validates its credential.
+        provider: anthropic
+        model: opaque/credential-model@eval
+        secretRef:
+          name: eval-empty-anthropic
+        runtime: {}
+        budget:
+          wallclock: 30s
+      graders:
+        - type: terminalPhase
+          phase: Failed
+        - type: envelopeOutcome
+          outcome: Failed
+        - type: envelopeErrorCode
+          errorCode: missing_provider_credentials
+        - type: podExitCode
+          exitCode: 1
+
+    - id: provider-network-failure
+      description: A dummy credential reaches a deterministic unreachable loopback endpoint
+      agentRun:
+        goal: Fail at the unreachable provider endpoint.
+        provider: openai-compatible
+        model: opaque/network-model@eval
+        secretRef:
+          name: eval-dummy-openai
+        runtime: {}
+        env:
+          - name: KONTEXT_PROVIDER_ENDPOINT
+            value: http://127.0.0.1:1/chat/completions
+        budget:
+          wallclock: 30s
+      graders:
+        - type: terminalPhase
+          phase: Failed
+        - type: envelopeOutcome
+          outcome: Failed
+        - type: envelopeErrorCode
+          errorCode: provider_network_error
+        - type: podExitCode
+          exitCode: 1
+
+    - id: controller-wallclock
+      description: The controller cancels a running Pod and removes it at wallclock expiry
+      timeout: 30s
+      agentRun:
+        goal: Remain active until the controller cancels this run.
+        provider: fake
+        model: opaque/timeout-model@eval
+        runtime: {}
+        env:
+          - name: KONTEXT_FAKE_SCENARIO
+            value: delay
+          - name: KONTEXT_FAKE_DELAY
+            value: 30s
+        budget:
+          wallclock: 3s
+      graders:
+        - type: terminalPhase
+          phase: BudgetExceeded
+        - type: duration
+          maxDuration: 20s
+
+    - id: malformed-provider-response
+      description: The fake provider returns a malformed normalized response
+      agentRun:
+        goal: Reject the malformed provider response.
+        provider: fake
+        model: opaque/malformed-model@eval
+        runtime: {}
+        env:
+          - name: KONTEXT_FAKE_SCENARIO
+            value: malformed
+        budget:
+          wallclock: 30s
+      graders:
+        - type: terminalPhase
+          phase: Failed
+        - type: envelopeOutcome
+          outcome: Failed
+        - type: envelopeErrorCode
+          errorCode: invalid_provider_response
+        - type: podExitCode
+          exitCode: 1
+
+    - id: reporter-process-crash
+      description: Reporter injection preserves a workload process exit code
+      agentRun:
+        goal: Preserve the fixture process crash.
+        provider: echo
+        model: opaque/crash-model@eval
+        runtime:
+          image: kontext-stdout-fixture:dev
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "fixture process is exiting" >&2
+              exit 7
+          result:
+            source: Stdout
+            format: LastLine
+        budget:
+          wallclock: 30s
+      graders:
+        - type: terminalPhase
+          phase: Failed
+        - type: podExitCode
+          exitCode: 7

--- a/internal/eval/cli.go
+++ b/internal/eval/cli.go
@@ -1,0 +1,151 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+)
+
+func Execute(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("kontext-eval", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var (
+		suitePath    string
+		namespace    string
+		kubeconfig   string
+		runtimeImage string
+		recordPath   string
+		summaryPath  string
+		judgeCommand string
+		keepRuns     bool
+	)
+	flags.StringVar(&suitePath, "suite", "", "path to an EvalSuite YAML file (required)")
+	flags.StringVar(&namespace, "namespace", "", "namespace override for created AgentRuns")
+	flags.StringVar(&kubeconfig, "kubeconfig", "", "path to kubeconfig (defaults to standard loading rules)")
+	flags.StringVar(&runtimeImage, "runtime-image", os.Getenv("KONTEXT_EVAL_RUNTIME_IMAGE"), "runtime image override (or KONTEXT_EVAL_RUNTIME_IMAGE)")
+	flags.StringVar(&recordPath, "records", "", "JSONL record output path")
+	flags.StringVar(&summaryPath, "summary", "", "JSON summary output path")
+	flags.StringVar(&judgeCommand, "judge-command", "", "optional external judge command; failures fail the evaluation")
+	flags.BoolVar(&keepRuns, "keep-runs", false, "keep AgentRuns created by this invocation")
+	flags.Usage = func() {
+		fmt.Fprintf(stderr, "Usage: kontext-eval --suite FILE [options]\n\n")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if suitePath == "" {
+		fmt.Fprintln(stderr, "--suite is required")
+		flags.Usage()
+		return 2
+	}
+	suite, err := LoadSuite(suitePath, runtimeImage)
+	if err != nil {
+		fmt.Fprintf(stderr, "load suite: %v\n", err)
+		return 2
+	}
+	if namespace != "" {
+		suite.Spec.Defaults.Namespace = namespace
+	}
+	startedAt := time.Now().UTC()
+	if recordPath == "" || summaryPath == "" {
+		base := filepath.Join(
+			"eval-results",
+			NameForCase(suite.Metadata.Name, startedAt.Format("20060102t150405z"), ""),
+		)
+		if recordPath == "" {
+			recordPath = base + ".jsonl"
+		}
+		if summaryPath == "" {
+			summaryPath = base + ".summary.json"
+		}
+	}
+
+	config, err := loadRESTConfig(kubeconfig)
+	if err != nil {
+		fmt.Fprintf(stderr, "load kubeconfig: %v\n", err)
+		return 2
+	}
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		fmt.Fprintf(stderr, "configure core scheme: %v\n", err)
+		return 2
+	}
+	if err := kontextv1alpha1.AddToScheme(scheme); err != nil {
+		fmt.Fprintf(stderr, "configure Kontext scheme: %v\n", err)
+		return 2
+	}
+	controllerClient, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		fmt.Fprintf(stderr, "create Kubernetes client: %v\n", err)
+		return 2
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		fmt.Fprintf(stderr, "create Kubernetes log client: %v\n", err)
+		return 2
+	}
+	var judge Judge
+	if strings.TrimSpace(judgeCommand) != "" {
+		judge = CommandJudge{Command: judgeCommand}
+	}
+	runner := Runner{
+		Client: controllerClient,
+		Logs:   KubernetesLogFetcher{Client: clientset},
+		Options: RunnerOptions{
+			Namespace: namespace,
+			KeepRuns:  keepRuns,
+			Judge:     judge,
+		},
+	}
+	records := runner.RunSuite(ctx, suite)
+	completedAt := time.Now().UTC()
+	summary := BuildSummary(suite.Metadata.Name, startedAt, completedAt, records, recordPath)
+	if err := WriteOutputs(recordPath, summaryPath, records, summary); err != nil {
+		fmt.Fprintf(stderr, "write evaluation outputs: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(
+		stdout,
+		"suite=%s total=%d passed=%d failed=%d records=%s summary=%s\n",
+		summary.Suite,
+		summary.Total,
+		summary.Passed,
+		summary.Failed,
+		recordPath,
+		summaryPath,
+	)
+	if !RecordsPass(records, len(suite.Spec.Cases)) {
+		return 1
+	}
+	return 0
+}
+
+func loadRESTConfig(path string) (*rest.Config, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if path != "" {
+		rules.ExplicitPath = path
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules,
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+}

--- a/internal/eval/grader.go
+++ b/internal/eval/grader.go
@@ -1,0 +1,165 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func GradeRecord(record *Record, graders []Grader) {
+	record.Grades = make([]Grade, 0, len(graders))
+	for _, grader := range graders {
+		record.Grades = append(record.Grades, grade(record, grader))
+	}
+}
+
+func grade(record *Record, grader Grader) Grade {
+	result := Grade{Type: grader.Type}
+	switch grader.Type {
+	case GraderTerminalPhase:
+		result.Expected = grader.Phase
+		result.Observed = record.TerminalPhase
+		result.Pass = record.TerminalPhase == grader.Phase
+	case GraderStatusResult:
+		result.Observed = record.StatusResult
+		switch {
+		case grader.StatusResult.Exact != nil:
+			result.Expected = map[string]string{"exact": *grader.StatusResult.Exact}
+			result.Pass = record.StatusResult == *grader.StatusResult.Exact
+		case grader.StatusResult.Contains != nil:
+			result.Expected = map[string]string{"contains": *grader.StatusResult.Contains}
+			result.Pass = strings.Contains(record.StatusResult, *grader.StatusResult.Contains)
+		case grader.StatusResult.NotContains != nil:
+			result.Expected = map[string]string{"notContains": *grader.StatusResult.NotContains}
+			result.Pass = !strings.Contains(record.StatusResult, *grader.StatusResult.NotContains)
+		}
+	case GraderStructuredOutput:
+		expectation := grader.StructuredOutput
+		present := record.StatusOutput != nil
+		valid := present && json.Valid(record.StatusOutput.Value)
+		mediaType := ""
+		if present {
+			mediaType = record.StatusOutput.MediaType
+		}
+		result.Expected = expectation
+		result.Observed = map[string]any{"present": present, "valid": valid, "mediaType": mediaType}
+		result.Pass = true
+		if expectation.Present != nil {
+			result.Pass = result.Pass && present == *expectation.Present
+		}
+		if expectation.Valid != nil {
+			result.Pass = result.Pass && valid == *expectation.Valid
+		}
+		if expectation.MediaType != "" {
+			result.Pass = result.Pass && mediaType == expectation.MediaType
+		}
+	case GraderUsageFields:
+		observed := usagePresence(record)
+		result.Expected = grader.UsageFields
+		result.Observed = observed
+		result.Pass = true
+		for _, field := range grader.UsageFields {
+			result.Pass = result.Pass && observed[field]
+		}
+	case GraderEnvelopeError:
+		result.Expected = grader.ErrorCode
+		if record.Envelope != nil && record.Envelope.Error != nil {
+			result.Observed = record.Envelope.Error.Code
+			result.Pass = record.Envelope.Error.Code == grader.ErrorCode
+		}
+	case GraderEnvelopeOutcome:
+		result.Expected = grader.Outcome
+		if record.Envelope != nil {
+			result.Observed = record.Envelope.Outcome
+			result.Pass = record.Envelope.Outcome == grader.Outcome
+		}
+	case GraderExecutionModel:
+		result.Expected = grader.Model
+		if record.Envelope != nil && record.Envelope.Execution != nil {
+			result.Observed = record.Envelope.Execution.Model
+			result.Pass = record.Envelope.Execution.Model == grader.Model
+		}
+	case GraderEnvelopeTurns:
+		result.Expected = *grader.Turns
+		if record.Envelope != nil && record.Envelope.Execution != nil &&
+			record.Envelope.Execution.Turns != nil {
+			result.Observed = *record.Envelope.Execution.Turns
+			result.Pass = *record.Envelope.Execution.Turns == *grader.Turns
+		}
+	case GraderEnvelopeTools:
+		result.Expected = *grader.ToolCalls
+		if record.Envelope != nil && record.Envelope.Execution != nil &&
+			record.Envelope.Execution.ToolCalls != nil {
+			result.Observed = *record.Envelope.Execution.ToolCalls
+			result.Pass = *record.Envelope.Execution.ToolCalls == *grader.ToolCalls
+		}
+	case GraderEventCount:
+		result.Expected = grader.Event.Count
+		result.Observed = record.Events.Counts[grader.Event.Type]
+		result.Pass = record.Events.Counts[grader.Event.Type] == grader.Event.Count
+	case GraderToolEvents:
+		matches := matchingTools(record.Events.Tools, *grader.Tool)
+		result.Expected = grader.Tool
+		result.Observed = matches
+		result.Pass = len(matches) == grader.Tool.Count
+	case GraderDuration:
+		result.Expected = grader.MaxDuration.Milliseconds()
+		result.Observed = record.DurationMillis
+		result.Pass = record.DurationMillis <= grader.MaxDuration.Milliseconds()
+	case GraderPodExitCode:
+		result.Expected = *grader.ExitCode
+		if record.PodExitCode != nil {
+			result.Observed = *record.PodExitCode
+			result.Pass = *record.PodExitCode == *grader.ExitCode
+		}
+	default:
+		result.Message = fmt.Sprintf("unsupported grader type %q", grader.Type)
+	}
+	if !result.Pass && result.Message == "" {
+		result.Message = "observed value did not match expectation"
+	}
+	return result
+}
+
+func usagePresence(record *Record) map[string]bool {
+	presence := map[string]bool{
+		"tokens": false, "inputTokens": false, "outputTokens": false, "dollars": false,
+	}
+	if record.StatusUsage == nil {
+		return presence
+	}
+	presence["tokens"] = record.StatusUsage.Tokens != nil
+	presence["inputTokens"] = record.StatusUsage.InputTokens != nil
+	presence["outputTokens"] = record.StatusUsage.OutputTokens != nil
+	presence["dollars"] = record.StatusUsage.Dollars != nil
+	return presence
+}
+
+func matchingTools(tools []ToolEvent, expectation ToolExpectation) []ToolEvent {
+	var matches []ToolEvent
+	for _, tool := range tools {
+		if tool.Name != expectation.Name {
+			continue
+		}
+		if expectation.IsError != nil && tool.IsError != *expectation.IsError {
+			continue
+		}
+		if expectation.ErrorCode != "" && tool.ErrorCode != expectation.ErrorCode {
+			continue
+		}
+		if expectation.Truncated != nil && tool.Truncated != *expectation.Truncated {
+			continue
+		}
+		matches = append(matches, tool)
+	}
+	return matches
+}
+
+func gradesPass(grades []Grade) bool {
+	for _, item := range grades {
+		if !item.Pass {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/eval/grader.go
+++ b/internal/eval/grader.go
@@ -15,6 +15,10 @@ func GradeRecord(record *Record, graders []Grader) {
 
 func grade(record *Record, grader Grader) Grade {
 	result := Grade{Type: grader.Type}
+	if err := validateGrader(grader); err != nil {
+		result.Message = fmt.Sprintf("invalid grader: %v", err)
+		return result
+	}
 	switch grader.Type {
 	case GraderTerminalPhase:
 		result.Expected = grader.Phase

--- a/internal/eval/judge.go
+++ b/internal/eval/judge.go
@@ -1,0 +1,157 @@
+package eval
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	MaxJudgeInputBytes  = 64 << 10
+	MaxJudgeOutputBytes = 16 << 10
+	MaxJudgeRationale   = 4096
+)
+
+type Judge interface {
+	Evaluate(context.Context, JudgeObservation) (JudgeResult, error)
+}
+
+type JudgeObservation struct {
+	Suite         string               `json:"suite"`
+	CaseID        string               `json:"caseId"`
+	Description   string               `json:"description,omitempty"`
+	TerminalPhase string               `json:"terminalPhase,omitempty"`
+	StatusResult  string               `json:"statusResult,omitempty"`
+	StatusOutput  *StatusOutput        `json:"statusOutput,omitempty"`
+	Envelope      *EnvelopeObservation `json:"envelope,omitempty"`
+	EventCounts   map[string]int       `json:"eventCounts,omitempty"`
+	Grades        []Grade              `json:"deterministicGrades"`
+}
+
+type CommandJudge struct {
+	Command string
+	Timeout time.Duration
+}
+
+func (judge CommandJudge) Evaluate(ctx context.Context, observation JudgeObservation) (JudgeResult, error) {
+	if strings.TrimSpace(judge.Command) == "" {
+		return JudgeResult{}, errors.New("judge command is empty")
+	}
+	input, err := json.Marshal(observation)
+	if err != nil {
+		return JudgeResult{}, err
+	}
+	if len(input) > MaxJudgeInputBytes {
+		return JudgeResult{}, fmt.Errorf("judge observation exceeds %d bytes", MaxJudgeInputBytes)
+	}
+	timeout := judge.Timeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	commandCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	command := exec.CommandContext(commandCtx, "/bin/sh", "-c", judge.Command)
+	hardenJudgeCommand(command)
+	command.Stdin = bytes.NewReader(input)
+	command.Env = safeCommandEnvironment()
+	var stdout bytes.Buffer
+	command.Stdout = &limitedWriter{Writer: &stdout, Remaining: MaxJudgeOutputBytes}
+	var stderr bytes.Buffer
+	command.Stderr = &limitedWriter{Writer: &stderr, Remaining: MaxJudgeOutputBytes}
+	runErr := command.Run()
+	terminateJudgeCommand(command)
+	if runErr != nil {
+		return JudgeResult{}, fmt.Errorf("judge command: %w: %s", runErr, boundedMessage(stderr.String()))
+	}
+	var response struct {
+		Pass      *bool    `json:"pass"`
+		Score     *float64 `json:"score"`
+		Rationale *string  `json:"rationale"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(stdout.Bytes()))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		return JudgeResult{}, fmt.Errorf("decode judge response: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return JudgeResult{}, errors.New("decode judge response: trailing data")
+	}
+	if response.Pass == nil || response.Score == nil || response.Rationale == nil {
+		return JudgeResult{}, errors.New("judge response requires pass, score, and rationale")
+	}
+	if *response.Score < 0 || *response.Score > 1 {
+		return JudgeResult{}, errors.New("judge score must be between 0 and 1")
+	}
+	result := JudgeResult{
+		Configured: true,
+		Pass:       *response.Pass,
+		Score:      *response.Score,
+		Rationale:  *response.Rationale,
+	}
+	if len(result.Rationale) > MaxJudgeRationale {
+		result.Rationale = result.Rationale[:MaxJudgeRationale]
+	}
+	return result, nil
+}
+
+func observationFor(record Record) JudgeObservation {
+	observation := JudgeObservation{
+		Suite:         record.Suite,
+		CaseID:        record.CaseID,
+		Description:   record.Description,
+		TerminalPhase: string(record.TerminalPhase),
+		StatusResult:  boundedMessage(record.StatusResult),
+		StatusOutput:  record.StatusOutput,
+		Grades:        record.Grades,
+		EventCounts:   make(map[string]int, len(record.Events.Counts)),
+	}
+	if observation.StatusOutput != nil && len(observation.StatusOutput.Value) > 16<<10 {
+		observation.StatusOutput = &StatusOutput{
+			MediaType: observation.StatusOutput.MediaType,
+			Value:     json.RawMessage(`null`),
+		}
+	}
+	observation.Envelope = record.Envelope
+	for eventType, count := range record.Events.Counts {
+		observation.EventCounts[string(eventType)] = count
+	}
+	return observation
+}
+
+func safeCommandEnvironment() []string {
+	var result []string
+	for _, key := range []string{"PATH", "LANG", "LC_ALL"} {
+		if value := os.Getenv(key); value != "" {
+			result = append(result, key+"="+value)
+		}
+	}
+	return result
+}
+
+type limitedWriter struct {
+	Writer    io.Writer
+	Remaining int
+}
+
+func (writer *limitedWriter) Write(data []byte) (int, error) {
+	original := len(data)
+	if writer.Remaining <= 0 {
+		return original, nil
+	}
+	if len(data) > writer.Remaining {
+		data = data[:writer.Remaining]
+	}
+	if _, err := writer.Writer.Write(data); err != nil {
+		return 0, err
+	}
+	writer.Remaining -= len(data)
+	return original, nil
+}

--- a/internal/eval/judge.go
+++ b/internal/eval/judge.go
@@ -19,6 +19,8 @@ const (
 	MaxJudgeRationale   = 4096
 )
 
+var errJudgeOutputLimit = errors.New("judge output exceeded configured limit")
+
 type Judge interface {
 	Evaluate(context.Context, JudgeObservation) (JudgeResult, error)
 }
@@ -142,16 +144,23 @@ type limitedWriter struct {
 }
 
 func (writer *limitedWriter) Write(data []byte) (int, error) {
-	original := len(data)
 	if writer.Remaining <= 0 {
-		return original, nil
+		return 0, errJudgeOutputLimit
 	}
+	originalLength := len(data)
 	if len(data) > writer.Remaining {
 		data = data[:writer.Remaining]
 	}
-	if _, err := writer.Writer.Write(data); err != nil {
-		return 0, err
+	written, err := writer.Writer.Write(data)
+	writer.Remaining -= written
+	if err != nil {
+		return written, err
 	}
-	writer.Remaining -= len(data)
-	return original, nil
+	if written != len(data) {
+		return written, io.ErrShortWrite
+	}
+	if written != originalLength {
+		return written, errJudgeOutputLimit
+	}
+	return written, nil
 }

--- a/internal/eval/judge_process_other.go
+++ b/internal/eval/judge_process_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd
+
+package eval
+
+import (
+	"os/exec"
+	"time"
+)
+
+func hardenJudgeCommand(command *exec.Cmd) {
+	command.WaitDelay = time.Second
+}
+
+func terminateJudgeCommand(command *exec.Cmd) {
+	if command.Process != nil {
+		_ = command.Process.Kill()
+	}
+}

--- a/internal/eval/judge_process_unix.go
+++ b/internal/eval/judge_process_unix.go
@@ -1,0 +1,33 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package eval
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func hardenJudgeCommand(command *exec.Cmd) {
+	command.WaitDelay = time.Second
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}
+
+func terminateJudgeCommand(command *exec.Cmd) {
+	if command.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+}

--- a/internal/eval/observe.go
+++ b/internal/eval/observe.go
@@ -1,0 +1,283 @@
+package eval
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+)
+
+const (
+	MaxLogBytes       = 2 << 20
+	MaxEventCount     = 1000
+	MaxEventLineBytes = 64 << 10
+)
+
+type parsedLogs struct {
+	Events EventSummary
+	Errors []string
+}
+
+func ParseLogs(
+	logs []byte,
+	truncated bool,
+	relevantTypes map[eventv1alpha1.Type]struct{},
+	detailTypes map[eventv1alpha1.Type]struct{},
+) parsedLogs {
+	parsed := parsedLogs{
+		Events: EventSummary{
+			Counts:    make(map[eventv1alpha1.Type]int),
+			Truncated: truncated,
+		},
+	}
+	if len(logs) > MaxLogBytes {
+		logs = logs[len(logs)-MaxLogBytes:]
+		parsed.Events.Truncated = true
+		parsed.Errors = append(parsed.Errors, "runtime logs exceeded collection limit")
+	}
+	if truncated {
+		parsed.Errors = append(parsed.Errors, "runtime log tail is incomplete")
+	}
+	metadataLimitReported := false
+	scanner := bufio.NewScanner(bytes.NewReader(logs))
+	scanner.Buffer(make([]byte, 4096), MaxEventLineBytes)
+	for scanner.Scan() {
+		line := append([]byte(nil), scanner.Bytes()...)
+		event, err := eventv1alpha1.Parse(line)
+		if err != nil {
+			if malformedRelevantEvent(line, relevantTypes) {
+				parsed.Errors = append(parsed.Errors, fmt.Sprintf("parse required runtime event: %v", err))
+			}
+			continue
+		}
+		if _, relevant := relevantTypes[event.Type]; !relevant {
+			continue
+		}
+		if err := validateEventData(event); err != nil {
+			parsed.Errors = append(
+				parsed.Errors,
+				fmt.Sprintf("parse required %s event data: %v", event.Type, err),
+			)
+			continue
+		}
+		parsed.Events.Counts[event.Type]++
+		if len(parsed.Events.Metadata) >= MaxEventCount {
+			parsed.Events.Truncated = true
+			if !metadataLimitReported {
+				parsed.Errors = append(parsed.Errors, "required runtime event metadata exceeded collection limit")
+				metadataLimitReported = true
+			}
+			continue
+		}
+		if _, detailsRequired := detailTypes[event.Type]; detailsRequired {
+			summarizeEvent(&parsed.Events, event)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		parsed.Errors = append(parsed.Errors, fmt.Sprintf("scan runtime logs: %v", err))
+	}
+	return parsed
+}
+
+func malformedRelevantEvent(line []byte, relevantTypes map[eventv1alpha1.Type]struct{}) bool {
+	var header struct {
+		APIVersion string             `json:"apiVersion"`
+		Type       eventv1alpha1.Type `json:"type"`
+	}
+	if err := json.Unmarshal(line, &header); err == nil {
+		_, relevant := relevantTypes[header.Type]
+		return relevant && strings.HasPrefix(header.APIVersion, "kontext.dev/event/")
+	}
+	normalized := normalizeMalformedFrame(line)
+	versionMarker := []byte(`"apiVersion":"` + eventv1alpha1.APIVersion + `"`)
+	if !bytes.Contains(normalized, versionMarker) {
+		return false
+	}
+	for eventType := range relevantTypes {
+		marker := []byte(`"type":"` + string(eventType) + `"`)
+		if bytes.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return len(relevantTypes) > 0 && bytes.Contains(normalized, []byte(`"type"`))
+}
+
+func normalizeMalformedFrame(line []byte) []byte {
+	normalized := make([]byte, 0, len(line))
+	for _, value := range line {
+		switch value {
+		case ' ', '\t', '\n', '\r', '\f', '\v':
+			continue
+		default:
+			normalized = append(normalized, value)
+		}
+	}
+	return bytes.ReplaceAll(normalized, []byte(`\/`), []byte(`/`))
+}
+
+func validateEventData(event eventv1alpha1.Event) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(event.Data, &fields); err != nil {
+		return fmt.Errorf("data must be an object: %w", err)
+	}
+	if fields == nil {
+		return fmt.Errorf("data must be an object")
+	}
+	switch event.Type {
+	case eventv1alpha1.TypeLifecycle:
+		if _, err := requiredString(fields, "phase"); err != nil {
+			return err
+		}
+	case eventv1alpha1.TypeTool:
+		if _, err := requiredString(fields, "name"); err != nil {
+			return err
+		}
+		count, err := requiredInt32(fields, "count")
+		if err != nil {
+			return err
+		}
+		if count < 1 {
+			return fmt.Errorf("count must be at least 1")
+		}
+		if _, err := requiredBool(fields, "isError"); err != nil {
+			return err
+		}
+		if _, err := requiredBool(fields, "truncated"); err != nil {
+			return err
+		}
+		if value, exists := fields["errorCode"]; exists {
+			var errorCode string
+			if err := json.Unmarshal(value, &errorCode); err != nil {
+				return fmt.Errorf("errorCode must be a string")
+			}
+		}
+	case eventv1alpha1.TypeError:
+		if _, err := requiredString(fields, "code"); err != nil {
+			return err
+		}
+		if _, err := requiredString(fields, "message"); err != nil {
+			return err
+		}
+	case eventv1alpha1.TypeOutput:
+		if _, err := requiredString(fields, "mediaType"); err != nil {
+			return err
+		}
+		if _, exists := fields["value"]; !exists {
+			return fmt.Errorf("value is required")
+		}
+	case eventv1alpha1.TypeUsage:
+		turn, err := requiredInt32(fields, "turn")
+		if err != nil {
+			return err
+		}
+		if turn < 1 {
+			return fmt.Errorf("turn must be at least 1")
+		}
+		var usage map[string]json.RawMessage
+		if err := json.Unmarshal(fields["usage"], &usage); err != nil || usage == nil {
+			return fmt.Errorf("usage must be an object")
+		}
+	}
+	return nil
+}
+
+func summarizeEvent(summary *EventSummary, event eventv1alpha1.Event) {
+	var fields map[string]json.RawMessage
+	_ = json.Unmarshal(event.Data, &fields)
+	metadata := EventMetadata{Timestamp: event.Timestamp, Type: event.Type}
+	switch event.Type {
+	case eventv1alpha1.TypeLifecycle:
+		metadata.Phase, _ = requiredString(fields, "phase")
+		if metadata.Phase != "" {
+			summary.Lifecycle = append(summary.Lifecycle, metadata.Phase)
+		}
+	case eventv1alpha1.TypeTool:
+		tool := ToolEvent{
+			ErrorCode: optionalString(fields, "errorCode"),
+		}
+		tool.Name, _ = requiredString(fields, "name")
+		tool.Count, _ = requiredInt32(fields, "count")
+		tool.IsError, _ = requiredBool(fields, "isError")
+		tool.Truncated, _ = requiredBool(fields, "truncated")
+		summary.Tools = append(summary.Tools, tool)
+		metadata.Name = tool.Name
+		metadata.IsError = tool.IsError
+		metadata.ErrorCode = tool.ErrorCode
+		metadata.Truncated = tool.Truncated
+	case eventv1alpha1.TypeError:
+		metadata.ErrorCode, _ = requiredString(fields, "code")
+		if metadata.ErrorCode != "" {
+			summary.Errors = append(summary.Errors, metadata.ErrorCode)
+		}
+	case eventv1alpha1.TypeOutput, eventv1alpha1.TypeUsage:
+	}
+	summary.Metadata = append(summary.Metadata, metadata)
+}
+
+func requiredString(fields map[string]json.RawMessage, name string) (string, error) {
+	value, exists := fields[name]
+	if !exists {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	var decoded string
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		return "", fmt.Errorf("%s must be a string", name)
+	}
+	if strings.TrimSpace(decoded) == "" {
+		return "", fmt.Errorf("%s must not be empty", name)
+	}
+	return decoded, nil
+}
+
+func requiredInt32(fields map[string]json.RawMessage, name string) (int32, error) {
+	value, exists := fields[name]
+	if !exists {
+		return 0, fmt.Errorf("%s is required", name)
+	}
+	var decoded int32
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		return 0, fmt.Errorf("%s must be an integer", name)
+	}
+	return decoded, nil
+}
+
+func requiredBool(fields map[string]json.RawMessage, name string) (bool, error) {
+	value, exists := fields[name]
+	if !exists {
+		return false, fmt.Errorf("%s is required", name)
+	}
+	var decoded bool
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		return false, fmt.Errorf("%s must be a boolean", name)
+	}
+	return decoded, nil
+}
+
+func optionalString(fields map[string]json.RawMessage, name string) string {
+	var decoded string
+	_ = json.Unmarshal(fields[name], &decoded)
+	return decoded
+}
+
+func boundedMessage(value string) string {
+	value = strings.TrimSpace(value)
+	return boundedString(value, 4096)
+}
+
+func boundedString(value string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len(value) > limit {
+		end := limit
+		for end > 0 && !utf8.ValidString(value[:end]) {
+			end--
+		}
+		return value[:end]
+	}
+	return value
+}

--- a/internal/eval/observe_grader_test.go
+++ b/internal/eval/observe_grader_test.go
@@ -1,0 +1,161 @@
+package eval
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+func TestParseLogsCollectsBoundedMetadataAndEnvelope(t *testing.T) {
+	var logs bytes.Buffer
+	logs.WriteString(`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"lifecycle","data":{"phase":"started","secret":"do-not-record"}}` + "\n")
+	logs.WriteString(`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:01Z","type":"tool","data":{"name":"shell","count":1,"isError":true,"errorCode":"denied","truncated":true,"output":"SECRET_VALUE"}}` + "\n")
+	logs.WriteString(`KONTEXT_RESULT: {"ignored":"logs are not envelope authority"}` + "\n")
+
+	parsed := ParseLogs(logs.Bytes(), false, map[eventv1alpha1.Type]struct{}{
+		eventv1alpha1.TypeLifecycle: {},
+		eventv1alpha1.TypeTool:      {},
+	}, map[eventv1alpha1.Type]struct{}{
+		eventv1alpha1.TypeLifecycle: {},
+		eventv1alpha1.TypeTool:      {},
+	})
+	if parsed.Events.Counts[eventv1alpha1.TypeTool] != 1 ||
+		len(parsed.Events.Tools) != 1 ||
+		!parsed.Events.Tools[0].Truncated {
+		t.Fatalf("unexpected event summary %#v", parsed.Events)
+	}
+	encoded, _ := json.Marshal(parsed.Events)
+	if strings.Contains(string(encoded), "SECRET_VALUE") || strings.Contains(string(encoded), "do-not-record") {
+		t.Fatalf("event summary retained unbounded/private event data: %s", encoded)
+	}
+}
+
+func TestParseLogsFailsRelevantMalformedAndIncompleteEvents(t *testing.T) {
+	validLifecycle := `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"lifecycle","data":{"phase":"started"}}`
+	relevantLifecycle := map[eventv1alpha1.Type]struct{}{eventv1alpha1.TypeLifecycle: {}}
+	oversized := strings.Repeat("x", MaxEventLineBytes+1) + "\n" + validLifecycle + "\n"
+	parsed := ParseLogs([]byte(oversized), false, relevantLifecycle, nil)
+	if len(parsed.Errors) == 0 || parsed.Events.Counts[eventv1alpha1.TypeLifecycle] != 0 {
+		t.Fatalf("oversized line did not make event collection incomplete: %#v", parsed)
+	}
+
+	malformedTool := `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"tool","data":{"name":"shell","count":1,"truncated":false}}`
+	parsed = ParseLogs(
+		[]byte(malformedTool+"\n"),
+		false,
+		map[eventv1alpha1.Type]struct{}{eventv1alpha1.TypeTool: {}},
+		nil,
+	)
+	if len(parsed.Errors) == 0 || parsed.Events.Counts[eventv1alpha1.TypeTool] != 0 {
+		t.Fatalf("malformed tool event was accepted: %#v", parsed)
+	}
+
+	parsed = ParseLogs([]byte(validLifecycle+"\n"), true, relevantLifecycle, nil)
+	if len(parsed.Errors) == 0 || !parsed.Events.Truncated {
+		t.Fatalf("truncated log tail was accepted: %#v", parsed)
+	}
+}
+
+func TestMalformedRelevantEventFallbackHandlesWhitespaceAndEscapedSlashes(t *testing.T) {
+	line := "{\t\"apiVersion\"\t:\t\"kontext.dev\\/event\\/v1alpha1\",\t" +
+		"\"type\"\t:\t\"tool\",\t\"data\":"
+	parsed := ParseLogs(
+		[]byte(line+"\n"),
+		false,
+		map[eventv1alpha1.Type]struct{}{eventv1alpha1.TypeTool: {}},
+		nil,
+	)
+	if len(parsed.Errors) == 0 {
+		t.Fatalf("malformed escaped event frame was ignored: %#v", parsed)
+	}
+}
+
+func TestEventCountDoesNotRetainUnrequestedMetadata(t *testing.T) {
+	tool := `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"tool","data":{"name":"shell","count":1,"isError":false,"errorCode":"","truncated":false,"output":"private"}}`
+	parsed := ParseLogs(
+		[]byte(tool+"\n"),
+		false,
+		map[eventv1alpha1.Type]struct{}{eventv1alpha1.TypeTool: {}},
+		nil,
+	)
+	if parsed.Events.Counts[eventv1alpha1.TypeTool] != 1 {
+		t.Fatalf("event was not counted: %#v", parsed)
+	}
+	if len(parsed.Events.Tools) != 0 || len(parsed.Events.Metadata) != 0 {
+		t.Fatalf("unrequested event metadata was retained: %#v", parsed.Events)
+	}
+}
+
+func TestGradeRecordCoversDeterministicGradersAndOptionalMetrics(t *testing.T) {
+	zero64 := int64(0)
+	exitCode := int32(7)
+	turns := int32(2)
+	toolCalls := int32(1)
+	trueValue := true
+	exact := "expected result"
+	record := Record{
+		TerminalPhase:  kontextv1alpha1.AgentRunPhaseFailed,
+		StatusResult:   exact,
+		StatusOutput:   &StatusOutput{MediaType: "application/json", Value: json.RawMessage(`{"ok":false}`)},
+		StatusUsage:    &kontextv1alpha1.UsageStatus{Tokens: &zero64, InputTokens: &zero64},
+		PodExitCode:    &exitCode,
+		DurationMillis: 25,
+		Envelope: &EnvelopeObservation{
+			Outcome: resultv1alpha1.OutcomeFailed,
+			Error:   &EnvelopeErrorObservation{Code: "denied"},
+			Execution: &EnvelopeExecutionObservation{
+				Model: "model-a", Turns: &turns, ToolCalls: &toolCalls,
+			},
+		},
+		Events: EventSummary{
+			Counts: map[eventv1alpha1.Type]int{eventv1alpha1.TypeTool: 1},
+			Tools:  []ToolEvent{{Name: "shell", IsError: true, ErrorCode: "denied", Truncated: true}},
+		},
+	}
+	graders := []Grader{
+		{Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseFailed},
+		{Type: GraderStatusResult, StatusResult: &StringMatch{Exact: &exact}},
+		{Type: GraderStructuredOutput, StructuredOutput: &StructuredOutputExpectation{
+			MediaType: "application/json", Present: &trueValue, Valid: &trueValue,
+		}},
+		{Type: GraderUsageFields, UsageFields: []string{"tokens", "inputTokens"}},
+		{Type: GraderEnvelopeError, ErrorCode: "denied"},
+		{Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeFailed},
+		{Type: GraderExecutionModel, Model: "model-a"},
+		{Type: GraderEnvelopeTurns, Turns: &turns},
+		{Type: GraderEnvelopeTools, ToolCalls: &toolCalls},
+		{Type: GraderEventCount, Event: &EventCountExpectation{Type: eventv1alpha1.TypeTool, Count: 1}},
+		{Type: GraderToolEvents, Tool: &ToolExpectation{
+			Name: "shell", Count: 1, IsError: &trueValue, ErrorCode: "denied", Truncated: &trueValue,
+		}},
+		{Type: GraderDuration, MaxDuration: Duration{Duration: time.Second}},
+		{Type: GraderPodExitCode, ExitCode: &exitCode},
+	}
+	GradeRecord(&record, graders)
+	if !gradesPass(record.Grades) {
+		t.Fatalf("expected all graders to pass: %#v", record.Grades)
+	}
+	presence := usagePresence(&record)
+	if !presence["tokens"] || presence["outputTokens"] {
+		t.Fatalf("nil/zero optional metric semantics lost: %#v", presence)
+	}
+}
+
+func TestStatusResultMatchModes(t *testing.T) {
+	contains := "needle"
+	notContains := "secret"
+	record := Record{StatusResult: "contains needle only"}
+	GradeRecord(&record, []Grader{
+		{Type: GraderStatusResult, StatusResult: &StringMatch{Contains: &contains}},
+		{Type: GraderStatusResult, StatusResult: &StringMatch{NotContains: &notContains}},
+	})
+	if !gradesPass(record.Grades) {
+		t.Fatalf("contains/not-contains graders failed: %#v", record.Grades)
+	}
+}

--- a/internal/eval/observe_grader_test.go
+++ b/internal/eval/observe_grader_test.go
@@ -159,3 +159,13 @@ func TestStatusResultMatchModes(t *testing.T) {
 		t.Fatalf("contains/not-contains graders failed: %#v", record.Grades)
 	}
 }
+
+func TestGradeRecordRejectsUnvalidatedGraders(t *testing.T) {
+	record := Record{}
+	GradeRecord(&record, []Grader{{Type: GraderEnvelopeTurns}})
+	if len(record.Grades) != 1 ||
+		record.Grades[0].Pass ||
+		!strings.Contains(record.Grades[0].Message, "invalid grader") {
+		t.Fatalf("unvalidated grader was not rejected safely: %#v", record.Grades)
+	}
+}

--- a/internal/eval/output.go
+++ b/internal/eval/output.go
@@ -1,0 +1,96 @@
+package eval
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func WriteOutputs(recordPath, summaryPath string, records []Record, summary Summary) error {
+	if err := writeJSONLAtomic(recordPath, records); err != nil {
+		return err
+	}
+	summary.RecordPath = recordPath
+	if err := writeJSONAtomic(summaryPath, summary); err != nil {
+		return err
+	}
+	return nil
+}
+
+func BuildSummary(suite string, startedAt, completedAt time.Time, records []Record, recordPath string) Summary {
+	summary := Summary{
+		APIVersion:  APIVersion,
+		Suite:       suite,
+		StartedAt:   startedAt,
+		CompletedAt: completedAt,
+		Total:       len(records),
+		RecordPath:  recordPath,
+	}
+	for _, record := range records {
+		if record.Pass {
+			summary.Passed++
+		} else {
+			summary.Failed++
+		}
+	}
+	return summary
+}
+
+func writeJSONLAtomic(path string, records []Record) error {
+	return atomicWrite(path, func(file *os.File) error {
+		writer := bufio.NewWriter(file)
+		encoder := json.NewEncoder(writer)
+		encoder.SetEscapeHTML(false)
+		for _, record := range records {
+			if err := encoder.Encode(record); err != nil {
+				return err
+			}
+		}
+		return writer.Flush()
+	})
+}
+
+func writeJSONAtomic(path string, value any) error {
+	return atomicWrite(path, func(file *os.File) error {
+		encoder := json.NewEncoder(file)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(value)
+	})
+}
+
+func atomicWrite(path string, write func(*os.File) error) error {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	file, err := os.CreateTemp(parent, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := file.Name()
+	cleanup := func() {
+		file.Close()
+		os.Remove(tempPath)
+	}
+	if err := write(file); err != nil {
+		cleanup()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		os.Remove(tempPath)
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		os.Remove(tempPath)
+		return err
+	}
+	return nil
+}

--- a/internal/eval/output_judge_test.go
+++ b/internal/eval/output_judge_test.go
@@ -1,0 +1,145 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+)
+
+func TestWriteOutputsProducesJSONLAndSummary(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "nested")
+	recordPath := filepath.Join(directory, "records.jsonl")
+	summaryPath := filepath.Join(directory, "summary.json")
+	records := []Record{
+		{APIVersion: APIVersion, Kind: RecordKind, Suite: "s", CaseID: "a", Pass: true},
+		{APIVersion: APIVersion, Kind: RecordKind, Suite: "s", CaseID: "b", Pass: false},
+	}
+	now := time.Now().UTC()
+	summary := BuildSummary("s", now, now, records, recordPath)
+	if err := WriteOutputs(recordPath, summaryPath, records, summary); err != nil {
+		t.Fatalf("WriteOutputs: %v", err)
+	}
+	data, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lines := strings.Count(strings.TrimSpace(string(data)), "\n") + 1; lines != 2 {
+		t.Fatalf("expected two JSONL records, got %d", lines)
+	}
+	summaryData, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Summary
+	if err := json.Unmarshal(summaryData, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Total != 2 || decoded.Passed != 1 || decoded.Failed != 1 || decoded.RecordPath != recordPath {
+		t.Fatalf("unexpected summary %#v", decoded)
+	}
+	for _, path := range []string{recordPath, summaryPath} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if permissions := info.Mode().Perm(); permissions != 0o600 {
+			t.Fatalf("%s permissions = %o, want 600", path, permissions)
+		}
+	}
+}
+
+func TestCommandJudgeBoundsAndResponseValidation(t *testing.T) {
+	judge := CommandJudge{Command: `printf '{"pass":true,"score":0.75,"rationale":"ok"}'`}
+	result, err := judge.Evaluate(context.Background(), JudgeObservation{
+		Suite: "s", CaseID: "c", Grades: []Grade{{Type: GraderTerminalPhase, Pass: true}},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !result.Configured || !result.Pass || result.Score != 0.75 {
+		t.Fatalf("unexpected judge result %#v", result)
+	}
+	_, err = judge.Evaluate(context.Background(), JudgeObservation{
+		Suite: "s", CaseID: "c", StatusResult: strings.Repeat("x", MaxJudgeInputBytes),
+	})
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected bounded input error, got %v", err)
+	}
+	_, err = (CommandJudge{Command: `printf '{"pass":true}'`}).Evaluate(
+		context.Background(),
+		JudgeObservation{Suite: "s", CaseID: "c"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "requires") {
+		t.Fatalf("expected incomplete response error, got %v", err)
+	}
+}
+
+func TestCommandJudgeDoesNotHangOnBackgroundPipeHolder(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "background-survived")
+	startedAt := time.Now()
+	_, err := (CommandJudge{
+		Command: fmt.Sprintf(
+			`(sleep 2; printf survived > %q) & printf '{"pass":true,"score":1,"rationale":"ok"}'`,
+			marker,
+		),
+		Timeout: 5 * time.Second,
+	}).Evaluate(context.Background(), JudgeObservation{
+		Suite: "s", CaseID: "background-child",
+	})
+	if err == nil {
+		t.Fatal("expected background pipe holder to be rejected")
+	}
+	if elapsed := time.Since(startedAt); elapsed > 3*time.Second {
+		t.Fatalf("judge waited too long for background descendant: %s", elapsed)
+	}
+	time.Sleep(1500 * time.Millisecond)
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("background judge descendant survived process-group termination: %v", statErr)
+	}
+}
+
+func TestCommandJudgeKillsDetachedChildrenAfterSuccessfulExit(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "detached-child-survived")
+	result, err := (CommandJudge{
+		Command: fmt.Sprintf(
+			`(sleep 1; printf survived > %q) >/dev/null 2>&1 & printf '{"pass":true,"score":1,"rationale":"ok"}'`,
+			marker,
+		),
+		Timeout: 5 * time.Second,
+	}).Evaluate(context.Background(), JudgeObservation{
+		Suite: "s", CaseID: "detached-child",
+	})
+	if err != nil || !result.Pass {
+		t.Fatalf("successful judge response failed: result=%#v err=%v", result, err)
+	}
+	time.Sleep(1200 * time.Millisecond)
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("detached judge child survived successful parent exit: %v", statErr)
+	}
+}
+
+func TestObservationContainsGradesButNoLogsOrEnvironment(t *testing.T) {
+	observation := observationFor(Record{
+		Suite:  "s",
+		CaseID: "c",
+		Grades: []Grade{{Type: GraderTerminalPhase, Pass: true}},
+		Events: EventSummary{Counts: map[eventv1alpha1.Type]int{}},
+	})
+	encoded, err := json.Marshal(observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(encoded)
+	if !strings.Contains(text, "deterministicGrades") ||
+		strings.Contains(text, "kubeconfig") ||
+		strings.Contains(text, "logs") {
+		t.Fatalf("unsafe or unordered observation: %s", text)
+	}
+}

--- a/internal/eval/output_judge_test.go
+++ b/internal/eval/output_judge_test.go
@@ -1,8 +1,10 @@
 package eval
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -78,6 +80,22 @@ func TestCommandJudgeBoundsAndResponseValidation(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "requires") {
 		t.Fatalf("expected incomplete response error, got %v", err)
+	}
+}
+
+func TestLimitedWriterReportsOutputLimit(t *testing.T) {
+	var output bytes.Buffer
+	writer := &limitedWriter{Writer: &output, Remaining: 3}
+	written, err := writer.Write([]byte("hello"))
+	if written != 3 || !errors.Is(err, errJudgeOutputLimit) {
+		t.Fatalf("first write = (%d, %v), want (3, output limit)", written, err)
+	}
+	if output.String() != "hel" {
+		t.Fatalf("bounded output = %q, want hel", output.String())
+	}
+	written, err = writer.Write([]byte("again"))
+	if written != 0 || !errors.Is(err, errJudgeOutputLimit) {
+		t.Fatalf("second write = (%d, %v), want (0, output limit)", written, err)
 	}
 }
 

--- a/internal/eval/runner.go
+++ b/internal/eval/runner.go
@@ -1,0 +1,692 @@
+package eval
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+const (
+	labelManagedBy  = "app.kubernetes.io/managed-by"
+	labelEvalSuite  = "kontext.dev/eval-suite"
+	labelEvalCase   = "kontext.dev/eval-case"
+	labelInvocation = "kontext.dev/eval-invocation"
+)
+
+type LogFetcher interface {
+	Fetch(context.Context, string, string, string) (LogCollection, error)
+}
+
+type LogCollection struct {
+	Data      []byte
+	Truncated bool
+}
+
+const MaxLogTailLines int64 = MaxEventCount + 1
+
+type PodLogStreamer func(
+	context.Context,
+	string,
+	string,
+	*corev1.PodLogOptions,
+) (io.ReadCloser, error)
+
+type KubernetesLogFetcher struct {
+	Client kubernetes.Interface
+	Stream PodLogStreamer
+}
+
+func (fetcher KubernetesLogFetcher) Fetch(
+	ctx context.Context,
+	namespace, podName, container string,
+) (LogCollection, error) {
+	tailLines := MaxLogTailLines
+	limitBytes := int64(MaxLogBytes + 1)
+	options := &corev1.PodLogOptions{
+		Container:  container,
+		TailLines:  &tailLines,
+		LimitBytes: &limitBytes,
+	}
+	streamLogs := fetcher.Stream
+	if streamLogs == nil {
+		streamLogs = func(
+			ctx context.Context,
+			namespace string,
+			podName string,
+			options *corev1.PodLogOptions,
+		) (io.ReadCloser, error) {
+			return fetcher.Client.CoreV1().Pods(namespace).GetLogs(podName, options).Stream(ctx)
+		}
+	}
+	stream, err := streamLogs(ctx, namespace, podName, options)
+	if err != nil {
+		return LogCollection{}, err
+	}
+	defer stream.Close()
+	tail := newBoundedTail(MaxLogBytes)
+	if _, err := io.Copy(tail, stream); err != nil {
+		return LogCollection{}, err
+	}
+	return LogCollection{
+		Data:      append([]byte(nil), tail.Bytes()...),
+		Truncated: tail.Truncated() || logLineCount(tail.Bytes()) >= MaxLogTailLines,
+	}, nil
+}
+
+type RunnerOptions struct {
+	Namespace    string
+	KeepRuns     bool
+	PollInterval time.Duration
+	Judge        Judge
+	Now          func() time.Time
+	InvocationID string
+}
+
+type Runner struct {
+	Client  client.Client
+	Logs    LogFetcher
+	Options RunnerOptions
+}
+
+func (runner Runner) RunSuite(ctx context.Context, suite EvalSuite) []Record {
+	if runner.Options.InvocationID == "" {
+		now := runner.Options.Now
+		if now == nil {
+			now = time.Now
+		}
+		runner.Options.InvocationID = invocationID(now())
+	}
+	records := make([]Record, 0, len(suite.Spec.Cases))
+	for _, item := range suite.Spec.Cases {
+		records = append(records, runner.runCase(ctx, suite, item))
+	}
+	return records
+}
+
+func (runner Runner) runCase(ctx context.Context, suite EvalSuite, item Case) Record {
+	now := runner.Options.Now
+	if now == nil {
+		now = time.Now
+	}
+	invocation := runner.Options.InvocationID
+	if invocation == "" {
+		invocation = invocationID(now())
+	}
+	namespace := runner.Options.Namespace
+	if namespace == "" {
+		namespace = suite.Spec.Defaults.Namespace
+	}
+	name := NameForCase(suite.Metadata.Name, item.ID, invocation)
+	record := Record{
+		APIVersion:  APIVersion,
+		Kind:        RecordKind,
+		Suite:       suite.Metadata.Name,
+		CaseID:      item.ID,
+		Description: item.Description,
+		Run:         RunRef{Namespace: namespace, Name: name},
+		StartedAt:   now().UTC(),
+	}
+	ownershipLabels := map[string]string{
+		labelManagedBy:  "kontext-eval",
+		labelEvalSuite:  labelValue(suite.Metadata.Name),
+		labelEvalCase:   labelValue(item.ID),
+		labelInvocation: labelValue(invocation),
+	}
+	run := newAgentRun(name, namespace, item.AgentRun, ownershipLabels)
+	caseCtx, cancel := context.WithTimeout(ctx, item.Timeout.Duration)
+	defer cancel()
+	created := false
+	if err := runner.Client.Create(caseCtx, run); err != nil {
+		record.CollectionErrors = append(record.CollectionErrors, fmt.Sprintf("create AgentRun: %v", err))
+		if !runner.Options.KeepRuns && ambiguousCreateError(err) {
+			record.CollectionErrors = append(
+				record.CollectionErrors,
+				runner.cleanupAmbiguousCreate(caseCtx, types.NamespacedName{
+					Namespace: namespace,
+					Name:      name,
+				}, ownershipLabels)...,
+			)
+		} else if apierrors.IsAlreadyExists(err) {
+			record.CollectionErrors = append(
+				record.CollectionErrors,
+				"AgentRun name collision was left untouched",
+			)
+		}
+		return runner.finishRecord(caseCtx, &record, item, nil, nil, created, now)
+	}
+	created = true
+
+	terminalRun, waitErr := runner.waitForTerminal(caseCtx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	})
+	if waitErr != nil {
+		record.CollectionErrors = append(record.CollectionErrors, fmt.Sprintf("wait for terminal AgentRun: %v", waitErr))
+	}
+	if terminalRun == nil {
+		terminalRun = run
+	}
+	record.TerminalPhase = terminalRun.Status.Phase
+	record.Run.PodName = terminalRun.Status.PodName
+	requirements := requirementsForGraders(item.Graders)
+	if requirements.statusResult {
+		record.StatusResult = terminalRun.Status.Result
+	}
+	if requirements.statusUsage {
+		record.StatusUsage = terminalRun.Status.Usage
+	}
+	if requirements.statusOutput && terminalRun.Status.Output != nil {
+		record.StatusOutput = &StatusOutput{
+			MediaType: terminalRun.Status.Output.MediaType,
+			Value:     append([]byte(nil), terminalRun.Status.Output.Value.Raw...),
+		}
+	}
+
+	var pod *corev1.Pod
+	if !requirements.pod {
+		return runner.finishRecord(caseCtx, &record, item, terminalRun, nil, created, now)
+	}
+	if terminalRun.Status.PodName == "" {
+		if requirements.pod {
+			record.CollectionErrors = append(record.CollectionErrors, "required runtime Pod name was not recorded")
+		}
+	} else {
+		pod = &corev1.Pod{}
+		if err := runner.getWithRetry(caseCtx, types.NamespacedName{
+			Namespace: namespace,
+			Name:      terminalRun.Status.PodName,
+		}, pod); err != nil {
+			if requirements.pod {
+				record.CollectionErrors = append(record.CollectionErrors, fmt.Sprintf("get required runtime Pod: %v", err))
+			}
+			pod = nil
+		}
+	}
+	return runner.finishRecord(caseCtx, &record, item, terminalRun, pod, created, now)
+}
+
+func (runner Runner) finishRecord(
+	ctx context.Context,
+	record *Record,
+	item Case,
+	run *kontextv1alpha1.AgentRun,
+	pod *corev1.Pod,
+	created bool,
+	now func() time.Time,
+) Record {
+	requirements := requirementsForGraders(item.Graders)
+	if requirements.exitCode {
+		record.PodExitCode = podExitCode(pod)
+		if pod != nil && record.PodExitCode == nil {
+			record.CollectionErrors = append(record.CollectionErrors, "required runtime container exit code was unavailable")
+		}
+	}
+	if pod != nil {
+		if requirements.envelope {
+			terminated := runtimeTermination(pod)
+			if terminated == nil {
+				record.CollectionErrors = append(record.CollectionErrors, "required runtime termination message was unavailable")
+			} else {
+				parsed, err := resultv1alpha1.Parse(terminated.Message)
+				if err != nil {
+					record.CollectionErrors = append(
+						record.CollectionErrors,
+						fmt.Sprintf("parse required runtime termination message: %v", err),
+					)
+				} else if parsed.Envelope == nil {
+					record.CollectionErrors = append(
+						record.CollectionErrors,
+						"required versioned result envelope was absent from runtime termination message",
+					)
+				} else {
+					record.Envelope = projectEnvelope(*parsed.Envelope, requirements)
+				}
+			}
+		}
+		if requirements.logs && runner.Logs == nil {
+			record.CollectionErrors = append(record.CollectionErrors, "required runtime log fetcher is not configured")
+		}
+		if requirements.logs && runner.Logs != nil {
+			logs, err := runner.Logs.Fetch(ctx, pod.Namespace, pod.Name, "runtime")
+			if err != nil {
+				record.CollectionErrors = append(record.CollectionErrors, fmt.Sprintf("fetch required runtime logs: %v", err))
+			} else {
+				parsed := ParseLogs(
+					logs.Data,
+					logs.Truncated,
+					requirements.eventTypes,
+					requirements.eventDetailTypes,
+				)
+				record.Events = parsed.Events
+				record.CollectionErrors = append(record.CollectionErrors, parsed.Errors...)
+			}
+		}
+	}
+	record.CompletedAt = now().UTC()
+	record.DurationMillis = record.CompletedAt.Sub(record.StartedAt).Milliseconds()
+	GradeRecord(record, item.Graders)
+
+	if runner.Options.Judge != nil {
+		judgeResult, err := runner.Options.Judge.Evaluate(ctx, observationFor(*record))
+		if err != nil {
+			record.Judge = &JudgeResult{Configured: true, Error: boundedMessage(err.Error())}
+		} else {
+			record.Judge = &judgeResult
+		}
+	}
+	if err := ctx.Err(); err != nil && !containsCollectionError(record.CollectionErrors, err.Error()) {
+		record.CollectionErrors = append(record.CollectionErrors, fmt.Sprintf("case context ended: %v", err))
+	}
+
+	if created && !runner.Options.KeepRuns {
+		target := run
+		if target == nil {
+			target = &kontextv1alpha1.AgentRun{}
+			target.Namespace = record.Run.Namespace
+			target.Name = record.Run.Name
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		err := runner.Client.Delete(cleanupCtx, target)
+		cancel()
+		if err != nil && !apierrors.IsNotFound(err) {
+			record.CollectionErrors = append(record.CollectionErrors, fmt.Sprintf("cleanup AgentRun: %v", err))
+		}
+	}
+	record.Pass = len(record.CollectionErrors) == 0 && gradesPass(record.Grades)
+	if record.Judge != nil {
+		record.Pass = record.Pass && record.Judge.Error == "" && record.Judge.Pass
+	}
+	return *record
+}
+
+type artifactRequirements struct {
+	pod              bool
+	logs             bool
+	envelope         bool
+	exitCode         bool
+	statusResult     bool
+	statusOutput     bool
+	statusUsage      bool
+	eventTypes       map[eventv1alpha1.Type]struct{}
+	eventDetailTypes map[eventv1alpha1.Type]struct{}
+	envelopeOutcome  bool
+	envelopeError    bool
+	envelopeModel    bool
+	envelopeTurns    bool
+	envelopeTools    bool
+}
+
+func requirementsForGraders(graders []Grader) artifactRequirements {
+	requirements := artifactRequirements{
+		eventTypes:       make(map[eventv1alpha1.Type]struct{}),
+		eventDetailTypes: make(map[eventv1alpha1.Type]struct{}),
+	}
+	for _, grader := range graders {
+		switch grader.Type {
+		case GraderEnvelopeError:
+			requirements.envelope = true
+			requirements.envelopeError = true
+			requirements.pod = true
+		case GraderEnvelopeOutcome:
+			requirements.envelope = true
+			requirements.envelopeOutcome = true
+			requirements.pod = true
+		case GraderExecutionModel:
+			requirements.envelope = true
+			requirements.envelopeModel = true
+			requirements.pod = true
+		case GraderEnvelopeTurns:
+			requirements.envelope = true
+			requirements.envelopeTurns = true
+			requirements.pod = true
+		case GraderEnvelopeTools:
+			requirements.envelope = true
+			requirements.envelopeTools = true
+			requirements.pod = true
+		case GraderEventCount:
+			requirements.logs = true
+			requirements.pod = true
+			requirements.eventTypes[grader.Event.Type] = struct{}{}
+		case GraderToolEvents:
+			requirements.logs = true
+			requirements.pod = true
+			requirements.eventTypes[eventv1alpha1.TypeTool] = struct{}{}
+			requirements.eventDetailTypes[eventv1alpha1.TypeTool] = struct{}{}
+		case GraderPodExitCode:
+			requirements.pod = true
+			requirements.exitCode = true
+		case GraderStatusResult:
+			requirements.statusResult = true
+		case GraderStructuredOutput:
+			requirements.statusOutput = true
+		case GraderUsageFields:
+			requirements.statusUsage = true
+		case GraderTerminalPhase, GraderDuration:
+		}
+	}
+	return requirements
+}
+
+func projectEnvelope(
+	envelope resultv1alpha1.Envelope,
+	requirements artifactRequirements,
+) *EnvelopeObservation {
+	observation := &EnvelopeObservation{}
+	if requirements.envelopeOutcome {
+		observation.Outcome = envelope.Outcome
+	}
+	if requirements.envelopeError && envelope.Error != nil {
+		observation.Error = &EnvelopeErrorObservation{Code: boundedString(envelope.Error.Code, 4096)}
+	}
+	if requirements.envelopeModel || requirements.envelopeTurns || requirements.envelopeTools {
+		execution := &EnvelopeExecutionObservation{}
+		if envelope.Execution != nil {
+			if requirements.envelopeModel {
+				execution.Model = boundedString(envelope.Execution.Model, 4096)
+			}
+			if requirements.envelopeTurns {
+				execution.Turns = cloneInt32(envelope.Execution.Turns)
+			}
+			if requirements.envelopeTools {
+				execution.ToolCalls = cloneInt32(envelope.Execution.ToolCalls)
+			}
+		}
+		observation.Execution = execution
+	}
+	return observation
+}
+
+func cloneInt32(value *int32) *int32 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func containsCollectionError(errors []string, fragment string) bool {
+	for _, message := range errors {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func ambiguousCreateError(err error) bool {
+	return !apierrors.IsAlreadyExists(err) &&
+		!apierrors.IsBadRequest(err) &&
+		!apierrors.IsInvalid(err) &&
+		!apierrors.IsForbidden(err) &&
+		!apierrors.IsUnauthorized(err) &&
+		!apierrors.IsMethodNotSupported(err) &&
+		!apierrors.IsNotAcceptable(err) &&
+		!apierrors.IsUnsupportedMediaType(err)
+}
+
+func (runner Runner) cleanupAmbiguousCreate(
+	parent context.Context,
+	key types.NamespacedName,
+	expectedLabels map[string]string,
+) []string {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), 300*time.Millisecond)
+	defer cancel()
+	backoff := 25 * time.Millisecond
+	var lastErr error
+	for {
+		observed := &kontextv1alpha1.AgentRun{}
+		err := runner.Client.Get(ctx, key, observed)
+		if err == nil {
+			if !hasExactEvaluatorOwnership(observed.Labels, expectedLabels) {
+				return []string{"ambiguous AgentRun exists without exact evaluator ownership; left untouched"}
+			}
+			if err := runner.Client.Delete(ctx, observed); err != nil && !apierrors.IsNotFound(err) {
+				return []string{fmt.Sprintf("cleanup ambiguous AgentRun: %v", err)}
+			}
+			return nil
+		}
+		lastErr = err
+		if !apierrors.IsNotFound(err) && !transientGetError(err) {
+			return []string{fmt.Sprintf("probe ambiguous AgentRun: %v", err)}
+		}
+		if err := waitBackoff(ctx, backoff); err != nil {
+			return []string{fmt.Sprintf("probe ambiguous AgentRun after create error: %v (last read: %v)", err, lastErr)}
+		}
+		if backoff < 200*time.Millisecond {
+			backoff *= 2
+			if backoff > 200*time.Millisecond {
+				backoff = 200 * time.Millisecond
+			}
+		}
+	}
+}
+
+func hasExactEvaluatorOwnership(actual, expected map[string]string) bool {
+	for _, name := range []string{
+		labelManagedBy,
+		labelEvalSuite,
+		labelEvalCase,
+		labelInvocation,
+	} {
+		if actual[name] == "" || actual[name] != expected[name] {
+			return false
+		}
+	}
+	return true
+}
+
+func runtimeTermination(pod *corev1.Pod) *corev1.ContainerStateTerminated {
+	for index := range pod.Status.ContainerStatuses {
+		status := &pod.Status.ContainerStatuses[index]
+		if status.Name == "runtime" {
+			return status.State.Terminated
+		}
+	}
+	return nil
+}
+
+type boundedTail struct {
+	data      []byte
+	limit     int
+	truncated bool
+}
+
+func newBoundedTail(limit int) *boundedTail {
+	return &boundedTail{data: make([]byte, 0, limit), limit: limit}
+}
+
+func (tail *boundedTail) Write(data []byte) (int, error) {
+	originalLength := len(data)
+	if tail.limit <= 0 {
+		tail.truncated = tail.truncated || len(data) > 0
+		return originalLength, nil
+	}
+	if len(data) >= tail.limit {
+		tail.data = append(tail.data[:0], data[len(data)-tail.limit:]...)
+		tail.truncated = true
+		return originalLength, nil
+	}
+	overflow := len(tail.data) + len(data) - tail.limit
+	if overflow > 0 {
+		copy(tail.data, tail.data[overflow:])
+		tail.data = tail.data[:len(tail.data)-overflow]
+		tail.truncated = true
+	}
+	tail.data = append(tail.data, data...)
+	return originalLength, nil
+}
+
+func (tail *boundedTail) Bytes() []byte {
+	return tail.data
+}
+
+func (tail *boundedTail) Truncated() bool {
+	return tail.truncated
+}
+
+func logLineCount(data []byte) int64 {
+	if len(data) == 0 {
+		return 0
+	}
+	count := int64(1)
+	for _, value := range data {
+		if value == '\n' {
+			count++
+		}
+	}
+	if data[len(data)-1] == '\n' {
+		count--
+	}
+	return count
+}
+
+func (runner Runner) getWithRetry(
+	ctx context.Context,
+	key types.NamespacedName,
+	object client.Object,
+) error {
+	backoff := 25 * time.Millisecond
+	for {
+		err := runner.Client.Get(ctx, key, object)
+		if err == nil || !transientGetError(err) {
+			return err
+		}
+		if err := waitBackoff(ctx, backoff); err != nil {
+			return err
+		}
+		if backoff < 500*time.Millisecond {
+			backoff *= 2
+			if backoff > 500*time.Millisecond {
+				backoff = 500 * time.Millisecond
+			}
+		}
+	}
+}
+
+func transientGetError(err error) bool {
+	if apierrors.IsForbidden(err) ||
+		apierrors.IsUnauthorized(err) ||
+		apierrors.IsInvalid(err) ||
+		apierrors.IsBadRequest(err) {
+		return false
+	}
+	if apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) {
+		return true
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+	var urlError *url.Error
+	if errors.As(err, &urlError) {
+		return true
+	}
+	var networkError net.Error
+	return errors.As(err, &networkError)
+}
+
+func waitBackoff(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (runner Runner) waitForTerminal(
+	ctx context.Context,
+	key types.NamespacedName,
+) (*kontextv1alpha1.AgentRun, error) {
+	interval := runner.Options.PollInterval
+	if interval <= 0 {
+		interval = 500 * time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	var latest *kontextv1alpha1.AgentRun
+	for {
+		current := &kontextv1alpha1.AgentRun{}
+		if err := runner.getWithRetry(ctx, key, current); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return latest, err
+			}
+		} else {
+			latest = current
+			if terminalPhase(current.Status.Phase) {
+				return current, nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return latest, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func terminalPhase(phase kontextv1alpha1.AgentRunPhase) bool {
+	switch phase {
+	case kontextv1alpha1.AgentRunPhaseSucceeded,
+		kontextv1alpha1.AgentRunPhaseFailed,
+		kontextv1alpha1.AgentRunPhaseBudgetExceeded:
+		return true
+	default:
+		return false
+	}
+}
+
+func invocationID(now time.Time) string {
+	random := make([]byte, 3)
+	if _, err := rand.Read(random); err != nil {
+		return fmt.Sprintf("%x", now.UnixNano())
+	}
+	return fmt.Sprintf("%x-%s", now.Unix(), hex.EncodeToString(random))
+}
+
+func labelValue(value string) string {
+	value = NameForCase(value, "", "")
+	if len(value) > 63 {
+		value = value[:63]
+	}
+	return value
+}
+
+func RecordsPass(records []Record, expected int) bool {
+	if len(records) != expected {
+		return false
+	}
+	for _, record := range records {
+		if !record.Pass {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/eval/runner_test.go
+++ b/internal/eval/runner_test.go
@@ -1,0 +1,1045 @@
+package eval
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/url"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+func TestRunnerCollectsGradesJudgesThenCleansOnlyCreatedRun(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := kontextv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cluster := &terminalClient{Client: base}
+	logs := successfulLogs(t)
+	judge := &orderingJudge{t: t}
+	timeout := Duration{Duration: time.Second}
+	suite := EvalSuite{
+		Metadata: Metadata{Name: "suite"},
+		Spec: SuiteSpec{
+			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
+			Cases: []Case{{
+				ID:      "case",
+				Timeout: &timeout,
+				AgentRun: kontextv1alpha1.AgentRunSpec{
+					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+				},
+				Graders: []Grader{
+					{Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded},
+					{Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeSucceeded},
+					{Type: GraderEventCount, Event: &EventCountExpectation{Type: eventv1alpha1.TypeLifecycle, Count: 1}},
+					{Type: GraderPodExitCode, ExitCode: int32Pointer(0)},
+				},
+			}},
+		},
+	}
+	runner := Runner{
+		Client: cluster,
+		Logs:   &staticLogs{data: logs},
+		Options: RunnerOptions{
+			PollInterval: time.Millisecond,
+			InvocationID: "invocation",
+			Judge:        judge,
+		},
+	}
+	records := runner.RunSuite(context.Background(), suite)
+	if len(records) != 1 || !records[0].Pass {
+		t.Fatalf("unexpected records %#v", records)
+	}
+	if records[0].Envelope == nil || records[0].Envelope.Outcome != resultv1alpha1.OutcomeSucceeded {
+		t.Fatalf("termination message envelope was not collected: %#v", records[0].Envelope)
+	}
+	encodedRecord, err := json.Marshal(records[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"private output", "secret-extension", "request-secret", "artifact-secret"} {
+		if bytes.Contains(encodedRecord, []byte(forbidden)) {
+			t.Fatalf("projected envelope leaked %q: %s", forbidden, encodedRecord)
+		}
+	}
+	if !judge.called || cluster.deletes != 1 {
+		t.Fatalf("judge/cleanup ordering not exercised: judge=%v deletes=%d", judge.called, cluster.deletes)
+	}
+	remaining := &kontextv1alpha1.AgentRun{}
+	err = base.Get(context.Background(), types.NamespacedName{
+		Namespace: "evals", Name: records[0].Run.Name,
+	}, remaining)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("created run was not cleaned up: %v", err)
+	}
+}
+
+func TestRunnerKeepRunsAndCreateFailureCleanup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = kontextv1alpha1.AddToScheme(scheme)
+	timeout := Duration{Duration: 10 * time.Millisecond}
+	suite := EvalSuite{
+		Metadata: Metadata{Name: "suite"},
+		Spec: SuiteSpec{
+			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
+			Cases: []Case{{
+				ID: "case", Timeout: &timeout,
+				AgentRun: kontextv1alpha1.AgentRunSpec{
+					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+				},
+			}},
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cluster := &terminalClient{Client: base}
+	runner := Runner{
+		Client: cluster, Logs: &staticLogs{data: successfulLogs(t)},
+		Options: RunnerOptions{KeepRuns: true, PollInterval: time.Millisecond, InvocationID: "keep"},
+	}
+	records := runner.RunSuite(context.Background(), suite)
+	if len(records) != 1 || cluster.deletes != 0 {
+		t.Fatalf("keep-runs deleted resources: %#v deletes=%d", records, cluster.deletes)
+	}
+
+	failing := &createFailClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	runner.Client = failing
+	runner.Options.KeepRuns = false
+	records = runner.RunSuite(context.Background(), suite)
+	if len(records) != 1 || records[0].Pass || failing.deletes != 0 {
+		t.Fatalf("create failure cleanup was unsafe: %#v deletes=%d", records, failing.deletes)
+	}
+}
+
+func TestAmbiguousCreateCleansOnlyExactlyOwnedRun(t *testing.T) {
+	timeout := Duration{Duration: time.Second}
+	suite := EvalSuite{
+		Metadata: Metadata{Name: "ambiguous"},
+		Spec: SuiteSpec{
+			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
+			Cases: []Case{{
+				ID: "case", Timeout: &timeout,
+				AgentRun: kontextv1alpha1.AgentRunSpec{
+					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+				},
+				Graders: []Grader{{
+					Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+				}},
+			}},
+		},
+	}
+	for name, unowned := range map[string]bool{"owned": false, "unowned": true} {
+		t.Run(name, func(t *testing.T) {
+			base := newFakeEvalClient(t)
+			cluster := &ambiguousCreateClient{
+				Client:             base,
+				unowned:            unowned,
+				probeNotFoundCount: 1,
+			}
+			records := (Runner{
+				Client: cluster,
+				Options: RunnerOptions{
+					PollInterval: time.Millisecond,
+					InvocationID: name,
+				},
+			}).RunSuite(context.Background(), suite)
+			if len(records) != 1 || records[0].Pass {
+				t.Fatalf("ambiguous create unexpectedly passed: %#v", records)
+			}
+			key := types.NamespacedName{
+				Namespace: records[0].Run.Namespace,
+				Name:      records[0].Run.Name,
+			}
+			remaining := &kontextv1alpha1.AgentRun{}
+			err := base.Get(context.Background(), key, remaining)
+			if unowned {
+				if err != nil || cluster.deletes != 0 {
+					t.Fatalf("unowned collision was modified: err=%v deletes=%d", err, cluster.deletes)
+				}
+			} else {
+				if !apierrors.IsNotFound(err) || cluster.deletes != 1 {
+					t.Fatalf("owned ambiguous run was not cleaned: err=%v deletes=%d", err, cluster.deletes)
+				}
+			}
+		})
+	}
+}
+
+func TestRunnerDoesNotFetchUnrequiredArtifactsOrStoreOutput(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = kontextv1alpha1.AddToScheme(scheme)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cluster := &terminalClient{Client: base}
+	logs := &staticLogs{data: []byte("sensitive logs")}
+	timeout := Duration{Duration: time.Second}
+	suite := EvalSuite{
+		Metadata: Metadata{Name: "suite"},
+		Spec: SuiteSpec{
+			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
+			Cases: []Case{{
+				ID: "status-only", Timeout: &timeout,
+				AgentRun: kontextv1alpha1.AgentRunSpec{
+					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+				},
+				Graders: []Grader{{
+					Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+				}},
+			}},
+		},
+	}
+	records := (Runner{
+		Client: cluster,
+		Logs:   logs,
+		Options: RunnerOptions{
+			PollInterval: time.Millisecond,
+			InvocationID: "status-only",
+		},
+	}).RunSuite(context.Background(), suite)
+	if len(records) != 1 || !records[0].Pass {
+		t.Fatalf("unexpected status-only record: %#v", records)
+	}
+	record := records[0]
+	if cluster.podGets != 0 || logs.calls != 0 {
+		t.Fatalf("unrequired artifacts were fetched: podGets=%d logCalls=%d", cluster.podGets, logs.calls)
+	}
+	if record.StatusResult != "" || record.StatusOutput != nil || record.StatusUsage != nil ||
+		record.Envelope != nil || len(record.Events.Metadata) != 0 {
+		t.Fatalf("unrequested output was retained: %#v", record)
+	}
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("sensitive model output")) {
+		t.Fatalf("serialized record retained unrequested model output: %s", encoded)
+	}
+}
+
+func TestFailureStatusMessageIsNotRecordedOrJudged(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = kontextv1alpha1.AddToScheme(scheme)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cluster := &terminalClient{
+		Client:  base,
+		phase:   kontextv1alpha1.AgentRunPhaseFailed,
+		message: "private failure detail",
+	}
+	timeout := Duration{Duration: time.Second}
+	suite := EvalSuite{
+		Metadata: Metadata{Name: "suite"},
+		Spec: SuiteSpec{
+			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
+			Cases: []Case{{
+				ID: "failure", Timeout: &timeout,
+				AgentRun: kontextv1alpha1.AgentRunSpec{
+					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+				},
+				Graders: []Grader{{
+					Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseFailed,
+				}},
+			}},
+		},
+	}
+	records := (Runner{
+		Client: cluster,
+		Options: RunnerOptions{
+			PollInterval: time.Millisecond,
+			InvocationID: "failure",
+		},
+	}).RunSuite(context.Background(), suite)
+	if len(records) != 1 || !records[0].Pass {
+		t.Fatalf("unexpected failure record: %#v", records)
+	}
+	encoded, err := json.Marshal(records[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := json.Marshal(observationFor(records[0]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("private failure detail")) ||
+		bytes.Contains(observation, []byte("private failure detail")) ||
+		bytes.Contains(observation, []byte("terminalMessage")) {
+		t.Fatalf("status.message leaked into record or judge: record=%s judge=%s", encoded, observation)
+	}
+}
+
+func TestEnvelopeGradersUseTerminationMessageWithoutLogs(t *testing.T) {
+	logs := &staticLogs{data: []byte("KONTEXT_RESULT: {not-authoritative}\n")}
+	pod := &corev1.Pod{}
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "runtime",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			ExitCode: 0,
+			Message:  successfulEnvelopeMessage(),
+		}},
+	}}
+	record := Record{StartedAt: time.Unix(0, 0)}
+	turns := int32(2)
+	tools := int32(1)
+	item := Case{Graders: []Grader{
+		{Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeSucceeded},
+		{Type: GraderExecutionModel, Model: "model"},
+		{Type: GraderEnvelopeTurns, Turns: &turns},
+		{Type: GraderEnvelopeTools, ToolCalls: &tools},
+	}}
+	finished := (Runner{Logs: logs}).finishRecord(
+		context.Background(),
+		&record,
+		item,
+		nil,
+		pod,
+		false,
+		func() time.Time { return time.Unix(1, 0) },
+	)
+	if !finished.Pass || finished.Envelope == nil {
+		t.Fatalf("termination-message envelope did not pass: %#v", finished)
+	}
+	if finished.Envelope.Execution == nil ||
+		finished.Envelope.Execution.Model != "model" ||
+		finished.Envelope.Execution.Turns == nil ||
+		*finished.Envelope.Execution.Turns != turns ||
+		finished.Envelope.Execution.ToolCalls == nil ||
+		*finished.Envelope.Execution.ToolCalls != tools {
+		t.Fatalf("requested envelope projection is incomplete: %#v", finished.Envelope)
+	}
+	if logs.calls != 0 {
+		t.Fatalf("envelope-only grading fetched logs %d times", logs.calls)
+	}
+}
+
+func TestEventGradersFailTransportAndTruncationErrors(t *testing.T) {
+	pod := &corev1.Pod{}
+	pod.Namespace = "evals"
+	pod.Name = "runtime"
+	item := Case{Graders: []Grader{{
+		Type: GraderEventCount,
+		Event: &EventCountExpectation{
+			Type: eventv1alpha1.TypeTool, Count: 0,
+		},
+	}}}
+	for name, logs := range map[string]*staticLogs{
+		"transport":  {err: errors.New("stream failed")},
+		"truncation": {truncated: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			record := Record{StartedAt: time.Unix(0, 0)}
+			judge := &orderingJudge{t: t}
+			finished := (Runner{Logs: logs, Options: RunnerOptions{Judge: judge}}).finishRecord(
+				context.Background(),
+				&record,
+				item,
+				nil,
+				pod,
+				false,
+				func() time.Time { return time.Unix(1, 0) },
+			)
+			if finished.Pass || len(finished.CollectionErrors) == 0 {
+				t.Fatalf("incomplete event collection passed: %#v", finished)
+			}
+			if !judge.called || finished.Judge == nil || !finished.Judge.Pass {
+				t.Fatalf("judge did not run after deterministic grading: %#v", finished.Judge)
+			}
+		})
+	}
+}
+
+func TestCleanupUsesFreshContextAfterCancellation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = kontextv1alpha1.AddToScheme(scheme)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	run := &kontextv1alpha1.AgentRun{}
+	run.Namespace = "evals"
+	run.Name = "created-run"
+	if err := base.Create(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	cluster := &cleanupContextClient{Client: base}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	record := Record{
+		Run:           RunRef{Namespace: run.Namespace, Name: run.Name},
+		StartedAt:     time.Unix(0, 0),
+		TerminalPhase: kontextv1alpha1.AgentRunPhaseSucceeded,
+	}
+	item := Case{Graders: []Grader{{
+		Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+	}}}
+	finished := (Runner{Client: cluster}).finishRecord(
+		ctx,
+		&record,
+		item,
+		run,
+		nil,
+		true,
+		func() time.Time { return time.Unix(1, 0) },
+	)
+	if cluster.deletes != 1 || cluster.deleteContextErr != nil || !cluster.hadDeadline {
+		t.Fatalf(
+			"cleanup context was not fresh and bounded: deletes=%d err=%v deadline=%v",
+			cluster.deletes,
+			cluster.deleteContextErr,
+			cluster.hadDeadline,
+		)
+	}
+	if finished.Pass ||
+		containsCollectionError(finished.CollectionErrors, "cleanup AgentRun") {
+		t.Fatalf("canceled case cleanup result was incorrect: %#v", finished)
+	}
+}
+
+func TestBoundedTailRetainsNewestBytes(t *testing.T) {
+	tail := newBoundedTail(5)
+	if _, err := tail.Write([]byte("abc")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tail.Write([]byte("defg")); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(tail.Bytes()); got != "cdefg" {
+		t.Fatalf("expected bounded tail, got %q", got)
+	}
+	if !tail.Truncated() {
+		t.Fatal("expected truncation to be reported")
+	}
+}
+
+func TestKubernetesLogFetcherSetsServerBoundsAndReportsIncompleteTail(t *testing.T) {
+	var captured *corev1.PodLogOptions
+	fetcher := KubernetesLogFetcher{
+		Stream: func(
+			_ context.Context,
+			_, _ string,
+			options *corev1.PodLogOptions,
+		) (io.ReadCloser, error) {
+			copy := options.DeepCopy()
+			captured = copy
+			lines := strings.Repeat("event\n", int(MaxLogTailLines))
+			return io.NopCloser(strings.NewReader(lines)), nil
+		},
+	}
+	logs, err := fetcher.Fetch(context.Background(), "evals", "pod", "runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured == nil ||
+		captured.TailLines == nil ||
+		*captured.TailLines != MaxLogTailLines ||
+		captured.LimitBytes == nil ||
+		*captured.LimitBytes != int64(MaxLogBytes+1) {
+		t.Fatalf("server-side log bounds were not configured: %#v", captured)
+	}
+	if !logs.Truncated {
+		t.Fatal("tail-line boundary was not reported as potentially incomplete")
+	}
+}
+
+func TestRunnerRetriesTransientAgentRunAndPodGets(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = kontextv1alpha1.AddToScheme(scheme)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	terminal := &terminalClient{Client: base}
+	cluster := &sequencedGetClient{
+		Client: terminal,
+		agentErrors: []error{
+			&url.Error{Op: "GET", URL: "https://cluster", Err: io.ErrUnexpectedEOF},
+			syscall.ECONNRESET,
+			apierrors.NewServiceUnavailable("try again"),
+		},
+		podErrors: []error{apierrors.NewTooManyRequests("slow down", 0)},
+	}
+	timeout := Duration{Duration: time.Second}
+	suite := EvalSuite{
+		Metadata: Metadata{Name: "retry"},
+		Spec: SuiteSpec{
+			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
+			Cases: []Case{{
+				ID: "transient", Timeout: &timeout,
+				AgentRun: kontextv1alpha1.AgentRunSpec{
+					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+				},
+				Graders: []Grader{{
+					Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeSucceeded,
+				}},
+			}},
+		},
+	}
+	records := (Runner{
+		Client: cluster,
+		Options: RunnerOptions{
+			PollInterval: time.Millisecond,
+			InvocationID: "retry",
+		},
+	}).RunSuite(context.Background(), suite)
+	if len(records) != 1 || !records[0].Pass {
+		t.Fatalf("transient reads did not recover: %#v", records)
+	}
+	if cluster.agentGets < 4 || cluster.podGets < 2 || terminal.deletes != 1 {
+		t.Fatalf(
+			"transient reads were not retried before cleanup: agent=%d pod=%d deletes=%d",
+			cluster.agentGets,
+			cluster.podGets,
+			terminal.deletes,
+		)
+	}
+}
+
+func TestRunnerFailsPermanentGetImmediately(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = kontextv1alpha1.AddToScheme(scheme)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	terminal := &terminalClient{Client: base}
+	cluster := &sequencedGetClient{
+		Client:      terminal,
+		agentErrors: []error{apierrors.NewBadRequest("invalid read")},
+	}
+	timeout := Duration{Duration: time.Second}
+	suite := EvalSuite{
+		Metadata: Metadata{Name: "permanent"},
+		Spec: SuiteSpec{
+			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
+			Cases: []Case{{
+				ID: "permanent", Timeout: &timeout,
+				AgentRun: kontextv1alpha1.AgentRunSpec{
+					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+				},
+				Graders: []Grader{{
+					Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+				}},
+			}},
+		},
+	}
+	records := (Runner{
+		Client: cluster,
+		Options: RunnerOptions{
+			PollInterval: time.Millisecond,
+			InvocationID: "permanent",
+		},
+	}).RunSuite(context.Background(), suite)
+	if len(records) != 1 || records[0].Pass || cluster.agentGets != 1 {
+		t.Fatalf("permanent read was not failed immediately: records=%#v gets=%d", records, cluster.agentGets)
+	}
+}
+
+func TestTransientGetErrorClassification(t *testing.T) {
+	resource := schema.GroupResource{Group: "kontext.dev", Resource: "agentruns"}
+	for name, err := range map[string]error{
+		"timeout":             apierrors.NewTimeoutError("timeout", 1),
+		"server timeout":      apierrors.NewServerTimeout(resource, "get", 1),
+		"too many requests":   apierrors.NewTooManyRequests("limited", 1),
+		"service unavailable": apierrors.NewServiceUnavailable("down"),
+		"internal":            apierrors.NewInternalError(errors.New("temporary")),
+		"url timeout": &url.Error{
+			Op: "GET", URL: "https://cluster", Err: io.ErrUnexpectedEOF,
+		},
+		"connection reset":   syscall.ECONNRESET,
+		"connection refused": syscall.ECONNREFUSED,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !transientGetError(err) {
+				t.Fatalf("error was not classified transient: %v", err)
+			}
+		})
+	}
+	if transientGetError(apierrors.NewBadRequest("permanent")) {
+		t.Fatal("permanent error was classified transient")
+	}
+	if transientGetError(apierrors.NewUnauthorized("permanent")) {
+		t.Fatal("unauthorized error was classified transient")
+	}
+}
+
+func TestCaseTimeoutCoversCreateWaitPodLogsAndJudge(t *testing.T) {
+	timeout := 40 * time.Millisecond
+	tests := map[string]func(*testing.T) (client.Client, LogFetcher, Judge, []Grader){
+		"create": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			return &blockingCreateClient{Client: newFakeEvalClient(t)}, nil, nil, []Grader{{
+				Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+			}}
+		},
+		"wait": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			return newFakeEvalClient(t), nil, nil, []Grader{{
+				Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+			}}
+		},
+		"pod": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			terminal := &terminalClient{Client: newFakeEvalClient(t)}
+			return &blockingPodGetClient{Client: terminal}, nil, nil, []Grader{{
+				Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeSucceeded,
+			}}
+		},
+		"logs": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			return &terminalClient{Client: newFakeEvalClient(t)}, blockingLogs{}, nil, []Grader{{
+				Type: GraderEventCount,
+				Event: &EventCountExpectation{
+					Type: eventv1alpha1.TypeTool, Count: 0,
+				},
+			}}
+		},
+		"judge": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			return &terminalClient{Client: newFakeEvalClient(t)}, nil, blockingJudge{}, []Grader{{
+				Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+			}}
+		},
+	}
+	for name, setup := range tests {
+		t.Run(name, func(t *testing.T) {
+			cluster, logs, judge, graders := setup(t)
+			duration := Duration{Duration: timeout}
+			suite := EvalSuite{
+				Metadata: Metadata{Name: "timeout"},
+				Spec: SuiteSpec{
+					Defaults: SuiteDefaults{Namespace: "evals", Timeout: &duration},
+					Cases: []Case{{
+						ID: "case", Timeout: &duration,
+						AgentRun: kontextv1alpha1.AgentRunSpec{
+							Goal: "goal", Model: "model",
+							Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+						},
+						Graders: graders,
+					}},
+				},
+			}
+			startedAt := time.Now()
+			records := (Runner{
+				Client: cluster,
+				Logs:   logs,
+				Options: RunnerOptions{
+					PollInterval: time.Millisecond,
+					InvocationID: name,
+					Judge:        judge,
+				},
+			}).RunSuite(context.Background(), suite)
+			if elapsed := time.Since(startedAt); elapsed > time.Second {
+				t.Fatalf("case timeout did not bound %s stage: %s", name, elapsed)
+			}
+			if len(records) != 1 || records[0].Pass ||
+				!containsCollectionError(records[0].CollectionErrors, context.DeadlineExceeded.Error()) {
+				t.Fatalf("%s stage did not fail on case timeout: %#v", name, records)
+			}
+		})
+	}
+}
+
+func TestFinishRecordAllowsStatusOnlyResultWithoutPodArtifacts(t *testing.T) {
+	timeout := Duration{Duration: time.Second}
+	item := Case{
+		ID:      "wallclock",
+		Timeout: &timeout,
+		Graders: []Grader{{
+			Type:  GraderTerminalPhase,
+			Phase: kontextv1alpha1.AgentRunPhaseBudgetExceeded,
+		}},
+	}
+	record := Record{
+		StartedAt:     time.Unix(0, 0),
+		TerminalPhase: kontextv1alpha1.AgentRunPhaseBudgetExceeded,
+	}
+	now := func() time.Time { return time.Unix(1, 0) }
+
+	finished := (Runner{}).finishRecord(
+		context.Background(),
+		&record,
+		item,
+		nil,
+		nil,
+		false,
+		now,
+	)
+	if !finished.Pass || len(finished.CollectionErrors) != 0 {
+		t.Fatalf("status-only record should not require Pod artifacts: %#v", finished)
+	}
+}
+
+func TestFinishRecordFailsWhenGraderRequiredArtifactIsMissing(t *testing.T) {
+	exitCode := int32(7)
+	turns := int32(1)
+	cases := map[string]Grader{
+		"event": {
+			Type:  GraderEventCount,
+			Event: &EventCountExpectation{Type: eventv1alpha1.TypeTool, Count: 1},
+		},
+		"envelope": {
+			Type:  GraderEnvelopeTurns,
+			Turns: &turns,
+		},
+		"exit": {
+			Type:     GraderPodExitCode,
+			ExitCode: &exitCode,
+		},
+	}
+	for name, grader := range cases {
+		t.Run(name, func(t *testing.T) {
+			requirements := requirementsForGraders([]Grader{grader})
+			if !requirements.pod {
+				t.Fatal("artifact grader did not require a Pod")
+			}
+			if name == "event" && len(requirements.eventTypes) == 0 {
+				t.Fatal("event grader did not require events")
+			}
+			if name == "envelope" && !requirements.envelope {
+				t.Fatal("envelope grader did not require an envelope")
+			}
+
+			record := Record{StartedAt: time.Unix(0, 0)}
+			item := Case{Graders: []Grader{grader}}
+			finished := (Runner{}).finishRecord(
+				context.Background(),
+				&record,
+				item,
+				nil,
+				nil,
+				false,
+				func() time.Time { return time.Unix(1, 0) },
+			)
+			if finished.Pass {
+				t.Fatalf("missing required artifact unexpectedly passed: %#v", finished)
+			}
+		})
+	}
+}
+
+type terminalClient struct {
+	client.Client
+	deletes int
+	podGets int
+	phase   kontextv1alpha1.AgentRunPhase
+	message string
+}
+
+func (cluster *terminalClient) Create(ctx context.Context, object client.Object, options ...client.CreateOption) error {
+	if err := cluster.Client.Create(ctx, object, options...); err != nil {
+		return err
+	}
+	run, ok := object.(*kontextv1alpha1.AgentRun)
+	if !ok {
+		return nil
+	}
+	exitCode := int32(0)
+	pod := &corev1.Pod{}
+	pod.Namespace = run.Namespace
+	pod.Name = "pod-" + run.Name
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "runtime",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			ExitCode: exitCode,
+		}},
+	}}
+	return cluster.Client.Create(ctx, pod)
+}
+
+func (cluster *terminalClient) Get(ctx context.Context, key types.NamespacedName, object client.Object, options ...client.GetOption) error {
+	if err := cluster.Client.Get(ctx, key, object, options...); err != nil {
+		return err
+	}
+	if run, ok := object.(*kontextv1alpha1.AgentRun); ok {
+		phase := cluster.phase
+		if phase == "" {
+			phase = kontextv1alpha1.AgentRunPhaseSucceeded
+		}
+		run.Status.Phase = phase
+		run.Status.Message = cluster.message
+		if run.Status.Message == "" {
+			run.Status.Message = "successful status message"
+		}
+		run.Status.PodName = "pod-" + run.Name
+		run.Status.Result = "sensitive model output"
+		value := int64(7)
+		run.Status.Usage = &kontextv1alpha1.UsageStatus{Tokens: &value}
+		run.Status.Output = &kontextv1alpha1.OutputStatus{
+			MediaType: "text/plain",
+			Value:     runtime.RawExtension{Raw: []byte(`"sensitive model output"`)},
+		}
+	}
+	if pod, ok := object.(*corev1.Pod); ok {
+		cluster.podGets++
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name: "runtime",
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Message:  successfulEnvelopeMessage(),
+			}},
+		}}
+	}
+	return nil
+}
+
+func (cluster *terminalClient) Delete(ctx context.Context, object client.Object, options ...client.DeleteOption) error {
+	cluster.deletes++
+	return cluster.Client.Delete(ctx, object, options...)
+}
+
+type createFailClient struct {
+	client.Client
+	deletes int
+}
+
+func (cluster *createFailClient) Create(context.Context, client.Object, ...client.CreateOption) error {
+	return apierrors.NewForbidden(
+		schema.GroupResource{Group: "kontext.dev", Resource: "agentruns"},
+		"case",
+		errors.New("forbidden"),
+	)
+}
+
+func (cluster *createFailClient) Delete(context.Context, client.Object, ...client.DeleteOption) error {
+	cluster.deletes++
+	return nil
+}
+
+type staticLogs struct {
+	data      []byte
+	err       error
+	truncated bool
+	calls     int
+}
+
+func (logs *staticLogs) Fetch(context.Context, string, string, string) (LogCollection, error) {
+	logs.calls++
+	return LogCollection{
+		Data:      append([]byte(nil), logs.data...),
+		Truncated: logs.truncated,
+	}, logs.err
+}
+
+type orderingJudge struct {
+	t      *testing.T
+	called bool
+}
+
+func (judge *orderingJudge) Evaluate(_ context.Context, observation JudgeObservation) (JudgeResult, error) {
+	judge.called = true
+	if len(observation.Grades) == 0 {
+		judge.t.Fatal("judge ran before deterministic graders")
+	}
+	return JudgeResult{Configured: true, Pass: true, Score: 1, Rationale: "ok"}, nil
+}
+
+func successfulLogs(t *testing.T) []byte {
+	t.Helper()
+	var logs bytes.Buffer
+	logs.WriteString(`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"lifecycle","data":{"phase":"started"}}` + "\n")
+	return logs.Bytes()
+}
+
+func successfulEnvelopeMessage() string {
+	output, _ := json.Marshal("private output")
+	extension, _ := json.Marshal("secret-extension")
+	turns := int32(2)
+	tools := int32(1)
+	envelope := resultv1alpha1.Envelope{
+		APIVersion: resultv1alpha1.APIVersion,
+		Outcome:    resultv1alpha1.OutcomeSucceeded,
+		Output: &resultv1alpha1.Output{
+			MediaType: "text/plain",
+			Value:     output,
+		},
+		Execution: &resultv1alpha1.Execution{
+			Provider:  "private-provider",
+			Model:     "model",
+			RequestID: "request-secret",
+			Turns:     &turns,
+			ToolCalls: &tools,
+		},
+		Artifacts: []resultv1alpha1.Artifact{{
+			Name: "artifact-secret", URI: "memory://artifact",
+		}},
+		Extensions: map[string]json.RawMessage{
+			"example.com/private": extension,
+		},
+	}
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
+func int32Pointer(value int32) *int32 {
+	return &value
+}
+
+type cleanupContextClient struct {
+	client.Client
+	deletes          int
+	deleteContextErr error
+	hadDeadline      bool
+}
+
+func (cluster *cleanupContextClient) Delete(
+	ctx context.Context,
+	object client.Object,
+	options ...client.DeleteOption,
+) error {
+	cluster.deletes++
+	cluster.deleteContextErr = ctx.Err()
+	_, cluster.hadDeadline = ctx.Deadline()
+	return cluster.Client.Delete(ctx, object, options...)
+}
+
+type sequencedGetClient struct {
+	client.Client
+	agentErrors []error
+	podErrors   []error
+	agentGets   int
+	podGets     int
+}
+
+func (cluster *sequencedGetClient) Get(
+	ctx context.Context,
+	key types.NamespacedName,
+	object client.Object,
+	options ...client.GetOption,
+) error {
+	switch object.(type) {
+	case *kontextv1alpha1.AgentRun:
+		cluster.agentGets++
+		if len(cluster.agentErrors) > 0 {
+			err := cluster.agentErrors[0]
+			cluster.agentErrors = cluster.agentErrors[1:]
+			return err
+		}
+	case *corev1.Pod:
+		cluster.podGets++
+		if len(cluster.podErrors) > 0 {
+			err := cluster.podErrors[0]
+			cluster.podErrors = cluster.podErrors[1:]
+			return err
+		}
+	}
+	return cluster.Client.Get(ctx, key, object, options...)
+}
+
+func newFakeEvalClient(t *testing.T) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := kontextv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).Build()
+}
+
+type blockingCreateClient struct {
+	client.Client
+}
+
+func (cluster *blockingCreateClient) Create(
+	ctx context.Context,
+	_ client.Object,
+	_ ...client.CreateOption,
+) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+type blockingPodGetClient struct {
+	client.Client
+}
+
+func (cluster *blockingPodGetClient) Get(
+	ctx context.Context,
+	key types.NamespacedName,
+	object client.Object,
+	options ...client.GetOption,
+) error {
+	if _, ok := object.(*corev1.Pod); ok {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return cluster.Client.Get(ctx, key, object, options...)
+}
+
+type blockingLogs struct{}
+
+func (blockingLogs) Fetch(
+	ctx context.Context,
+	_, _, _ string,
+) (LogCollection, error) {
+	<-ctx.Done()
+	return LogCollection{}, ctx.Err()
+}
+
+type blockingJudge struct{}
+
+func (blockingJudge) Evaluate(
+	ctx context.Context,
+	_ JudgeObservation,
+) (JudgeResult, error) {
+	<-ctx.Done()
+	return JudgeResult{}, ctx.Err()
+}
+
+type ambiguousCreateClient struct {
+	client.Client
+	unowned            bool
+	probeNotFoundCount int
+	deletes            int
+}
+
+func (cluster *ambiguousCreateClient) Create(
+	ctx context.Context,
+	object client.Object,
+	_ ...client.CreateOption,
+) error {
+	run := object.(*kontextv1alpha1.AgentRun).DeepCopy()
+	if cluster.unowned {
+		run.Labels = map[string]string{"owner": "user"}
+	}
+	if err := cluster.Client.Create(ctx, run); err != nil {
+		return err
+	}
+	return apierrors.NewTimeoutError("create response lost", 0)
+}
+
+func (cluster *ambiguousCreateClient) Get(
+	ctx context.Context,
+	key types.NamespacedName,
+	object client.Object,
+	options ...client.GetOption,
+) error {
+	if _, ok := object.(*kontextv1alpha1.AgentRun); ok && cluster.probeNotFoundCount > 0 {
+		cluster.probeNotFoundCount--
+		return apierrors.NewNotFound(
+			schema.GroupResource{Group: "kontext.dev", Resource: "agentruns"},
+			key.Name,
+		)
+	}
+	return cluster.Client.Get(ctx, key, object, options...)
+}
+
+func (cluster *ambiguousCreateClient) Delete(
+	ctx context.Context,
+	object client.Object,
+	options ...client.DeleteOption,
+) error {
+	cluster.deletes++
+	return cluster.Client.Delete(ctx, object, options...)
+}

--- a/internal/eval/suite.go
+++ b/internal/eval/suite.go
@@ -1,0 +1,260 @@
+package eval
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+const defaultTimeout = 5 * time.Minute
+
+var invalidDNSChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
+func LoadSuite(path string, runtimeImageOverride string) (EvalSuite, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return EvalSuite{}, err
+	}
+	return ParseSuite(data, runtimeImageOverride)
+}
+
+func ParseSuite(data []byte, runtimeImageOverride string) (EvalSuite, error) {
+	jsonData, err := yaml.YAMLToJSON(data)
+	if err != nil {
+		return EvalSuite{}, fmt.Errorf("decode suite YAML: %w", err)
+	}
+	var suite EvalSuite
+	decoder := json.NewDecoder(bytes.NewReader(jsonData))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&suite); err != nil {
+		return EvalSuite{}, fmt.Errorf("decode suite: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return EvalSuite{}, errors.New("decode suite: trailing JSON value")
+		}
+		return EvalSuite{}, fmt.Errorf("decode suite trailing data: %w", err)
+	}
+	if err := prepareSuite(&suite, strings.TrimSpace(runtimeImageOverride)); err != nil {
+		return EvalSuite{}, err
+	}
+	return suite, nil
+}
+
+func prepareSuite(suite *EvalSuite, runtimeImageOverride string) error {
+	if suite.APIVersion != APIVersion {
+		return fmt.Errorf("unsupported suite apiVersion %q", suite.APIVersion)
+	}
+	if suite.Kind != Kind {
+		return fmt.Errorf("unsupported suite kind %q", suite.Kind)
+	}
+	if strings.TrimSpace(suite.Metadata.Name) == "" {
+		return errors.New("metadata.name is required")
+	}
+	if len(suite.Spec.Cases) == 0 {
+		return errors.New("spec.cases must not be empty")
+	}
+	if suite.Spec.Defaults.Timeout == nil {
+		suite.Spec.Defaults.Timeout = &Duration{Duration: defaultTimeout}
+	}
+	if suite.Spec.Defaults.Timeout.Duration <= 0 {
+		return errors.New("spec.defaults.timeout must be greater than zero")
+	}
+	if suite.Spec.Defaults.Namespace == "" {
+		suite.Spec.Defaults.Namespace = "default"
+	}
+	seen := make(map[string]struct{}, len(suite.Spec.Cases))
+	for index := range suite.Spec.Cases {
+		item := &suite.Spec.Cases[index]
+		item.ID = strings.TrimSpace(item.ID)
+		if item.ID == "" {
+			return fmt.Errorf("spec.cases[%d].id is required", index)
+		}
+		if _, exists := seen[item.ID]; exists {
+			return fmt.Errorf("duplicate case id %q", item.ID)
+		}
+		seen[item.ID] = struct{}{}
+		if item.Timeout == nil {
+			item.Timeout = suite.Spec.Defaults.Timeout
+		}
+		if item.Timeout.Duration <= 0 {
+			return fmt.Errorf("case %q timeout must be greater than zero", item.ID)
+		}
+		if runtimeImageOverride != "" {
+			item.AgentRun.Runtime.Image = runtimeImageOverride
+		} else if item.AgentRun.Runtime.Image == "" {
+			item.AgentRun.Runtime.Image = suite.Spec.Defaults.RuntimeImage
+		}
+		if strings.TrimSpace(item.AgentRun.Runtime.Image) == "" {
+			return fmt.Errorf("case %q requires agentRun.runtime.image", item.ID)
+		}
+		if strings.TrimSpace(item.AgentRun.Model) == "" {
+			return fmt.Errorf("case %q requires agentRun.model", item.ID)
+		}
+		if strings.TrimSpace(item.AgentRun.Goal) == "" {
+			return fmt.Errorf("case %q requires agentRun.goal", item.ID)
+		}
+		if len(item.Graders) == 0 {
+			return fmt.Errorf("case %q requires at least one deterministic grader", item.ID)
+		}
+		for graderIndex, grader := range item.Graders {
+			if err := validateGrader(grader); err != nil {
+				return fmt.Errorf("case %q grader %d: %w", item.ID, graderIndex, err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateGrader(grader Grader) error {
+	switch grader.Type {
+	case GraderTerminalPhase:
+		switch grader.Phase {
+		case kontextv1alpha1.AgentRunPhaseSucceeded,
+			kontextv1alpha1.AgentRunPhaseFailed,
+			kontextv1alpha1.AgentRunPhaseBudgetExceeded:
+		default:
+			return fmt.Errorf("invalid terminal phase %q", grader.Phase)
+		}
+	case GraderStatusResult:
+		if grader.StatusResult == nil {
+			return errors.New("statusResult expectation is required")
+		}
+		count := 0
+		if grader.StatusResult.Exact != nil {
+			count++
+		}
+		if grader.StatusResult.Contains != nil {
+			count++
+		}
+		if grader.StatusResult.NotContains != nil {
+			count++
+		}
+		if count != 1 {
+			return errors.New("statusResult requires exactly one of exact, contains, or notContains")
+		}
+		if grader.StatusResult.Contains != nil && *grader.StatusResult.Contains == "" {
+			return errors.New("statusResult.contains must not be empty")
+		}
+		if grader.StatusResult.NotContains != nil && *grader.StatusResult.NotContains == "" {
+			return errors.New("statusResult.notContains must not be empty")
+		}
+	case GraderStructuredOutput:
+		if grader.StructuredOutput == nil {
+			return errors.New("structuredOutput expectation is required")
+		}
+		if grader.StructuredOutput.Present == nil &&
+			grader.StructuredOutput.Valid == nil &&
+			strings.TrimSpace(grader.StructuredOutput.MediaType) == "" {
+			return errors.New("structuredOutput requires present, valid, or mediaType")
+		}
+		if grader.StructuredOutput.MediaType != "" &&
+			strings.TrimSpace(grader.StructuredOutput.MediaType) == "" {
+			return errors.New("structuredOutput.mediaType must not be blank")
+		}
+	case GraderUsageFields:
+		if len(grader.UsageFields) == 0 {
+			return errors.New("usageFields must not be empty")
+		}
+		seenFields := make(map[string]struct{}, len(grader.UsageFields))
+		for _, field := range grader.UsageFields {
+			switch field {
+			case "tokens", "inputTokens", "outputTokens", "dollars":
+			default:
+				return fmt.Errorf("invalid usage field %q", field)
+			}
+			if _, exists := seenFields[field]; exists {
+				return fmt.Errorf("duplicate usage field %q", field)
+			}
+			seenFields[field] = struct{}{}
+		}
+	case GraderEnvelopeError:
+		if strings.TrimSpace(grader.ErrorCode) == "" {
+			return errors.New("errorCode is required")
+		}
+	case GraderEnvelopeOutcome:
+		switch grader.Outcome {
+		case resultv1alpha1.OutcomeSucceeded, resultv1alpha1.OutcomeFailed:
+		default:
+			return fmt.Errorf("invalid envelope outcome %q", grader.Outcome)
+		}
+	case GraderExecutionModel:
+		if strings.TrimSpace(grader.Model) == "" {
+			return errors.New("model is required")
+		}
+	case GraderEnvelopeTurns:
+		if grader.Turns == nil || *grader.Turns < 0 {
+			return errors.New("turns must be a non-negative integer")
+		}
+	case GraderEnvelopeTools:
+		if grader.ToolCalls == nil || *grader.ToolCalls < 0 {
+			return errors.New("toolCalls must be a non-negative integer")
+		}
+	case GraderEventCount:
+		if grader.Event == nil || grader.Event.Count < 0 {
+			return errors.New("event with non-negative count is required")
+		}
+		switch grader.Event.Type {
+		case eventv1alpha1.TypeLifecycle, eventv1alpha1.TypeOutput, eventv1alpha1.TypeUsage,
+			eventv1alpha1.TypeTool, eventv1alpha1.TypeError:
+		default:
+			return fmt.Errorf("invalid event type %q", grader.Event.Type)
+		}
+	case GraderToolEvents:
+		if grader.Tool == nil {
+			return errors.New("tool expectation is required")
+		}
+		if strings.TrimSpace(grader.Tool.Name) == "" {
+			return errors.New("tool.name is required")
+		}
+		if grader.Tool.Count < 0 {
+			return errors.New("tool.count must be non-negative")
+		}
+		if grader.Tool.ErrorCode != "" && strings.TrimSpace(grader.Tool.ErrorCode) == "" {
+			return errors.New("tool.errorCode must not be blank")
+		}
+	case GraderDuration:
+		if grader.MaxDuration.Duration <= 0 {
+			return errors.New("maxDuration must be greater than zero")
+		}
+	case GraderPodExitCode:
+		if grader.ExitCode == nil {
+			return errors.New("exitCode is required")
+		}
+	default:
+		return fmt.Errorf("unsupported grader type %q", grader.Type)
+	}
+	return nil
+}
+
+func NameForCase(suiteName, caseID, invocation string) string {
+	raw := suiteName + "\x00" + caseID + "\x00" + invocation
+	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(raw)))[:10]
+	readable := strings.ToLower(strings.Join([]string{suiteName, caseID, invocation}, "-"))
+	readable = strings.Trim(invalidDNSChars.ReplaceAllString(readable, "-"), "-")
+	if readable == "" {
+		readable = "eval"
+	}
+	maxReadable := 63 - len(digest) - 1
+	if len(readable) > maxReadable {
+		readable = strings.Trim(readable[:maxReadable], "-")
+	}
+	if readable == "" {
+		readable = "eval"
+	}
+	return readable + "-" + digest
+}

--- a/internal/eval/suite_test.go
+++ b/internal/eval/suite_test.go
@@ -1,0 +1,213 @@
+package eval
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const validSuiteYAML = `
+apiVersion: kontext.dev/eval/v1alpha1
+kind: EvalSuite
+metadata:
+  name: providers
+spec:
+  defaults:
+    namespace: evals
+    timeout: 30s
+    runtimeImage: reference:dev
+  cases:
+    - id: prompt-model-a
+      agentRun:
+        goal: Say hello
+        provider: fake
+        model: model-a
+        runtime: {}
+      graders:
+        - type: terminalPhase
+          phase: Succeeded
+    - id: prompt-model-b
+      timeout: 10s
+      agentRun:
+        goal: Say hello
+        provider: fake
+        model: model-b
+        runtime: {}
+      graders:
+        - type: eventCount
+          event:
+            type: tool
+            count: 0
+`
+
+func TestParseSuiteStrictDefaultsAndSamePromptModels(t *testing.T) {
+	suite, err := ParseSuite([]byte(validSuiteYAML), "override:dev")
+	if err != nil {
+		t.Fatalf("ParseSuite: %v", err)
+	}
+	if len(suite.Spec.Cases) != 2 {
+		t.Fatalf("expected two cases, got %d", len(suite.Spec.Cases))
+	}
+	first, second := suite.Spec.Cases[0], suite.Spec.Cases[1]
+	if first.AgentRun.Goal != second.AgentRun.Goal || first.AgentRun.Model == second.AgentRun.Model {
+		t.Fatalf("same prompt/different model cases changed: %#v %#v", first.AgentRun, second.AgentRun)
+	}
+	if first.AgentRun.Runtime.Image != "override:dev" || second.AgentRun.Runtime.Image != "override:dev" {
+		t.Fatalf("runtime image override was not applied")
+	}
+	if first.Timeout.Duration != 30*time.Second || second.Timeout.Duration != 10*time.Second {
+		t.Fatalf("unexpected timeouts: %s and %s", first.Timeout, second.Timeout)
+	}
+}
+
+func TestRepositoryKeylessSuiteParsesAndKeepsPerCaseImages(t *testing.T) {
+	path := filepath.Join("..", "..", "evals", "suites", "keyless.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read keyless suite: %v", err)
+	}
+	suite, err := ParseSuite(data, "")
+	if err != nil {
+		t.Fatalf("parse keyless suite: %v", err)
+	}
+	if len(suite.Spec.Cases) != 10 {
+		t.Fatalf("expected 10 keyless cases, got %d", len(suite.Spec.Cases))
+	}
+
+	var availableNotUsed, crash *Case
+	for index := range suite.Spec.Cases {
+		item := &suite.Spec.Cases[index]
+		switch item.ID {
+		case "read-knowledge-available-not-used":
+			availableNotUsed = item
+		case "reporter-process-crash":
+			crash = item
+		}
+	}
+	if availableNotUsed == nil ||
+		len(availableNotUsed.AgentRun.Tools) != 1 ||
+		availableNotUsed.AgentRun.Tools[0] != "read_knowledge" {
+		t.Fatalf("available-but-unused tool case lost spec.tools: %#v", availableNotUsed)
+	}
+	if crash == nil || crash.AgentRun.Runtime.Image != "kontext-stdout-fixture:dev" {
+		t.Fatalf("crash case lost its fixture image: %#v", crash)
+	}
+}
+
+func TestParseSuiteRejectsInvalidInput(t *testing.T) {
+	tests := map[string]string{
+		"unknown field": strings.Replace(validSuiteYAML, "metadata:\n", "unexpected: true\nmetadata:\n", 1),
+		"duplicate IDs": strings.Replace(validSuiteYAML, "prompt-model-b", "prompt-model-a", 1),
+		"zero timeout":  strings.Replace(validSuiteYAML, "timeout: 30s", "timeout: 0s", 1),
+		"invalid phase": strings.Replace(validSuiteYAML, "phase: Succeeded", "phase: Running", 1),
+		"invalid tool": strings.Replace(
+			validSuiteYAML,
+			"name: providers",
+			"name: providers",
+			1,
+		) + "\n",
+	}
+	tests["invalid tool"] = strings.Replace(
+		validSuiteYAML,
+		"type: terminalPhase\n          phase: Succeeded",
+		"type: toolEvents\n          tool:\n            name: \"\"\n            count: -1",
+		1,
+	)
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseSuite([]byte(input), ""); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestParseSuiteRejectsEmptyCasesAndMissingRequiredSpec(t *testing.T) {
+	for name, input := range map[string]string{
+		"empty": `
+apiVersion: kontext.dev/eval/v1alpha1
+kind: EvalSuite
+metadata: {name: empty}
+spec: {defaults: {}, cases: []}
+`,
+		"missing goal":  strings.Replace(validSuiteYAML, "goal: Say hello", "goal: \"\"", 1),
+		"missing model": strings.Replace(validSuiteYAML, "model: model-a", "model: \"\"", 1),
+		"missing image": strings.Replace(validSuiteYAML, "runtimeImage: reference:dev", "runtimeImage: \"\"", 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseSuite([]byte(input), ""); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestParseSuiteRejectsCasesWithoutGraders(t *testing.T) {
+	input := strings.Replace(
+		validSuiteYAML,
+		"      graders:\n        - type: terminalPhase\n          phase: Succeeded",
+		"      graders: []",
+		1,
+	)
+	if _, err := ParseSuite([]byte(input), ""); err == nil ||
+		!strings.Contains(err.Error(), "at least one deterministic grader") {
+		t.Fatalf("expected missing-grader validation error, got %v", err)
+	}
+}
+
+func TestValidateGraderRejectsVacuousExpectations(t *testing.T) {
+	empty := ""
+	for name, grader := range map[string]Grader{
+		"structured output": {
+			Type: GraderStructuredOutput, StructuredOutput: &StructuredOutputExpectation{},
+		},
+		"contains empty": {
+			Type: GraderStatusResult, StatusResult: &StringMatch{Contains: &empty},
+		},
+		"not contains empty": {
+			Type: GraderStatusResult, StatusResult: &StringMatch{NotContains: &empty},
+		},
+		"empty error code": {
+			Type: GraderEnvelopeError,
+		},
+		"duplicate usage field": {
+			Type: GraderUsageFields, UsageFields: []string{"tokens", "tokens"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateGrader(grader); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestNameForCaseIsStableDNSSafeAndBounded(t *testing.T) {
+	first := NameForCase("Suite_Name", "CASE with spaces", strings.Repeat("x", 100))
+	second := NameForCase("Suite_Name", "CASE with spaces", strings.Repeat("x", 100))
+	if first != second || len(first) > 63 {
+		t.Fatalf("unexpected name %q / %q", first, second)
+	}
+	for _, character := range first {
+		if !(character >= 'a' && character <= 'z') &&
+			!(character >= '0' && character <= '9') &&
+			character != '-' {
+			t.Fatalf("name contains invalid character %q", character)
+		}
+	}
+	other := NameForCase("Suite_Name", strings.Repeat("c", 100)+"a", strings.Repeat("x", 100))
+	another := NameForCase("Suite_Name", strings.Repeat("c", 100)+"b", strings.Repeat("x", 100))
+	if other == another {
+		t.Fatalf("long case names collided: %q", other)
+	}
+	sanitizedA := NameForCase("suite", "case_with_separator", "invocation")
+	sanitizedB := NameForCase("suite", "case-with-separator", "invocation")
+	if sanitizedA == sanitizedB {
+		t.Fatalf("raw case IDs that sanitize alike collided: %q", sanitizedA)
+	}
+	if NameForCase("suite", "case", "invocation") == "suite-case-invocation" {
+		t.Fatal("short names must also carry a collision-resistant hash")
+	}
+}

--- a/internal/eval/types.go
+++ b/internal/eval/types.go
@@ -1,0 +1,259 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+)
+
+const (
+	APIVersion = "kontext.dev/eval/v1alpha1"
+	Kind       = "EvalSuite"
+	RecordKind = "EvalRecord"
+)
+
+type Duration struct {
+	time.Duration
+}
+
+func (duration *Duration) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("duration must be a string: %w", err)
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return err
+	}
+	duration.Duration = parsed
+	return nil
+}
+
+func (duration Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(duration.String())
+}
+
+type EvalSuite struct {
+	APIVersion string    `json:"apiVersion"`
+	Kind       string    `json:"kind"`
+	Metadata   Metadata  `json:"metadata"`
+	Spec       SuiteSpec `json:"spec"`
+}
+
+type Metadata struct {
+	Name string `json:"name"`
+}
+
+type SuiteSpec struct {
+	Defaults SuiteDefaults `json:"defaults"`
+	Cases    []Case        `json:"cases"`
+}
+
+type SuiteDefaults struct {
+	Namespace    string    `json:"namespace,omitempty"`
+	Timeout      *Duration `json:"timeout,omitempty"`
+	RuntimeImage string    `json:"runtimeImage,omitempty"`
+}
+
+type Case struct {
+	ID          string                       `json:"id"`
+	Description string                       `json:"description,omitempty"`
+	AgentRun    kontextv1alpha1.AgentRunSpec `json:"agentRun"`
+	Timeout     *Duration                    `json:"timeout,omitempty"`
+	Graders     []Grader                     `json:"graders"`
+}
+
+type GraderType string
+
+const (
+	GraderTerminalPhase    GraderType = "terminalPhase"
+	GraderStatusResult     GraderType = "statusResult"
+	GraderStructuredOutput GraderType = "structuredOutput"
+	GraderUsageFields      GraderType = "usageFields"
+	GraderEnvelopeError    GraderType = "envelopeErrorCode"
+	GraderEnvelopeOutcome  GraderType = "envelopeOutcome"
+	GraderExecutionModel   GraderType = "executionModel"
+	GraderEnvelopeTurns    GraderType = "envelopeTurns"
+	GraderEnvelopeTools    GraderType = "envelopeToolCalls"
+	GraderEventCount       GraderType = "eventCount"
+	GraderToolEvents       GraderType = "toolEvents"
+	GraderDuration         GraderType = "duration"
+	GraderPodExitCode      GraderType = "podExitCode"
+)
+
+type StringMatch struct {
+	Exact       *string `json:"exact,omitempty"`
+	Contains    *string `json:"contains,omitempty"`
+	NotContains *string `json:"notContains,omitempty"`
+}
+
+type StructuredOutputExpectation struct {
+	MediaType string `json:"mediaType,omitempty"`
+	Present   *bool  `json:"present,omitempty"`
+	Valid     *bool  `json:"valid,omitempty"`
+}
+
+type EventCountExpectation struct {
+	Type  eventv1alpha1.Type `json:"type"`
+	Count int                `json:"count"`
+}
+
+type ToolExpectation struct {
+	Name      string `json:"name"`
+	Count     int    `json:"count"`
+	IsError   *bool  `json:"isError,omitempty"`
+	ErrorCode string `json:"errorCode,omitempty"`
+	Truncated *bool  `json:"truncated,omitempty"`
+}
+
+type Grader struct {
+	Type             GraderType                    `json:"type"`
+	Phase            kontextv1alpha1.AgentRunPhase `json:"phase,omitempty"`
+	StatusResult     *StringMatch                  `json:"statusResult,omitempty"`
+	StructuredOutput *StructuredOutputExpectation  `json:"structuredOutput,omitempty"`
+	UsageFields      []string                      `json:"usageFields,omitempty"`
+	ErrorCode        string                        `json:"errorCode,omitempty"`
+	Outcome          resultv1alpha1.Outcome        `json:"outcome,omitempty"`
+	Model            string                        `json:"model,omitempty"`
+	Turns            *int32                        `json:"turns,omitempty"`
+	ToolCalls        *int32                        `json:"toolCalls,omitempty"`
+	Event            *EventCountExpectation        `json:"event,omitempty"`
+	Tool             *ToolExpectation              `json:"tool,omitempty"`
+	MaxDuration      Duration                      `json:"maxDuration,omitempty"`
+	ExitCode         *int32                        `json:"exitCode,omitempty"`
+}
+
+type RunRef struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	PodName   string `json:"podName,omitempty"`
+}
+
+type StatusOutput struct {
+	MediaType string          `json:"mediaType"`
+	Value     json.RawMessage `json:"value"`
+}
+
+type EventSummary struct {
+	Counts    map[eventv1alpha1.Type]int `json:"counts,omitempty"`
+	Tools     []ToolEvent                `json:"tools,omitempty"`
+	Lifecycle []string                   `json:"lifecycle,omitempty"`
+	Errors    []string                   `json:"errors,omitempty"`
+	Metadata  []EventMetadata            `json:"metadata,omitempty"`
+	Truncated bool                       `json:"truncated,omitempty"`
+}
+
+type ToolEvent struct {
+	Name      string `json:"name,omitempty"`
+	Count     int32  `json:"count,omitempty"`
+	IsError   bool   `json:"isError,omitempty"`
+	ErrorCode string `json:"errorCode,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+type EventMetadata struct {
+	Timestamp time.Time          `json:"timestamp"`
+	Type      eventv1alpha1.Type `json:"type"`
+	Phase     string             `json:"phase,omitempty"`
+	Name      string             `json:"name,omitempty"`
+	ErrorCode string             `json:"errorCode,omitempty"`
+	IsError   bool               `json:"isError,omitempty"`
+	Truncated bool               `json:"truncated,omitempty"`
+}
+
+type Grade struct {
+	Type     GraderType `json:"type"`
+	Pass     bool       `json:"pass"`
+	Expected any        `json:"expected,omitempty"`
+	Observed any        `json:"observed,omitempty"`
+	Message  string     `json:"message,omitempty"`
+}
+
+type JudgeResult struct {
+	Configured bool    `json:"configured"`
+	Pass       bool    `json:"pass,omitempty"`
+	Score      float64 `json:"score,omitempty"`
+	Rationale  string  `json:"rationale,omitempty"`
+	Error      string  `json:"error,omitempty"`
+}
+
+type EnvelopeObservation struct {
+	Outcome   resultv1alpha1.Outcome        `json:"outcome,omitempty"`
+	Error     *EnvelopeErrorObservation     `json:"error,omitempty"`
+	Execution *EnvelopeExecutionObservation `json:"execution,omitempty"`
+}
+
+type EnvelopeErrorObservation struct {
+	Code string `json:"code"`
+}
+
+type EnvelopeExecutionObservation struct {
+	Model     string `json:"model,omitempty"`
+	Turns     *int32 `json:"turns,omitempty"`
+	ToolCalls *int32 `json:"toolCalls,omitempty"`
+}
+
+type Record struct {
+	APIVersion       string                        `json:"apiVersion"`
+	Kind             string                        `json:"kind"`
+	Suite            string                        `json:"suite"`
+	CaseID           string                        `json:"caseId"`
+	Description      string                        `json:"description,omitempty"`
+	Run              RunRef                        `json:"run"`
+	StartedAt        time.Time                     `json:"startedAt"`
+	CompletedAt      time.Time                     `json:"completedAt"`
+	DurationMillis   int64                         `json:"durationMillis"`
+	TerminalPhase    kontextv1alpha1.AgentRunPhase `json:"terminalPhase,omitempty"`
+	StatusResult     string                        `json:"statusResult,omitempty"`
+	StatusOutput     *StatusOutput                 `json:"statusOutput,omitempty"`
+	StatusUsage      *kontextv1alpha1.UsageStatus  `json:"statusUsage,omitempty"`
+	PodExitCode      *int32                        `json:"podExitCode,omitempty"`
+	Envelope         *EnvelopeObservation          `json:"envelope,omitempty"`
+	Events           EventSummary                  `json:"events"`
+	Grades           []Grade                       `json:"grades"`
+	Judge            *JudgeResult                  `json:"judge,omitempty"`
+	CollectionErrors []string                      `json:"collectionErrors,omitempty"`
+	Pass             bool                          `json:"pass"`
+}
+
+type Summary struct {
+	APIVersion  string    `json:"apiVersion"`
+	Suite       string    `json:"suite"`
+	StartedAt   time.Time `json:"startedAt"`
+	CompletedAt time.Time `json:"completedAt"`
+	Total       int       `json:"total"`
+	Passed      int       `json:"passed"`
+	Failed      int       `json:"failed"`
+	RecordPath  string    `json:"recordPath"`
+}
+
+func podExitCode(pod *corev1.Pod) *int32 {
+	if pod == nil {
+		return nil
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == "runtime" && status.State.Terminated != nil {
+			value := status.State.Terminated.ExitCode
+			return &value
+		}
+	}
+	return nil
+}
+
+func newAgentRun(name, namespace string, spec kontextv1alpha1.AgentRunSpec, labels map[string]string) *kontextv1alpha1.AgentRun {
+	return &kontextv1alpha1.AgentRun{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: kontextv1alpha1.GroupVersion.String(),
+			Kind:       "AgentRun",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Spec:       spec,
+	}
+}

--- a/pkg/event/v1alpha1/types.go
+++ b/pkg/event/v1alpha1/types.go
@@ -1,0 +1,68 @@
+// Package v1alpha1 defines the versioned JSONL event contract shared by
+// Kontext runtimes and external observers.
+package v1alpha1
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+const APIVersion = "kontext.dev/event/v1alpha1"
+
+type Type string
+
+const (
+	TypeLifecycle Type = "lifecycle"
+	TypeOutput    Type = "output"
+	TypeUsage     Type = "usage"
+	TypeTool      Type = "tool"
+	TypeError     Type = "error"
+)
+
+type Event struct {
+	APIVersion string          `json:"apiVersion"`
+	Timestamp  time.Time       `json:"timestamp"`
+	Type       Type            `json:"type"`
+	Data       json.RawMessage `json:"data"`
+}
+
+func (event Event) Validate() error {
+	if event.APIVersion != APIVersion {
+		return fmt.Errorf("unsupported event apiVersion %q", event.APIVersion)
+	}
+	switch event.Type {
+	case TypeLifecycle, TypeOutput, TypeUsage, TypeTool, TypeError:
+	default:
+		return fmt.Errorf("unsupported event type %q", event.Type)
+	}
+	if event.Timestamp.IsZero() {
+		return fmt.Errorf("event timestamp is required")
+	}
+	if len(bytes.TrimSpace(event.Data)) == 0 || !json.Valid(event.Data) {
+		return fmt.Errorf("event data must be valid JSON")
+	}
+	return nil
+}
+
+func Parse(line []byte) (Event, error) {
+	var event Event
+	decoder := json.NewDecoder(bytes.NewReader(line))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&event); err != nil {
+		return Event{}, fmt.Errorf("decode event: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return Event{}, fmt.Errorf("decode event: trailing JSON value")
+		}
+		return Event{}, fmt.Errorf("decode event trailing data: %w", err)
+	}
+	if err := event.Validate(); err != nil {
+		return Event{}, err
+	}
+	return event, nil
+}

--- a/pkg/event/v1alpha1/types_test.go
+++ b/pkg/event/v1alpha1/types_test.go
@@ -1,0 +1,32 @@
+package v1alpha1_test
+
+import (
+	"strings"
+	"testing"
+
+	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+)
+
+func TestParseValidatesVersionTypeTimestampAndShape(t *testing.T) {
+	valid := `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"tool","data":{"name":"shell"}}`
+	event, err := eventv1alpha1.Parse([]byte(valid))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if event.Type != eventv1alpha1.TypeTool {
+		t.Fatalf("unexpected event type %q", event.Type)
+	}
+	for name, input := range map[string]string{
+		"version":   strings.Replace(valid, eventv1alpha1.APIVersion, "other/v1", 1),
+		"type":      strings.Replace(valid, `"tool"`, `"unknown"`, 1),
+		"timestamp": strings.Replace(valid, `"2026-07-19T00:00:00Z"`, `null`, 1),
+		"unknown":   strings.Replace(valid, `"data":`, `"extra":true,"data":`, 1),
+		"trailing":  valid + `{}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := eventv1alpha1.Parse([]byte(input)); err == nil {
+				t.Fatal("expected parse error")
+			}
+		})
+	}
+}

--- a/runtimes/echo/README.md
+++ b/runtimes/echo/README.md
@@ -1,0 +1,11 @@
+# Echo conformance oracle
+
+The echo image is a deterministic, keyless oracle for the control-plane
+contract. Task mode writes logs, emits a fixed usage/result summary, and exits.
+Service mode remains alive and emits heartbeats so recast behavior can be
+tested without a provider.
+
+During the v1alpha1 transition it intentionally writes the accepted legacy
+`{result,tokensUsed,dollarsUsed}` termination payload. It is not the maintained
+model-backed runtime; use `runtimes/reference` for the versioned envelope,
+provider transports, events, and tools.

--- a/runtimes/python-anthropic/README.md
+++ b/runtimes/python-anthropic/README.md
@@ -1,8 +1,11 @@
-# python-anthropic runtime
+# Legacy python-anthropic behavior oracle
 
-A Kontext runtime image that fulfills one `AgentRun` by sending the goal to the
-Anthropic Messages API and reporting the result through the runtime contract
-(see `SPEC.md` at the repo root).
+This image is retained as a legacy behavior oracle. It is not the maintained
+primary runtime; new provider work and release acceptance target the Go
+`runtimes/reference` image.
+
+It fulfills one `AgentRun` by sending the goal to the Anthropic Messages API
+and reporting through the accepted transition contract (see `SPEC.md`).
 
 Contract surface used:
 
@@ -10,8 +13,9 @@ Contract surface used:
   `KONTEXT_BUDGET_TOKENS`, `KONTEXT_BUDGET_WALLCLOCK`, `KONTEXT_AGENT_NAME`.
 - Expects `ANTHROPIC_API_KEY` injected from the Agent's `secretRef`.
 - Streams progress to stdout (`kubectl logs -f`).
-- Writes `{result, tokensUsed, dollarsUsed}` JSON to `/dev/termination-log`,
-  which the controller parses into `AgentRun.status`.
+- Writes the legacy `{result, tokensUsed, dollarsUsed}` JSON payload to
+  `/dev/termination-log`, which the v1alpha1 controller still parses into
+  `AgentRun.status`.
 
 Build:
 

--- a/runtimes/reference/Dockerfile
+++ b/runtimes/reference/Dockerfile
@@ -8,6 +8,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY pkg/result/ pkg/result/
+COPY pkg/event/ pkg/event/
 COPY runtimes/reporter/ runtimes/reporter/
 COPY runtimes/reference/ runtimes/reference/
 

--- a/runtimes/reference/README.md
+++ b/runtimes/reference/README.md
@@ -17,9 +17,11 @@ kontext-reporter (PID 1)
 ```
 
 The runtime emits versioned JSONL lifecycle, usage, output, and error events to
-stdout. Its final line is a `KONTEXT_RESULT:`-prefixed result envelope. The
-reporter preserves the logs and process exit status, compacts the envelope, and
-writes `/dev/termination-log`.
+stdout. Internally, it gives its final envelope to the bundled reporter through
+the `KONTEXT_RESULT:` capture prefix. The reporter preserves process semantics,
+compacts the envelope, and writes the authoritative Pod termination message.
+Consumers use `AgentRun.status` or that termination message for terminal data;
+raw logs remain events and diagnostics.
 
 No private chain-of-thought is emitted.
 
@@ -175,7 +177,8 @@ The maintained runtime includes three tools:
 
 - `read_knowledge` reads one UTF-8 file below `/kontext/knowledge`. Absolute
   paths, parent traversal, escaping symlinks, directories, and oversized reads
-  are rejected or truncated.
+  are rejected or truncated. The mounted ConfigMap is static context for the
+  run, not production RAG.
 - `kubernetes_read` performs current-namespace `get` or `list` operations for
   a fixed resource allowlist. It has no namespace argument and never permits
   Secrets. Kubernetes RBAC remains authoritative.
@@ -187,7 +190,8 @@ The maintained runtime includes three tools:
 Allowlisting a tool makes it visible to the model; it does not grant new
 infrastructure permissions. The Pod's ServiceAccount, security context,
 mounted volumes, filesystem permissions, and NetworkPolicy determine what a
-tool can actually access.
+tool can actually access. Availability also does not guarantee model use;
+versioned tool events are the evidence that a call occurred.
 
 Environment filtering is defense in depth, not a Secret boundary. The shell
 runs in the same container as the runtime. Filtering changes only the direct
@@ -427,8 +431,9 @@ Each dispatch builds the maintained operator and reference runtime, loads them
 into an ephemeral kind cluster, and injects only the selected provider key
 through a namespace-local Secret. The default `tool` scenario mounts a tiny
 ConfigMap, exposes only `read_knowledge`, and requires exactly one call before
-an exact final response. The `text` scenario preserves the ordinary one-turn
-transport check.
+an exact final response. Acceptance requires exactly one matching tool event
+with `count: 1`, `isError: false`, and no error code. The `text` scenario
+preserves the ordinary one-turn transport check.
 
 The tool scenario permits at most two provider turns, one tool call, 256 bytes
 per tool result and in total, 2,048 cumulative measured tokens, and 90 seconds
@@ -444,6 +449,20 @@ retained briefly; maintainers should still review them before sharing. The
 model and endpoint inputs are visible workflow metadata. The acceptance script
 rejects endpoint userinfo, queries, fragments, and whitespace so credentials
 cannot be embedded there.
+
+The script writes a bounded `kontext.dev/eval/v1alpha1`
+`ProviderAcceptanceRecord` on success and safe failure paths. It includes the
+provider, opaque model, scenario, commit/run identity, phase, duration,
+measured usage, turns, tool calls, and pass/fail only. It excludes API keys,
+Secret values, raw logs, and model output. The workflow uploads this record on
+success or failure with short retention.
+
+Before an alpha release, dispatch the workflow for each maintained transport
+being released, approve the protected environment, require a passing run, and
+retain the `provider-acceptance-<run>-<attempt>` artifact with the release
+evidence. Without those protected credentials, no local or keyless run counts
+as authenticated acceptance. Immutable versioned image publication is a
+separate release step.
 
 ## Dependency inventory
 

--- a/runtimes/reference/internal/events/emitter.go
+++ b/runtimes/reference/internal/events/emitter.go
@@ -6,26 +6,22 @@ import (
 	"io"
 	"sync"
 	"time"
+
+	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
 )
 
-const APIVersion = "kontext.dev/event/v1alpha1"
+const APIVersion = eventv1alpha1.APIVersion
 
-type Type string
+type Type = eventv1alpha1.Type
+type Event = eventv1alpha1.Event
 
 const (
-	TypeLifecycle Type = "lifecycle"
-	TypeOutput    Type = "output"
-	TypeUsage     Type = "usage"
-	TypeTool      Type = "tool"
-	TypeError     Type = "error"
+	TypeLifecycle = eventv1alpha1.TypeLifecycle
+	TypeOutput    = eventv1alpha1.TypeOutput
+	TypeUsage     = eventv1alpha1.TypeUsage
+	TypeTool      = eventv1alpha1.TypeTool
+	TypeError     = eventv1alpha1.TypeError
 )
-
-type Event struct {
-	APIVersion string          `json:"apiVersion"`
-	Timestamp  time.Time       `json:"timestamp"`
-	Type       Type            `json:"type"`
-	Data       json.RawMessage `json:"data"`
-}
 
 type Emitter struct {
 	writer      io.Writer

--- a/runtimes/reporter/README.md
+++ b/runtimes/reporter/README.md
@@ -42,9 +42,11 @@ The child emits a complete versioned envelope on one stdout line:
 KONTEXT_RESULT: {"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","output":{"mediaType":"application/json","value":{"ok":true}}}
 ```
 
-The line remains visible in ordinary logs. If multiple prefixed lines are
-present, the last one wins. Missing, malformed, legacy, or capture-truncated
-candidates produce a failed result envelope.
+The line remains visible in ordinary logs as capture input, but the log copy is
+not the authoritative terminal record. The reporter writes that record to the
+Pod termination message, which the controller projects into `AgentRun.status`.
+If multiple prefixed lines are present, the last one wins. Missing, malformed,
+legacy, or capture-truncated candidates produce a failed result envelope.
 
 `RESULT:` is not a reporter prefix. The exact prefix is `KONTEXT_RESULT:`.
 
@@ -81,7 +83,9 @@ go test ./runtimes/reporter -count=1
 make docker-build-reporter
 ```
 
-Reporter injection into arbitrary workload images is intentionally deferred to
-the control plane. The internal `--install-to PATH` mode atomically copies the
-running static executable into the shared injection volume; it is used by the
-trusted init container rather than by workload authors.
+Reporter injection is selected by `runtime.result` and performed by the control
+plane. The internal `--install-to PATH` mode atomically copies the running
+static executable into the shared injection volume; it is used by the trusted
+init container rather than by workload authors. Images that write a native
+termination envelope omit `runtime.result` and receive no injected reporter.
+See `deploy/examples/v1alpha1/README.md` for all four result paths.

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -51,6 +51,8 @@ cleanup_e2e_resources() {
   kubectl delete agent echo-service --ignore-not-found=true --wait=true || status=1
   kubectl delete agentrun \
     echo-review \
+    plain-logs \
+    native-envelope \
     stdout-last-line \
     stdout-envelope \
     stdout-failure \
@@ -111,6 +113,44 @@ if [[ "${phase}" != "Succeeded" ]]; then
   exit 1
 fi
 echo "task result: ${result}"
+
+echo "==> verifying plain image logs without structured result capture"
+kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/plain-logs-run.yaml"
+wait_for_run_phase plain-logs Succeeded
+plain_result="$(kubectl get agentrun plain-logs -o jsonpath='{.status.result}')"
+plain_output="$(kubectl get agentrun plain-logs -o jsonpath='{.status.output}')"
+plain_logs="$(kubectl logs run-plain-logs -c runtime)"
+plain_init_containers="$(
+  kubectl get pod run-plain-logs -o jsonpath='{.spec.initContainers[*].name}'
+)"
+if [[ -n "${plain_result}" ||
+  -n "${plain_output}" ||
+  "${plain_logs}" != *"ordinary image log"* ||
+  "${plain_init_containers}" == *"inject-reporter"* ]]; then
+  echo "plain image path unexpectedly captured a result or changed its logs" >&2
+  exit 1
+fi
+
+echo "==> verifying a native versioned termination envelope"
+kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/native-envelope-run.yaml"
+wait_for_run_phase native-envelope Succeeded
+native_result="$(kubectl get agentrun native-envelope -o jsonpath='{.status.result}')"
+native_input_tokens="$(
+  kubectl get agentrun native-envelope -o jsonpath='{.status.usage.inputTokens}'
+)"
+native_output_tokens="$(
+  kubectl get agentrun native-envelope -o jsonpath='{.status.usage.outputTokens}'
+)"
+native_init_containers="$(
+  kubectl get pod run-native-envelope -o jsonpath='{.spec.initContainers[*].name}'
+)"
+if [[ "${native_result}" != '{"answer":"native"}' ||
+  "${native_input_tokens}" != "0" ||
+  "${native_output_tokens}" != "1" ||
+  "${native_init_containers}" == *"inject-reporter"* ]]; then
+  echo "native envelope path did not preserve structured output without injection" >&2
+  exit 1
+fi
 
 echo "==> verifying last-line capture from an unmodified image"
 kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/stdout-last-line-run.yaml"

--- a/scripts/eval-kind.sh
+++ b/scripts/eval-kind.sh
@@ -53,10 +53,12 @@ wait_for_service() {
 cleanup() {
   local status=$?
   if [[ "${status}" -eq 0 ]]; then
-    kubectl delete namespace "${EVAL_NAMESPACE}" \
+    if ! kubectl delete namespace "${EVAL_NAMESPACE}" \
       --ignore-not-found=true \
       --wait=true \
-      --timeout=60s >/dev/null
+      --timeout=60s >/dev/null; then
+      echo "warning: evaluation passed but namespace cleanup did not finish" >&2
+    fi
   else
     echo "preserving namespace ${EVAL_NAMESPACE} for diagnostics" >&2
     kubectl get agent,agentrun,pod -n "${EVAL_NAMESPACE}" -o wide >&2 || true

--- a/scripts/eval-kind.sh
+++ b/scripts/eval-kind.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Deterministic, keyless evaluation acceptance against an already-installed kind
+# cluster. The script reuses the images loaded by scripts/install-go-kind.sh.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EVAL_NAMESPACE="${KONTEXT_EVAL_NAMESPACE:-kontext-eval}"
+EVAL_DIR="${KONTEXT_EVAL_DIR:-${ROOT_DIR}/eval-results/kind}"
+RECORDS="${EVAL_DIR}/keyless.jsonl"
+SUMMARY="${EVAL_DIR}/keyless.summary.json"
+MARKER="${EVAL_DIR}/not-run.json"
+SERVICE_AGENT="echo-service"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+wait_for_service() {
+  local previous_run="${1:-}"
+  local current_run=""
+  local pod_name=""
+  local pod_phase=""
+  for _ in $(seq 1 60); do
+    current_run="$(
+      kubectl get agent "${SERVICE_AGENT}" -n "${EVAL_NAMESPACE}" \
+        -o jsonpath='{.status.currentRunName}' 2>/dev/null || true
+    )"
+    pod_name="$(
+      kubectl get pod -n "${EVAL_NAMESPACE}" \
+        -l "kontext.dev/agent=${SERVICE_AGENT}" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true
+    )"
+    pod_phase="$(
+      kubectl get pod "${pod_name}" -n "${EVAL_NAMESPACE}" \
+        -o jsonpath='{.status.phase}' 2>/dev/null || true
+    )"
+    if [[ -n "${current_run}" &&
+      "${current_run}" != "${previous_run}" &&
+      "${pod_phase}" == "Running" ]]; then
+      printf '%s\n' "${current_run}"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "service did not become Running with a fresh run" >&2
+  kubectl get agent,agentrun,pod -n "${EVAL_NAMESPACE}" -o wide >&2 || true
+  return 1
+}
+
+cleanup() {
+  local status=$?
+  if [[ "${status}" -eq 0 ]]; then
+    kubectl delete namespace "${EVAL_NAMESPACE}" \
+      --ignore-not-found=true \
+      --wait=true \
+      --timeout=60s >/dev/null
+  else
+    echo "preserving namespace ${EVAL_NAMESPACE} for diagnostics" >&2
+    kubectl get agent,agentrun,pod -n "${EVAL_NAMESPACE}" -o wide >&2 || true
+  fi
+  return "${status}"
+}
+
+need go
+need jq
+need kubectl
+trap cleanup EXIT
+
+mkdir -p "${EVAL_DIR}"
+rm -f "${RECORDS}" "${SUMMARY}"
+if [[ -f "${MARKER}" ]]; then
+  marker_temporary="${MARKER}.tmp"
+  jq '
+    .state = "Running"
+    | .failureStage = "eval_script_started"
+  ' "${MARKER}" >"${marker_temporary}"
+  mv "${marker_temporary}" "${MARKER}"
+fi
+
+echo "==> preparing disposable evaluation namespace"
+kubectl delete namespace "${EVAL_NAMESPACE}" \
+  --ignore-not-found=true \
+  --wait=true \
+  --timeout=60s >/dev/null
+kubectl create namespace "${EVAL_NAMESPACE}" >/dev/null
+kubectl apply -n "${EVAL_NAMESPACE}" \
+  -f "${ROOT_DIR}/evals/fixtures/keyless-setup.yaml" >/dev/null
+
+echo "==> running external keyless evaluation suite"
+(
+  cd "${ROOT_DIR}"
+  go run ./cmd/kontext-eval \
+    --suite evals/suites/keyless.yaml \
+    --namespace "${EVAL_NAMESPACE}" \
+    --records "${RECORDS}" \
+    --summary "${SUMMARY}" \
+    --keep-runs
+)
+
+echo "==> validating machine-readable evaluation records"
+jq -e '
+  .apiVersion == "kontext.dev/eval/v1alpha1"
+  and .suite == "keyless"
+  and .total == 10
+  and .passed == 10
+  and .failed == 0
+' "${SUMMARY}" >/dev/null
+
+jq -s -e '
+  length == 10
+  and all(.[];
+    .apiVersion == "kontext.dev/eval/v1alpha1"
+    and .kind == "EvalRecord"
+    and .pass == true
+    and (.collectionErrors | length == 0)
+  )
+  and (
+    map(select(.caseId == "same-goal-model-a"))[0] as $a
+    | map(select(.caseId == "same-goal-model-b"))[0] as $b
+    | $a.statusResult == $b.statusResult
+    and $a.envelope.execution.model == "opaque/vendor-model-a@eval"
+    and $b.envelope.execution.model == "opaque/vendor-model-b@eval"
+  )
+  and (
+    map(select(.caseId == "read-knowledge-used"))[0]
+    | .envelope.execution.toolCalls == 1
+    and ([
+      .events.tools[]
+      | select(.name == "read_knowledge" and ((.isError // false) == false))
+    ] | length) == 1
+  )
+  and (
+    map(select(.caseId == "read-knowledge-available-not-used"))[0]
+    | .envelope.execution.toolCalls == 0
+    and ((.events.counts.tool // 0) == 0)
+  )
+  and (
+    map(select(.caseId == "kubernetes-read-rbac-denied"))[0]
+    | [.events.tools[] | select(
+        .name == "kubernetes_read"
+        and .isError == true
+        and .errorCode == "kubernetes_rbac_denied"
+      )] | length == 1
+  )
+  and (
+    map(select(.caseId == "missing-provider-credential"))[0]
+    | .terminalPhase == "Failed"
+    and .envelope.error.code == "missing_provider_credentials"
+  )
+  and (
+    map(select(.caseId == "provider-network-failure"))[0]
+    | .terminalPhase == "Failed"
+    and .envelope.error.code == "provider_network_error"
+  )
+  and (
+    map(select(.caseId == "controller-wallclock"))[0]
+    | .terminalPhase == "BudgetExceeded"
+  )
+  and (
+    map(select(.caseId == "malformed-provider-response"))[0]
+    | .terminalPhase == "Failed"
+    and .envelope.error.code == "invalid_provider_response"
+  )
+  and (
+    map(select(.caseId == "reporter-process-crash"))[0]
+    | .terminalPhase == "Failed"
+    and .podExitCode == 7
+  )
+' "${RECORDS}" >/dev/null
+
+wallclock_pod="$(
+  jq -r 'select(.caseId == "controller-wallclock") | .run.podName' "${RECORDS}"
+)"
+wallclock_run="$(
+  jq -r 'select(.caseId == "controller-wallclock") | .run.name' "${RECORDS}"
+)"
+for _ in $(seq 1 30); do
+  if ! kubectl get pod "${wallclock_pod}" -n "${EVAL_NAMESPACE}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+wallclock_phase="$(
+  kubectl get agentrun "${wallclock_run}" -n "${EVAL_NAMESPACE}" \
+    -o jsonpath='{.status.phase}' 2>/dev/null || true
+)"
+if [[ -z "${wallclock_pod}" ||
+  -z "${wallclock_run}" ||
+  "${wallclock_phase}" != "BudgetExceeded" ]] ||
+  kubectl get pod "${wallclock_pod}" -n "${EVAL_NAMESPACE}" >/dev/null 2>&1; then
+  echo "wallclock case did not record and clean up its runtime Pod" >&2
+  exit 1
+fi
+
+if jq -s -e '
+  tostring
+  | test("keyless-placeholder|fixture process is exiting")
+' "${RECORDS}" "${SUMMARY}" >/dev/null; then
+  echo "evaluation outputs contain a credential marker or raw fixture log" >&2
+  exit 1
+fi
+
+echo "==> proving Service mode omits wallclock deadlines and recasts"
+kubectl apply -n "${EVAL_NAMESPACE}" \
+  -f "${ROOT_DIR}/deploy/examples/v1alpha1/echo-service-agent.yaml" >/dev/null
+first_run="$(wait_for_service)"
+first_pod="$(
+  kubectl get pod -n "${EVAL_NAMESPACE}" \
+    -l "kontext.dev/agent=${SERVICE_AGENT}" \
+    -o jsonpath='{.items[0].metadata.name}'
+)"
+
+if ! kubectl get agent "${SERVICE_AGENT}" -n "${EVAL_NAMESPACE}" -o json |
+  jq -e '((.spec.budget // {}) | has("wallclock") | not)' >/dev/null; then
+  echo "Service example unexpectedly configures a wallclock budget" >&2
+  exit 1
+fi
+if ! kubectl get agentrun "${first_run}" -n "${EVAL_NAMESPACE}" -o json |
+  jq -e '((.spec.budget // {}) | has("wallclock") | not)' >/dev/null; then
+  echo "Service run unexpectedly inherited a wallclock budget" >&2
+  exit 1
+fi
+if ! kubectl get pod "${first_pod}" -n "${EVAL_NAMESPACE}" -o json |
+  jq -e '.spec.activeDeadlineSeconds == null and .status.phase == "Running"' >/dev/null; then
+  echo "Service Pod has a deadline or is not Running" >&2
+  exit 1
+fi
+
+kubectl delete pod "${first_pod}" -n "${EVAL_NAMESPACE}" --wait=true >/dev/null
+second_run="$(wait_for_service "${first_run}")"
+if [[ "${second_run}" == "${first_run}" ]]; then
+  echo "Service controller did not recast a fresh AgentRun" >&2
+  exit 1
+fi
+
+rm -f "${MARKER}"
+echo "keyless eval acceptance passed: records=${RECORDS} summary=${SUMMARY}"

--- a/scripts/provider-acceptance-kind.sh
+++ b/scripts/provider-acceptance-kind.sh
@@ -17,6 +17,91 @@ runtime_image="${KONTEXT_REFERENCE_IMAGE:-kontext-reference:dev}"
 run_name="provider-${scenario}"
 secret_name="provider-acceptance-credentials"
 knowledge_name="provider-acceptance-knowledge"
+record_path="${KONTEXT_ACCEPTANCE_RECORD:-${KONTEXT_EVAL_DIR:-eval-results}/provider-acceptance.json}"
+started_epoch="$(date +%s)"
+phase="NotStarted"
+failure_stage="initialization"
+pass=false
+usage_json='{}'
+turns_json='null'
+tool_calls_json='null'
+commit_sha="${GITHUB_SHA:-}"
+run_id="${GITHUB_RUN_ID:-local}"
+run_attempt="${GITHUB_RUN_ATTEMPT:-1}"
+
+need jq
+
+if [[ -z "${commit_sha}" ]]; then
+  commit_sha="$(git -C "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+fi
+
+write_acceptance_record() {
+  local completed_epoch duration_millis record_dir temp_path
+  completed_epoch="$(date +%s)"
+  duration_millis="$(( (completed_epoch - started_epoch) * 1000 ))"
+  record_dir="$(dirname "${record_path}")"
+  mkdir -p "${record_dir}"
+  temp_path="${record_path}.tmp"
+  jq -n \
+    --arg apiVersion "kontext.dev/eval/v1alpha1" \
+    --arg commitSHA "${commit_sha:0:64}" \
+    --arg failureStage "${failure_stage:0:128}" \
+    --arg kind "ProviderAcceptanceRecord" \
+    --arg model "${model:0:256}" \
+    --arg phase "${phase:0:64}" \
+    --arg provider "${provider:0:64}" \
+    --arg runAttempt "${run_attempt:0:32}" \
+    --arg runID "${run_id:0:128}" \
+    --arg scenario "${scenario:0:64}" \
+    --argjson durationMillis "${duration_millis}" \
+    --argjson measuredUsage "${usage_json}" \
+    --argjson pass "${pass}" \
+    --argjson toolCalls "${tool_calls_json}" \
+    --argjson turns "${turns_json}" \
+    '{
+      apiVersion: $apiVersion,
+      kind: $kind,
+      provider: $provider,
+      model: $model,
+      scenario: $scenario,
+      commitSHA: $commitSHA,
+      runID: $runID,
+      runAttempt: $runAttempt,
+      phase: $phase,
+      durationMillis: $durationMillis,
+      measuredUsage: $measuredUsage,
+      turns: $turns,
+      toolCalls: $toolCalls,
+      pass: $pass
+    }
+    | if $pass then . else .failureStage = $failureStage end' >"${temp_path}"
+  mv "${temp_path}" "${record_path}"
+}
+
+on_exit() {
+  local status=$?
+  trap - EXIT
+  if [[ "${status}" -eq 0 ]]; then
+    pass=true
+    failure_stage=""
+  fi
+  if ! write_acceptance_record; then
+    echo "failed to write provider acceptance record: ${record_path}" >&2
+    if [[ "${status}" -eq 0 ]]; then
+      status=1
+    fi
+  fi
+  exit "${status}"
+}
+
+trap on_exit EXIT
+
+if [[ "${KONTEXT_ACCEPTANCE_INITIALIZE_ONLY:-false}" == "true" ]]; then
+  failure_stage="workflow_not_started"
+  write_acceptance_record
+  trap - EXIT
+  exit 0
+fi
 
 if [[ -n "${endpoint}" ]]; then
   if [[ "${endpoint}" != http://* && "${endpoint}" != https://* ]]; then
@@ -34,10 +119,17 @@ fi
 
 case "${provider}" in
   anthropic)
+    normalized_provider="anthropic"
     credential_env="ANTHROPIC_API_KEY"
     other_credential_env="OPENAI_API_KEY"
     ;;
-  openai | openai-compatible)
+  openai)
+    normalized_provider="openai"
+    credential_env="OPENAI_API_KEY"
+    other_credential_env="ANTHROPIC_API_KEY"
+    ;;
+  openai-compatible)
+    normalized_provider="openai-compatible"
     credential_env="OPENAI_API_KEY"
     other_credential_env="ANTHROPIC_API_KEY"
     ;;
@@ -63,8 +155,6 @@ case "${scenario}" in
     exit 1
     ;;
 esac
-
-need jq
 
 render_run_manifest() {
   jq -n \
@@ -137,17 +227,21 @@ render_run_manifest() {
 }
 
 if [[ "${KONTEXT_ACCEPTANCE_RENDER_ONLY:-false}" == "true" ]]; then
+  trap - EXIT
   render_run_manifest
   exit 0
 fi
 
 need kubectl
 
+failure_stage="credential_check"
 if [[ -z "${KONTEXT_PROVIDER_API_KEY:-}" ]]; then
   echo "the selected provider credential is empty" >&2
   exit 1
 fi
 
+phase="Preparing"
+failure_stage="namespace_setup"
 echo "==> preparing isolated namespace"
 kubectl create namespace "${namespace}" \
   --dry-run=client \
@@ -173,9 +267,12 @@ if [[ "${scenario}" == "tool" ]]; then
     kubectl apply -f - >/dev/null
 fi
 
+phase="Pending"
+failure_stage="create_agentrun"
 echo "==> creating ${provider} ${scenario} AgentRun"
 render_run_manifest | kubectl apply -f - >/dev/null
 
+failure_stage="wait_for_terminal_phase"
 echo "==> waiting for AgentRun success"
 phase=""
 for _ in $(seq 1 75); do
@@ -211,6 +308,18 @@ run_json="$(
     --namespace "${namespace}" \
     -o json
 )"
+usage_json="$(
+  jq -c '
+    (.status.usage // {})
+    | with_entries(select(
+        .key == "tokens"
+        or .key == "inputTokens"
+        or .key == "outputTokens"
+        or .key == "dollars"
+      ))
+  ' <<<"${run_json}"
+)"
+failure_stage="validate_result"
 result="$(jq -r '.status.result' <<<"${run_json}")"
 if [[ "${result}" != "${expected_result}" ]]; then
   echo "unexpected final result: ${result}" >&2
@@ -271,54 +380,72 @@ if ! kubectl get secret "${secret_name}" \
   exit 1
 fi
 
-logs="$(
-  kubectl logs "${pod_name}" \
-    --namespace "${namespace}" \
-    --container runtime
-)"
+failure_stage="validate_envelope"
 envelope="$(
-  jq -R -s -c '
+  jq -c '
     [
-      split("\n")[]
-      | select(startswith("KONTEXT_RESULT:"))
-      | sub("^KONTEXT_RESULT:[[:space:]]*"; "")
+      .status.containerStatuses[]?
+      | select(.name == "runtime")
+      | .state.terminated.message // empty
       | fromjson
     ]
     | last
-  ' <<<"${logs}"
+  ' <<<"${pod_json}"
 )"
 if [[ "${envelope}" == "null" ]]; then
-  echo "runtime logs did not contain a terminal result envelope" >&2
+  echo "runtime Pod did not contain a terminal result envelope" >&2
   exit 1
 fi
 
+if ! jq -e \
+  --arg expectedModel "${model}" \
+  --arg expectedProvider "${normalized_provider}" '
+    .apiVersion == "kontext.dev/result/v1alpha1"
+    and .execution.provider == $expectedProvider
+    and .execution.model == $expectedModel
+  ' <<<"${envelope}" >/dev/null; then
+  echo "terminal envelope did not preserve provider/model identity" >&2
+  exit 1
+fi
+
+turns_json="$(jq -c '.execution.turns // null' <<<"${envelope}")"
+tool_calls_json="$(jq -c '.execution.toolCalls // null' <<<"${envelope}")"
+
 if [[ "${scenario}" == "tool" ]]; then
-  tool_event_count="$(
-    jq -R -s '
-      [
-        split("\n")[]
-        | fromjson?
-        | select(
-            .apiVersion == "kontext.dev/event/v1alpha1"
-            and .type == "tool"
-            and .data.name == "read_knowledge"
-          )
-      ]
-      | length
-    ' <<<"${logs}"
+  failure_stage="validate_tool_event"
+  logs="$(
+    kubectl logs "${pod_name}" \
+      --namespace "${namespace}" \
+      --container runtime
   )"
-  if [[ "${tool_event_count}" != "1" ]] ||
+  if ! jq -R -s -e '
+    [
+      split("\n")[]
+      | fromjson?
+      | select(
+          .apiVersion == "kontext.dev/event/v1alpha1"
+          and .type == "tool"
+        )
+    ] as $events
+    | ($events | length) == 1
+    and $events[0].data.name == "read_knowledge"
+    and $events[0].data.count == 1
+    and $events[0].data.isError == false
+    and (($events[0].data.errorCode // "") == "")
+  ' <<<"${logs}" >/dev/null ||
     ! jq -e '
-      .outcome == "Succeeded"
+      .apiVersion == "kontext.dev/result/v1alpha1"
+      and .outcome == "Succeeded"
       and .execution.turns == 2
       and .execution.toolCalls == 1
     ' <<<"${envelope}" >/dev/null; then
-    echo "tool scenario did not record exactly one read_knowledge call" >&2
+    echo "tool scenario did not record exactly one successful read_knowledge event" >&2
     exit 1
   fi
 else
   if ! jq -e '
-    .outcome == "Succeeded"
+    .apiVersion == "kontext.dev/result/v1alpha1"
+    and .outcome == "Succeeded"
     and .execution.turns == 1
     and .execution.toolCalls == 0
   ' <<<"${envelope}" >/dev/null; then
@@ -327,4 +454,6 @@ else
   fi
 fi
 
+phase="Succeeded"
+failure_stage="complete"
 echo "provider acceptance passed: provider=${provider} scenario=${scenario}"


### PR DESCRIPTION
## Summary
- add an external `kontext-eval` runner with strict suites, grader-driven collection, deterministic grading, bounded optional judges, and private machine-readable records
- add a 10-case keyless suite covering model comparisons, tool choice, RBAC, credentials, endpoint failures, cancellation, malformed responses, and process crashes
- record protected provider acceptance, document runtime/BYO choices and operational limits, and index plain, captured, structured, native, and no-deadline Service examples

Closes #21

## Stack
- depends on #32
- targets `feat/mcp-tools` so this diff contains only issue #21; retarget to `main` after #32 merges

## Test plan
- [x] `make test`
- [x] `make vulncheck`
- [x] `go test -race ./internal/eval ./pkg/event/v1alpha1`
- [x] `./scripts/e2e-kind.sh`
- [x] `./scripts/eval-kind.sh` (10/10 cases plus no-deadline Service recast)
- [x] provider acceptance initialization/render checks
- [x] workflow, shell, manifest, generated-artifact, and CLI build/help validation

Protected authenticated provider acceptance remains a documented pre-alpha release step because those environment credentials are not available locally.