### PR TITLE
Fix service recast reconciliation from observed runs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,8 +80,9 @@ func main() {
 	}
 
 	if err := (&controller.AgentReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Agent")
 		os.Exit(1)

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -113,7 +113,7 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 		if !apierrors.IsAlreadyExists(err) {
 			return ctrl.Result{}, err
 		}
-		return r.handleServiceRunAlreadyExists(ctx, agent, runName, nextSuffix)
+		return r.handleServiceRunAlreadyExists(ctx, agent, runName)
 	}
 
 	nextStatus := kontextv1alpha1.AgentStatus{
@@ -143,7 +143,6 @@ func (r *AgentReconciler) handleServiceRunAlreadyExists(
 	ctx context.Context,
 	agent *kontextv1alpha1.Agent,
 	runName string,
-	expectedSuffix int32,
 ) (ctrl.Result, error) {
 	if r.APIReader == nil {
 		return ctrl.Result{}, fmt.Errorf("cannot verify existing AgentRun %s/%s: APIReader is not configured", agent.Namespace, runName)
@@ -157,8 +156,7 @@ func (r *AgentReconciler) handleServiceRunAlreadyExists(
 		return ctrl.Result{}, err
 	}
 
-	suffix, canonical := serviceRunSuffix(agent.Name, existing.Name)
-	if canonical && suffix == expectedSuffix && metav1.IsControlledBy(&existing, agent) {
+	if metav1.IsControlledBy(&existing, agent) {
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -172,10 +170,9 @@ func (r *AgentReconciler) handleServiceRunAlreadyExists(
 }
 
 type observedServiceRuns struct {
-	current    *kontextv1alpha1.AgentRun
-	previous   *kontextv1alpha1.AgentRun
-	maxSuffix  int32
-	prevSuffix int32
+	current   *kontextv1alpha1.AgentRun
+	previous  *kontextv1alpha1.AgentRun
+	maxSuffix int32
 }
 
 func (r *AgentReconciler) observeServiceRuns(
@@ -193,6 +190,7 @@ func (r *AgentReconciler) observeServiceRuns(
 	}
 
 	var observed observedServiceRuns
+	var previousSuffix int32
 	for i := range children.Items {
 		run := &children.Items[i]
 		if !metav1.IsControlledBy(run, agent) {
@@ -205,12 +203,12 @@ func (r *AgentReconciler) observeServiceRuns(
 		switch {
 		case suffix > observed.maxSuffix:
 			observed.previous = observed.current
-			observed.prevSuffix = observed.maxSuffix
+			previousSuffix = observed.maxSuffix
 			observed.current = run
 			observed.maxSuffix = suffix
-		case suffix > observed.prevSuffix:
+		case suffix > previousSuffix:
 			observed.previous = run
-			observed.prevSuffix = suffix
+			previousSuffix = suffix
 		}
 	}
 	return observed, nil
@@ -230,6 +228,8 @@ func serviceRunSuffix(agentName, runName string) (int32, bool) {
 }
 
 func (runs observedServiceRuns) status(generation int64) kontextv1alpha1.AgentStatus {
+	// Run suffixes form a monotonic creation sequence, so deleting old runs
+	// does not reduce the historical creation and restart counters.
 	next := kontextv1alpha1.AgentStatus{
 		RunsCreated:        runs.maxSuffix,
 		ObservedGeneration: generation,

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -3,12 +3,13 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -25,12 +26,14 @@ import (
 const (
 	defaultBackoffInitial = 5
 	defaultBackoffMax     = 60
+	maxRunSuffix          = int32(1<<31 - 1)
 )
 
 // AgentReconciler reconciles an Agent object.
 type AgentReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 }
 
 // +kubebuilder:rbac:groups=kontext.dev,resources=agents,verbs=get;list;watch;create;update;patch;delete
@@ -56,8 +59,13 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1alpha1.Agent) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	runs, err := r.observeServiceRuns(ctx, agent)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if agent.Spec.Goal == "" {
-		return r.setAgentStatus(ctx, agent, agent.Status, false, metav1.Condition{
+		return r.setAgentStatus(ctx, agent, runs.status(agent.Generation), false, metav1.Condition{
 			Type:    conditions.Ready,
 			Status:  metav1.ConditionFalse,
 			Reason:  "MissingGoal",
@@ -65,27 +73,12 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 		})
 	}
 
-	currentRun, missingCurrentRun, err := r.getCurrentRun(ctx, agent)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if missingCurrentRun {
-		logger.Info("current service run missing; minting replacement", "agent", agent.Name, "run", agent.Status.CurrentRunName)
-	}
-
-	if currentRun != nil && !status.IsTerminalPhase(currentRun.Status.Phase) {
-		return r.setAgentStatus(ctx, agent, kontextv1alpha1.AgentStatus{
-			CurrentRunName:     currentRun.Name,
-			LastRunName:        agent.Status.LastRunName,
-			RunsCreated:        agent.Status.RunsCreated,
-			Restarts:           agent.Status.Restarts,
-			ObservedGeneration: agent.Generation,
-		}, false, metav1.Condition{
+	if runs.current != nil && !status.IsTerminalPhase(runs.current.Status.Phase) {
+		return r.setAgentStatus(ctx, agent, runs.status(agent.Generation), false, metav1.Condition{
 			Type:    conditions.Ready,
 			Status:  metav1.ConditionTrue,
 			Reason:  "RunActive",
-			Message: fmt.Sprintf("Service run %s is active.", currentRun.Name),
+			Message: fmt.Sprintf("Service run %s is active.", runs.current.Name),
 		}, metav1.Condition{
 			Type:    conditions.Progressing,
 			Status:  metav1.ConditionFalse,
@@ -94,48 +87,43 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 		})
 	}
 
-	if currentRun != nil && status.IsTerminalPhase(currentRun.Status.Phase) {
-		delay := r.backoffDelay(*agent)
-		if since := timeSinceCompletion(currentRun); since < delay {
-			logger.Info("waiting before service recast", "delay", delay-since, "run", currentRun.Name)
+	if runs.current != nil && status.IsTerminalPhase(runs.current.Status.Phase) &&
+		runs.current.Status.CompletionTime != nil {
+		delay := r.backoffDelay(*agent, runs.maxSuffix-1)
+		if since := time.Since(runs.current.Status.CompletionTime.Time); since < delay {
+			logger.Info("waiting before service recast", "delay", delay-since, "run", runs.current.Name)
+			if _, err := r.setAgentStatus(ctx, agent, runs.status(agent.Generation), false); err != nil {
+				return ctrl.Result{}, err
+			}
 			return ctrl.Result{RequeueAfter: delay - since}, nil
 		}
 	}
 
-	runName := fmt.Sprintf("%s-%d", agent.Name, agent.Status.RunsCreated+1)
+	if runs.maxSuffix == maxRunSuffix {
+		return ctrl.Result{}, fmt.Errorf("service run suffix exhausted for Agent %s/%s", agent.Namespace, agent.Name)
+	}
+	nextSuffix := runs.maxSuffix + 1
+	runName := fmt.Sprintf("%s-%d", agent.Name, nextSuffix)
 	run := r.buildServiceRun(agent, runName)
 	if err := controllerutil.SetControllerReference(agent, run, r.Scheme); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	created := true
 	if err := r.Create(ctx, run); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return ctrl.Result{}, err
 		}
-		created = false
-		var existing kontextv1alpha1.AgentRun
-		if err := r.Get(ctx, types.NamespacedName{
-			Namespace: agent.Namespace,
-			Name:      runName,
-		}, &existing); err != nil {
-			return ctrl.Result{}, err
-		}
-		run = &existing
+		return r.handleServiceRunAlreadyExists(ctx, agent, runName, nextSuffix)
 	}
 
 	nextStatus := kontextv1alpha1.AgentStatus{
 		CurrentRunName:     run.Name,
-		LastRunName:        agent.Status.CurrentRunName,
-		RunsCreated:        agent.Status.RunsCreated,
-		Restarts:           agent.Status.Restarts,
+		RunsCreated:        nextSuffix,
+		Restarts:           nextSuffix - 1,
 		ObservedGeneration: agent.Generation,
 	}
-	if created {
-		nextStatus.RunsCreated = agent.Status.RunsCreated + 1
-		if currentRun != nil {
-			nextStatus.Restarts = agent.Status.Restarts + 1
-		}
+	if runs.current != nil {
+		nextStatus.LastRunName = runs.current.Name
 	}
 
 	return r.setAgentStatus(ctx, agent, nextStatus, true, metav1.Condition{
@@ -151,21 +139,111 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 	})
 }
 
-func (r *AgentReconciler) getCurrentRun(ctx context.Context, agent *kontextv1alpha1.Agent) (*kontextv1alpha1.AgentRun, bool, error) {
-	if agent.Status.CurrentRunName == "" {
-		return nil, false, nil
+func (r *AgentReconciler) handleServiceRunAlreadyExists(
+	ctx context.Context,
+	agent *kontextv1alpha1.Agent,
+	runName string,
+	expectedSuffix int32,
+) (ctrl.Result, error) {
+	if r.APIReader == nil {
+		return ctrl.Result{}, fmt.Errorf("cannot verify existing AgentRun %s/%s: APIReader is not configured", agent.Namespace, runName)
 	}
-	var run kontextv1alpha1.AgentRun
-	if err := r.Get(ctx, types.NamespacedName{
-		Namespace: agent.Namespace,
-		Name:      agent.Status.CurrentRunName,
-	}, &run); err != nil {
+
+	var existing kontextv1alpha1.AgentRun
+	if err := r.APIReader.Get(ctx, client.ObjectKey{Namespace: agent.Namespace, Name: runName}, &existing); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, true, nil
+			return ctrl.Result{Requeue: true}, nil
 		}
-		return nil, false, err
+		return ctrl.Result{}, err
 	}
-	return &run, false, nil
+
+	suffix, canonical := serviceRunSuffix(agent.Name, existing.Name)
+	if canonical && suffix == expectedSuffix && metav1.IsControlledBy(&existing, agent) {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	return ctrl.Result{}, fmt.Errorf(
+		"service run name collision: AgentRun %s/%s is not controlled by Agent %s/%s",
+		existing.Namespace,
+		existing.Name,
+		agent.Namespace,
+		agent.Name,
+	)
+}
+
+type observedServiceRuns struct {
+	current    *kontextv1alpha1.AgentRun
+	previous   *kontextv1alpha1.AgentRun
+	maxSuffix  int32
+	prevSuffix int32
+}
+
+func (r *AgentReconciler) observeServiceRuns(
+	ctx context.Context,
+	agent *kontextv1alpha1.Agent,
+) (observedServiceRuns, error) {
+	var children kontextv1alpha1.AgentRunList
+	if err := r.List(
+		ctx,
+		&children,
+		client.InNamespace(agent.Namespace),
+		client.MatchingLabels{podbuilder.LabelAgentName: agent.Name},
+	); err != nil {
+		return observedServiceRuns{}, err
+	}
+
+	var observed observedServiceRuns
+	for i := range children.Items {
+		run := &children.Items[i]
+		if !metav1.IsControlledBy(run, agent) {
+			continue
+		}
+		suffix, ok := serviceRunSuffix(agent.Name, run.Name)
+		if !ok {
+			continue
+		}
+		switch {
+		case suffix > observed.maxSuffix:
+			observed.previous = observed.current
+			observed.prevSuffix = observed.maxSuffix
+			observed.current = run
+			observed.maxSuffix = suffix
+		case suffix > observed.prevSuffix:
+			observed.previous = run
+			observed.prevSuffix = suffix
+		}
+	}
+	return observed, nil
+}
+
+func serviceRunSuffix(agentName, runName string) (int32, bool) {
+	prefix := agentName + "-"
+	if !strings.HasPrefix(runName, prefix) {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(strings.TrimPrefix(runName, prefix), 10, 32)
+	if err != nil || value < 1 {
+		return 0, false
+	}
+	suffix := int32(value)
+	return suffix, runName == fmt.Sprintf("%s-%d", agentName, suffix)
+}
+
+func (runs observedServiceRuns) status(generation int64) kontextv1alpha1.AgentStatus {
+	next := kontextv1alpha1.AgentStatus{
+		RunsCreated:        runs.maxSuffix,
+		ObservedGeneration: generation,
+	}
+	if runs.maxSuffix > 0 {
+		next.Restarts = runs.maxSuffix - 1
+	}
+	if runs.current != nil {
+		next.CurrentRunName = runs.current.Name
+	}
+	if runs.previous != nil {
+		next.LastRunName = runs.previous.Name
+	}
+	return next
 }
 
 func (r *AgentReconciler) buildServiceRun(agent *kontextv1alpha1.Agent, runName string) *kontextv1alpha1.AgentRun {
@@ -203,7 +281,7 @@ func (r *AgentReconciler) buildServiceRun(agent *kontextv1alpha1.Agent, runName 
 	return run
 }
 
-func (r *AgentReconciler) backoffDelay(agent kontextv1alpha1.Agent) time.Duration {
+func (r *AgentReconciler) backoffDelay(agent kontextv1alpha1.Agent, restarts int32) time.Duration {
 	initial := int32(defaultBackoffInitial)
 	maximum := int32(defaultBackoffMax)
 	if agent.Spec.Backoff != nil {
@@ -215,26 +293,25 @@ func (r *AgentReconciler) backoffDelay(agent kontextv1alpha1.Agent) time.Duratio
 		}
 	}
 
-	attempt := agent.Status.Restarts
+	attempt := restarts
 	if attempt < 1 {
 		attempt = 1
 	}
 	delay := time.Duration(initial) * time.Second
-	for i := int32(1); i < attempt; i++ {
-		delay *= 2
-	}
 	maxDelay := time.Duration(maximum) * time.Second
-	if delay > maxDelay {
-		delay = maxDelay
+	if delay >= maxDelay {
+		return maxDelay
+	}
+	for i := int32(1); i < attempt; i++ {
+		if delay > maxDelay-delay {
+			return maxDelay
+		}
+		delay *= 2
+		if delay >= maxDelay {
+			return maxDelay
+		}
 	}
 	return delay
-}
-
-func timeSinceCompletion(run *kontextv1alpha1.AgentRun) time.Duration {
-	if run.Status.CompletionTime != nil {
-		return time.Since(run.Status.CompletionTime.Time)
-	}
-	return 0
 }
 
 func (r *AgentReconciler) setAgentStatus(

--- a/internal/controller/agent_controller_internal_test.go
+++ b/internal/controller/agent_controller_internal_test.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+)
+
+func TestBackoffDelaySaturatesForLargeRestartCount(t *testing.T) {
+	reconciler := &AgentReconciler{}
+	agent := kontextv1alpha1.Agent{
+		Spec: kontextv1alpha1.AgentSpec{
+			Backoff: &kontextv1alpha1.BackoffSpec{
+				InitialSeconds: 1,
+				MaxSeconds:     60,
+			},
+		},
+	}
+
+	if got := reconciler.backoffDelay(agent, maxRunSuffix-1); got != 60*time.Second {
+		t.Fatalf("expected saturated 60-second backoff, got %s", got)
+	}
+}
+
+func TestBackoffDelayCapsInitialAtMaximum(t *testing.T) {
+	reconciler := &AgentReconciler{}
+	agent := kontextv1alpha1.Agent{
+		Spec: kontextv1alpha1.AgentSpec{
+			Backoff: &kontextv1alpha1.BackoffSpec{
+				InitialSeconds: 30,
+				MaxSeconds:     10,
+			},
+		},
+	}
+
+	if got := reconciler.backoffDelay(agent, 1); got != 10*time.Second {
+		t.Fatalf("expected maximum 10-second backoff, got %s", got)
+	}
+}

--- a/internal/controller/agent_controller_test.go
+++ b/internal/controller/agent_controller_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,9 +11,11 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
 	"github.com/kontext-dev/kontext/internal/conditions"
+	"github.com/kontext-dev/kontext/internal/controller"
 	"github.com/kontext-dev/kontext/internal/podbuilder"
 )
 
@@ -96,6 +99,151 @@ func TestAgentReconcilerMintsServiceRun(t *testing.T) {
 	}
 }
 
+func TestAgentReconcilerRequeuesWhenCachedListMissesOwnedRun(t *testing.T) {
+	ctx := context.Background()
+	agent := &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale-list-owner",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:     kontextv1alpha1.AgentModeService,
+			Goal:     "stay ready",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	run := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale-list-owner-1",
+			Namespace: agent.Namespace,
+			Labels:    map[string]string{podbuilder.LabelAgentName: agent.Name},
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			AgentRef: &kontextv1alpha1.AgentRef{Name: agent.Name},
+			Goal:     agent.Spec.Goal,
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	createOwnedAgentRun(ctx, t, agent, run)
+
+	staleClient := &staleAgentRunListClient{
+		Client:   k8sClient,
+		omitName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace},
+	}
+	reconciler := &controller.AgentReconciler{
+		Client:    staleClient,
+		APIReader: k8sClient,
+		Scheme:    scheme,
+	}
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("reconcile with stale List: %v", err)
+	}
+	if !result.Requeue || result.RequeueAfter != 0 {
+		t.Fatalf("expected clean immediate requeue, got %#v", result)
+	}
+
+	var updated kontextv1alpha1.Agent
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if updated.Status.CurrentRunName != "" || updated.Status.RunsCreated != 0 {
+		t.Fatalf("stale-list recovery mutated status: %#v", updated.Status)
+	}
+
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace},
+	}); err != nil {
+		t.Fatalf("follow-up reconcile: %v", err)
+	}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get agent after follow-up: %v", err)
+	}
+	if updated.Status.CurrentRunName != run.Name || updated.Status.RunsCreated != 1 {
+		t.Fatalf("follow-up did not observe existing run: %#v", updated.Status)
+	}
+
+	var runs kontextv1alpha1.AgentRunList
+	if err := k8sClient.List(ctx, &runs, client.InNamespace(agent.Namespace), client.MatchingLabels{
+		podbuilder.LabelAgentName: agent.Name,
+	}); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs.Items) != 1 {
+		t.Fatalf("expected one owned run after stale-list recovery, got %d", len(runs.Items))
+	}
+}
+
+func TestAgentReconcilerRejectsUnrelatedRunNameCollision(t *testing.T) {
+	ctx := context.Background()
+	agent := &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "collision-owner",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:     kontextv1alpha1.AgentModeService,
+			Goal:     "stay ready",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	unrelated := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "collision-owner-1",
+			Namespace: agent.Namespace,
+			Labels:    map[string]string{podbuilder.LabelAgentName: agent.Name},
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			Goal:     "unrelated work",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, unrelated); err != nil {
+		t.Fatalf("create unrelated run: %v", err)
+	}
+
+	_, err := newAgentReconciler().Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace},
+	})
+	if err == nil || !strings.Contains(err.Error(), "service run name collision") {
+		t.Fatalf("expected explicit name collision, got %v", err)
+	}
+
+	var existing kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: unrelated.Name, Namespace: unrelated.Namespace}, &existing); err != nil {
+		t.Fatalf("get unrelated run: %v", err)
+	}
+	if len(existing.OwnerReferences) != 0 || existing.Spec.AgentRef != nil {
+		t.Fatalf("unrelated run was adopted or mutated: %#v", existing)
+	}
+
+	var updated kontextv1alpha1.Agent
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if updated.Status.CurrentRunName != "" || updated.Status.RunsCreated != 0 {
+		t.Fatalf("collision mutated Agent status: %#v", updated.Status)
+	}
+}
+
 func TestAgentReconcilerNoopsWhenRunActive(t *testing.T) {
 	ctx := context.Background()
 	agent := &kontextv1alpha1.Agent{
@@ -135,9 +283,7 @@ func TestAgentReconcilerNoopsWhenRunActive(t *testing.T) {
 			Runtime:  echoRuntimeSpec(),
 		},
 	}
-	if err := k8sClient.Create(ctx, run); err != nil {
-		t.Fatalf("create run: %v", err)
-	}
+	createOwnedAgentRun(ctx, t, agent, run)
 	if err := updateAgentRunStatus(ctx, run, kontextv1alpha1.AgentRunStatus{
 		Phase: kontextv1alpha1.AgentRunPhaseRunning,
 	}); err != nil {
@@ -155,7 +301,7 @@ func TestAgentReconcilerNoopsWhenRunActive(t *testing.T) {
 	}
 }
 
-func TestAgentReconcilerRecastsAfterTerminalRun(t *testing.T) {
+func TestAgentReconcilerRecastsTerminalRunWithStaleStatus(t *testing.T) {
 	ctx := context.Background()
 	agent := &kontextv1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -174,13 +320,6 @@ func TestAgentReconcilerRecastsAfterTerminalRun(t *testing.T) {
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
-	if err := updateAgentStatus(ctx, agent, kontextv1alpha1.AgentStatus{
-		CurrentRunName: "recast-owner-1",
-		RunsCreated:    1,
-		Restarts:       0,
-	}); err != nil {
-		t.Fatalf("update agent status: %v", err)
-	}
 
 	run := &kontextv1alpha1.AgentRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -196,9 +335,7 @@ func TestAgentReconcilerRecastsAfterTerminalRun(t *testing.T) {
 			Runtime:  echoRuntimeSpec(),
 		},
 	}
-	if err := k8sClient.Create(ctx, run); err != nil {
-		t.Fatalf("create run: %v", err)
-	}
+	createOwnedAgentRun(ctx, t, agent, run)
 	if err := updateAgentRunStatus(ctx, run, kontextv1alpha1.AgentRunStatus{
 		Phase:          kontextv1alpha1.AgentRunPhaseFailed,
 		CompletionTime: &metav1.Time{Time: time.Now().Add(-time.Minute)},
@@ -246,7 +383,7 @@ func TestAgentReconcilerRecastsAfterTerminalRun(t *testing.T) {
 	}
 }
 
-func TestAgentReconcilerBacksOffWhenTerminalRunHasNoCompletionTime(t *testing.T) {
+func TestAgentReconcilerRecastsTerminalRunWithoutCompletionTime(t *testing.T) {
 	ctx := context.Background()
 	agent := &kontextv1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -264,12 +401,6 @@ func TestAgentReconcilerBacksOffWhenTerminalRunHasNoCompletionTime(t *testing.T)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
-	if err := updateAgentStatus(ctx, agent, kontextv1alpha1.AgentStatus{
-		CurrentRunName: "missing-completion-owner-1",
-		RunsCreated:    1,
-	}); err != nil {
-		t.Fatalf("update agent status: %v", err)
-	}
 
 	run := &kontextv1alpha1.AgentRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -285,9 +416,7 @@ func TestAgentReconcilerBacksOffWhenTerminalRunHasNoCompletionTime(t *testing.T)
 			Runtime:  echoRuntimeSpec(),
 		},
 	}
-	if err := k8sClient.Create(ctx, run); err != nil {
-		t.Fatalf("create run: %v", err)
-	}
+	createOwnedAgentRun(ctx, t, agent, run)
 	if err := updateAgentRunStatus(ctx, run, kontextv1alpha1.AgentRunStatus{
 		Phase: kontextv1alpha1.AgentRunPhaseFailed,
 	}); err != nil {
@@ -300,8 +429,77 @@ func TestAgentReconcilerBacksOffWhenTerminalRunHasNoCompletionTime(t *testing.T)
 	if err != nil {
 		t.Fatalf("reconcile agent: %v", err)
 	}
-	if result.RequeueAfter <= 0 {
-		t.Fatalf("expected positive backoff, got %s", result.RequeueAfter)
+	if result.RequeueAfter != 2*time.Second {
+		t.Fatalf("expected normal post-create requeue, got %s", result.RequeueAfter)
+	}
+
+	var runs kontextv1alpha1.AgentRunList
+	if err := k8sClient.List(ctx, &runs, client.MatchingLabels{podbuilder.LabelAgentName: agent.Name}); err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs.Items) != 2 {
+		t.Fatalf("expected immediate recast, got %d runs", len(runs.Items))
+	}
+
+	var updated kontextv1alpha1.Agent
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if updated.Status.CurrentRunName != "missing-completion-owner-2" {
+		t.Fatalf("expected missing-completion-owner-2, got %q", updated.Status.CurrentRunName)
+	}
+}
+
+func TestAgentReconcilerBacksOffFromObservedTerminalRun(t *testing.T) {
+	ctx := context.Background()
+	agent := &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backoff-owner",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:     kontextv1alpha1.AgentModeService,
+			Goal:     "stay ready",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+			Backoff:  &kontextv1alpha1.BackoffSpec{InitialSeconds: 30, MaxSeconds: 30},
+		},
+	}
+	if err := k8sClient.Create(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	run := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backoff-owner-1",
+			Namespace: "default",
+			Labels:    map[string]string{podbuilder.LabelAgentName: agent.Name},
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			AgentRef: &kontextv1alpha1.AgentRef{Name: agent.Name},
+			Goal:     agent.Spec.Goal,
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	createOwnedAgentRun(ctx, t, agent, run)
+	if err := updateAgentRunStatus(ctx, run, kontextv1alpha1.AgentRunStatus{
+		Phase:          kontextv1alpha1.AgentRunPhaseFailed,
+		CompletionTime: &metav1.Time{Time: time.Now()},
+	}); err != nil {
+		t.Fatalf("update run status: %v", err)
+	}
+
+	result, err := newAgentReconciler().Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("reconcile agent: %v", err)
+	}
+	if result.RequeueAfter <= 0 || result.RequeueAfter > 30*time.Second {
+		t.Fatalf("expected remaining 30-second backoff, got %s", result.RequeueAfter)
 	}
 
 	var runs kontextv1alpha1.AgentRunList
@@ -309,11 +507,19 @@ func TestAgentReconcilerBacksOffWhenTerminalRunHasNoCompletionTime(t *testing.T)
 		t.Fatalf("list runs: %v", err)
 	}
 	if len(runs.Items) != 1 {
-		t.Fatalf("expected no immediate recast, got %d runs", len(runs.Items))
+		t.Fatalf("expected one run during backoff, got %d", len(runs.Items))
+	}
+
+	var updated kontextv1alpha1.Agent
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if updated.Status.CurrentRunName != run.Name || updated.Status.RunsCreated != 1 {
+		t.Fatalf("status was not recovered during backoff: %#v", updated.Status)
 	}
 }
 
-func TestAgentReconcilerRecastsWhenCurrentRunMissing(t *testing.T) {
+func TestAgentReconcilerIgnoresStaleStatusWhenNoChildrenExist(t *testing.T) {
 	ctx := context.Background()
 	agent := &kontextv1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -344,20 +550,20 @@ func TestAgentReconcilerRecastsWhenCurrentRunMissing(t *testing.T) {
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
 		t.Fatalf("get agent: %v", err)
 	}
-	if updated.Status.CurrentRunName != "missing-run-owner-2" {
-		t.Fatalf("expected missing-run-owner-2, got %q", updated.Status.CurrentRunName)
+	if updated.Status.CurrentRunName != "missing-run-owner-1" {
+		t.Fatalf("expected missing-run-owner-1, got %q", updated.Status.CurrentRunName)
 	}
-	if updated.Status.RunsCreated != 2 {
-		t.Fatalf("expected runsCreated=2, got %d", updated.Status.RunsCreated)
+	if updated.Status.RunsCreated != 1 {
+		t.Fatalf("expected runsCreated=1, got %d", updated.Status.RunsCreated)
 	}
 
 	var run kontextv1alpha1.AgentRun
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "missing-run-owner-2", Namespace: agent.Namespace}, &run); err != nil {
-		t.Fatalf("expected replacement run: %v", err)
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "missing-run-owner-1", Namespace: agent.Namespace}, &run); err != nil {
+		t.Fatalf("expected first observed run: %v", err)
 	}
 }
 
-func TestAgentReconcilerAlreadyExistsDoesNotBumpCounters(t *testing.T) {
+func TestAgentReconcilerRecoversStatusFromObservedChildren(t *testing.T) {
 	ctx := context.Background()
 	agent := &kontextv1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -390,9 +596,7 @@ func TestAgentReconcilerAlreadyExistsDoesNotBumpCounters(t *testing.T) {
 			Runtime:  echoRuntimeSpec(),
 		},
 	}
-	if err := k8sClient.Create(ctx, run); err != nil {
-		t.Fatalf("create run: %v", err)
-	}
+	createOwnedAgentRun(ctx, t, agent, run)
 
 	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
 
@@ -403,8 +607,8 @@ func TestAgentReconcilerAlreadyExistsDoesNotBumpCounters(t *testing.T) {
 	if updated.Status.CurrentRunName != "exists-owner-1" {
 		t.Fatalf("expected current run exists-owner-1, got %q", updated.Status.CurrentRunName)
 	}
-	if updated.Status.RunsCreated != 0 {
-		t.Fatalf("expected runsCreated to remain 0, got %d", updated.Status.RunsCreated)
+	if updated.Status.RunsCreated != 1 {
+		t.Fatalf("expected runsCreated to recover to 1, got %d", updated.Status.RunsCreated)
 	}
 
 	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
@@ -412,8 +616,86 @@ func TestAgentReconcilerAlreadyExistsDoesNotBumpCounters(t *testing.T) {
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
 		t.Fatalf("get agent after second reconcile: %v", err)
 	}
-	if updated.Status.RunsCreated != 0 {
-		t.Fatalf("expected runsCreated to remain 0 after duplicate reconcile, got %d", updated.Status.RunsCreated)
+	if updated.Status.RunsCreated != 1 {
+		t.Fatalf("expected runsCreated to remain 1 after duplicate reconcile, got %d", updated.Status.RunsCreated)
+	}
+}
+
+func TestAgentReconcilerUsesOwnedCanonicalRunSequence(t *testing.T) {
+	ctx := context.Background()
+	agent := &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sequence-owner",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:     kontextv1alpha1.AgentModeService,
+			Goal:     "stay ready",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+			Backoff:  &kontextv1alpha1.BackoffSpec{InitialSeconds: 1, MaxSeconds: 1},
+		},
+	}
+	if err := k8sClient.Create(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	unrelated := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sequence-owner-99",
+			Namespace: agent.Namespace,
+			Labels:    map[string]string{podbuilder.LabelAgentName: agent.Name},
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			AgentRef: &kontextv1alpha1.AgentRef{Name: agent.Name},
+			Goal:     agent.Spec.Goal,
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, unrelated); err != nil {
+		t.Fatalf("create unrelated same-label run: %v", err)
+	}
+
+	malformed := unrelated.DeepCopy()
+	malformed.ObjectMeta = metav1.ObjectMeta{
+		Name:      "sequence-owner-02",
+		Namespace: agent.Namespace,
+		Labels:    map[string]string{podbuilder.LabelAgentName: agent.Name},
+	}
+	createOwnedAgentRun(ctx, t, agent, malformed)
+
+	current := unrelated.DeepCopy()
+	current.ObjectMeta = metav1.ObjectMeta{
+		Name:      "sequence-owner-3",
+		Namespace: agent.Namespace,
+		Labels:    map[string]string{podbuilder.LabelAgentName: agent.Name},
+	}
+	createOwnedAgentRun(ctx, t, agent, current)
+	if err := updateAgentRunStatus(ctx, current, kontextv1alpha1.AgentRunStatus{
+		Phase:          kontextv1alpha1.AgentRunPhaseFailed,
+		CompletionTime: &metav1.Time{Time: time.Now().Add(-time.Minute)},
+	}); err != nil {
+		t.Fatalf("update current run status: %v", err)
+	}
+
+	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
+
+	var next kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "sequence-owner-4", Namespace: agent.Namespace}, &next); err != nil {
+		t.Fatalf("expected next canonical run after gap: %v", err)
+	}
+
+	var updated kontextv1alpha1.Agent
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if updated.Status.CurrentRunName != next.Name ||
+		updated.Status.LastRunName != current.Name ||
+		updated.Status.RunsCreated != 4 {
+		t.Fatalf("unexpected status from observed sequence: %#v", updated.Status)
 	}
 }
 
@@ -456,4 +738,49 @@ func TestAgentReconcilerUnsupportedMode(t *testing.T) {
 func updateAgentStatus(ctx context.Context, agent *kontextv1alpha1.Agent, next kontextv1alpha1.AgentStatus) error {
 	agent.Status = next
 	return k8sClient.Status().Update(ctx, agent)
+}
+
+func createOwnedAgentRun(
+	ctx context.Context,
+	t *testing.T,
+	agent *kontextv1alpha1.Agent,
+	run *kontextv1alpha1.AgentRun,
+) {
+	t.Helper()
+	if err := controllerutil.SetControllerReference(agent, run, scheme); err != nil {
+		t.Fatalf("set AgentRun owner: %v", err)
+	}
+	if err := k8sClient.Create(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+}
+
+type staleAgentRunListClient struct {
+	client.Client
+	omitName types.NamespacedName
+}
+
+func (c *staleAgentRunListClient) List(
+	ctx context.Context,
+	list client.ObjectList,
+	opts ...client.ListOption,
+) error {
+	runs, ok := list.(*kontextv1alpha1.AgentRunList)
+	if !ok || c.omitName.Name == "" {
+		return c.Client.List(ctx, list, opts...)
+	}
+	if err := c.Client.List(ctx, runs, opts...); err != nil {
+		return err
+	}
+	filtered := runs.Items[:0]
+	for i := range runs.Items {
+		run := runs.Items[i]
+		if run.Name == c.omitName.Name && run.Namespace == c.omitName.Namespace {
+			continue
+		}
+		filtered = append(filtered, run)
+	}
+	runs.Items = filtered
+	c.omitName = types.NamespacedName{}
+	return nil
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -69,8 +69,9 @@ func newAgentRunReconciler() *controller.AgentRunReconciler {
 
 func newAgentReconciler() *controller.AgentReconciler {
 	return &controller.AgentReconciler{
-		Client: k8sClient,
-		Scheme: scheme,
+		Client:    k8sClient,
+		APIReader: k8sClient,
+		Scheme:    scheme,
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive service-run sequencing and status from verified owned `AgentRun` resources instead of `Agent.status`
- preserve deterministic `<agent>-N` names while handling stale cache reads and name collisions safely
- recast terminal runs without completion timestamps and saturate restart backoff without overflow
- add regression coverage for stale status, stale list reads, ownership filtering, collisions, gaps, and missing completion times

## Test plan
- [x] `go test ./internal/controller`
- [x] `go test ./...`
- [x] `git diff --check`