### PR TITLE
Make deployment image configuration declarative

### DIFF
--- a/.github/workflows/provider-acceptance.yml
+++ b/.github/workflows/provider-acceptance.yml
@@ -42,6 +42,7 @@ jobs:
       KONTEXT_ACCEPTANCE_NAMESPACE: provider-acceptance
       KONTEXT_ACCEPTANCE_SCENARIO: ${{ inputs.scenario }}
       KONTEXT_OPERATOR_IMAGE: kontext-operator:dev
+      KONTEXT_REPORTER_IMAGE: kontext-reporter:dev
       KONTEXT_REFERENCE_IMAGE: kontext-reference:dev
       KONTEXT_PROVIDER: ${{ inputs.provider }}
       KONTEXT_MODEL: ${{ inputs.model }}
@@ -79,6 +80,17 @@ jobs:
           cache-from: type=gha,scope=provider-acceptance-operator
           cache-to: type=gha,mode=max,scope=provider-acceptance-operator
 
+      - name: Build reusable reporter image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: runtimes/reporter/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
+          cache-from: type=gha,scope=provider-acceptance-reporter
+          cache-to: type=gha,mode=max,scope=provider-acceptance-reporter
+
       - name: Build maintained reference runtime image
         uses: docker/build-push-action@v6
         with:
@@ -99,6 +111,7 @@ jobs:
       - name: Load maintained images
         run: |
           kind load docker-image "${KONTEXT_OPERATOR_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+          kind load docker-image "${KONTEXT_REPORTER_IMAGE}" --name "${KIND_CLUSTER_NAME}"
           kind load docker-image "${KONTEXT_REFERENCE_IMAGE}" --name "${KIND_CLUSTER_NAME}"
 
       - name: Install maintained operator

--- a/.github/workflows/provider-acceptance.yml
+++ b/.github/workflows/provider-acceptance.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Install maintained operator
         run: |
-          kubectl apply -k config/default
+          kubectl apply -k config/overlays/dev
           kubectl rollout status deployment/controller-manager \
             --namespace kontext-system \
             --timeout=120s

--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,7 @@ uninstall: manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube
 
 .PHONY: deploy
 deploy: manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && kustomize edit set image controller=${IMG}
-	kubectl apply -k config/default
+	kubectl apply -k config/overlays/dev
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ uninstall: manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube
 
 .PHONY: deploy
 deploy: manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	kubectl apply -k config/overlays/dev
+	KONTEXT_OPERATOR_IMAGE="${IMG}" KONTEXT_REPORTER_IMAGE="${REPORTER_IMG}" ./scripts/deploy-go.sh
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ after Kontext replaces it with the reporter. `LastLine` captures the final
 non-empty stdout line as text; `KontextEnvelope` accepts a
 `KONTEXT_RESULT:`-prefixed structured envelope. Logs remain ordinary
 `kubectl logs` output. If `result` is absent, the image runs unchanged. Cluster
-installations must configure `KONTEXT_REPORTER_IMAGE`; `make kind-install`
-wires the locally built reporter automatically.
+install manifests declare the trusted reporter image alongside the operator
+image. The development overlay selects the locally built reporter used by
+`make kind-install`.
 
 The complete four-path example index (plain logs, final-line capture,
 structured capture, and native envelope) is in

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
             - /manager
           env:
             - name: KONTEXT_REPORTER_IMAGE
-              value: ""
+              value: reporter:latest
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -2,8 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../crd
-  - ../rbac
-  - ../manager
+  - ../../default
 
-namespace: kontext-system
+patches:
+  - path: manager_patch.yaml

--- a/config/overlays/dev/manager_patch.yaml
+++ b/config/overlays/dev/manager_patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: kontext-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: kontext-operator:dev
+          env:
+            - name: KONTEXT_REPORTER_IMAGE
+              value: kontext-reporter:dev

--- a/scripts/deploy-go.sh
+++ b/scripts/deploy-go.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Apply the development overlay with caller-selected operator and reporter images.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OPERATOR_IMAGE="${KONTEXT_OPERATOR_IMAGE:-kontext-operator:dev}"
+REPORTER_IMAGE="${KONTEXT_REPORTER_IMAGE:-kontext-reporter:dev}"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need kubectl
+
+DEPLOY_OVERLAY_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kontext-deploy-overlay.XXXXXX")"
+cleanup() {
+  rm -rf "${DEPLOY_OVERLAY_DIR}"
+}
+trap cleanup EXIT
+
+cp -R "${ROOT_DIR}/config" "${DEPLOY_OVERLAY_DIR}/config"
+
+cat >"${DEPLOY_OVERLAY_DIR}/kustomization.yaml" <<'EOF'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - config/overlays/dev
+
+patches:
+  - path: manager_patch.yaml
+EOF
+
+cat >"${DEPLOY_OVERLAY_DIR}/manager_patch.yaml" <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: kontext-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: "${OPERATOR_IMAGE}"
+          env:
+            - name: KONTEXT_REPORTER_IMAGE
+              value: "${REPORTER_IMAGE}"
+EOF
+
+kubectl kustomize "${DEPLOY_OVERLAY_DIR}" |
+  kubectl apply -f -

--- a/scripts/install-go-kind.sh
+++ b/scripts/install-go-kind.sh
@@ -55,18 +55,20 @@ if [[ "${IMAGE_SET}" == "full" ]]; then
   fi
 fi
 
-KIND_OVERLAY_DIR="$(mktemp -d "${ROOT_DIR}/config/overlays/.kind.XXXXXX")"
+KIND_OVERLAY_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kontext-kind-overlay.XXXXXX")"
 cleanup() {
   rm -rf "${KIND_OVERLAY_DIR}"
 }
 trap cleanup EXIT
+
+cp -R "${ROOT_DIR}/config" "${KIND_OVERLAY_DIR}/config"
 
 cat >"${KIND_OVERLAY_DIR}/kustomization.yaml" <<'EOF'
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../dev
+  - config/overlays/dev
 
 patches:
   - path: manager_patch.yaml
@@ -127,7 +129,8 @@ if kubectl get crd agents.kontext.dev >/dev/null 2>&1; then
   fi
 fi
 kubectl delete deployment kontext-controller -n default --ignore-not-found=true
-kubectl apply -k "${KIND_OVERLAY_DIR}"
+kubectl kustomize "${KIND_OVERLAY_DIR}" |
+  kubectl apply -f -
 
 echo "==> waiting for controller rollout"
 kubectl rollout status deployment/controller-manager -n kontext-system --timeout=120s

--- a/scripts/install-go-kind.sh
+++ b/scripts/install-go-kind.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Load prebuilt operator, runtime, reporter, and test images into kind and
-# install the controller. Build images first with `make kind-install`.
+# Load prebuilt operator, runtime, reporter, and test images into kind, then
+# install the controller through the development kustomize overlay.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -55,6 +55,43 @@ if [[ "${IMAGE_SET}" == "full" ]]; then
   fi
 fi
 
+KIND_OVERLAY_DIR="$(mktemp -d "${ROOT_DIR}/config/overlays/.kind.XXXXXX")"
+cleanup() {
+  rm -rf "${KIND_OVERLAY_DIR}"
+}
+trap cleanup EXIT
+
+cat >"${KIND_OVERLAY_DIR}/kustomization.yaml" <<'EOF'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../dev
+
+patches:
+  - path: manager_patch.yaml
+EOF
+
+cat >"${KIND_OVERLAY_DIR}/manager_patch.yaml" <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: kontext-system
+spec:
+  template:
+    metadata:
+      annotations:
+        kontext.dev/local-operator-image-id: "${OPERATOR_IMAGE_ID}"
+    spec:
+      containers:
+        - name: manager
+          image: "${OPERATOR_IMAGE}"
+          env:
+            - name: KONTEXT_REPORTER_IMAGE
+              value: "${REPORTER_IMAGE}"
+EOF
+
 if ! kind get clusters | grep -qx "${CLUSTER_NAME}"; then
   echo "==> creating kind cluster ${CLUSTER_NAME}"
   kind create cluster --name "${CLUSTER_NAME}"
@@ -90,11 +127,7 @@ if kubectl get crd agents.kontext.dev >/dev/null 2>&1; then
   fi
 fi
 kubectl delete deployment kontext-controller -n default --ignore-not-found=true
-kubectl apply -k "${ROOT_DIR}/config/default"
-kubectl set env deployment/controller-manager -n kontext-system \
-  "KONTEXT_REPORTER_IMAGE=${REPORTER_IMAGE}"
-kubectl patch deployment/controller-manager -n kontext-system --type=merge -p \
-  "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kontext.dev/local-operator-image-id\":\"${OPERATOR_IMAGE_ID}\"}}}}}"
+kubectl apply -k "${KIND_OVERLAY_DIR}"
 
 echo "==> waiting for controller rollout"
 kubectl rollout status deployment/controller-manager -n kontext-system --timeout=120s


### PR DESCRIPTION
## Summary
- separate environment-neutral manager configuration from local development image references
- configure the trusted reporter declaratively and apply kind-specific image overrides through a development overlay
- remove tracked-file edits and post-apply deployment patching from local installation

## Test plan
- [x] `make verify`
- [x] `bash -n scripts/install-go-kind.sh`
- [x] render `config/default` and `config/overlays/dev` and verify operator/reporter references
- [x] `./scripts/install-go-kind.sh`
- [x] `./scripts/e2e-kind.sh`

Closes #36