### PR TITLE
Centralize container image build configuration

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -1,0 +1,49 @@
+name: Build container image
+description: Build a Kontext image with consistent Buildx caching
+
+inputs:
+  context:
+    description: Docker build context
+    required: true
+  dockerfile:
+    description: Dockerfile path relative to the repository root
+    required: false
+    default: Dockerfile
+  tags:
+    description: Newline-delimited image tags
+    required: true
+  cache-scope:
+    description: GitHub Actions cache scope
+    required: true
+  load:
+    description: Load the single-platform result into the local Docker daemon
+    required: false
+    default: "true"
+  push:
+    description: Push the build result to its registry
+    required: false
+    default: "false"
+  platforms:
+    description: Optional comma-delimited target platforms
+    required: false
+    default: ""
+
+outputs:
+  digest:
+    description: Image manifest digest
+    value: ${{ steps.build.outputs.digest }}
+
+runs:
+  using: composite
+  steps:
+    - id: build
+      uses: docker/build-push-action@v6
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        tags: ${{ inputs.tags }}
+        load: ${{ inputs.load }}
+        push: ${{ inputs.push }}
+        platforms: ${{ inputs.platforms }}
+        cache-from: type=gha,scope=${{ inputs.cache-scope }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,26 +64,20 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build reusable reporter image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          file: runtimes/reporter/Dockerfile
-          push: false
-          load: true
+          dockerfile: runtimes/reporter/Dockerfile
           tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
-          cache-from: type=gha,scope=reporter
-          cache-to: type=gha,mode=max,scope=reporter
+          cache-scope: reporter
 
       - name: Build model-agnostic reference runtime image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          file: runtimes/reference/Dockerfile
-          push: false
-          load: true
+          dockerfile: runtimes/reference/Dockerfile
           tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
-          cache-from: type=gha,scope=reference
-          cache-to: type=gha,mode=max,scope=reference
+          cache-scope: reference
 
       - name: Smoke test reference runtime execution
         run: |
@@ -132,14 +126,12 @@ jobs:
           [[ "${failure_output}" == *'"outcome":"Failed"'* ]]
 
       - name: Build Anthropic reference runtime image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: runtimes/python-anthropic
-          push: false
-          load: true
+          dockerfile: runtimes/python-anthropic/Dockerfile
           tags: ${{ env.KONTEXT_ANTHROPIC_IMAGE }}
-          cache-from: type=gha,scope=anthropic
-          cache-to: type=gha,mode=max,scope=anthropic
+          cache-scope: anthropic
 
   e2e:
     name: Kind e2e
@@ -193,56 +185,43 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build operator image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          push: false
-          load: true
           tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
-          cache-from: type=gha,scope=operator
-          cache-to: type=gha,mode=max,scope=operator
+          cache-scope: operator
 
       - name: Build echo runtime image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: runtimes/echo
-          push: false
-          load: true
+          dockerfile: runtimes/echo/Dockerfile
           tags: ${{ env.KONTEXT_ECHO_IMAGE }}
-          cache-from: type=gha,scope=echo
-          cache-to: type=gha,mode=max,scope=echo
+          cache-scope: echo
 
       - name: Build reusable reporter image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          file: runtimes/reporter/Dockerfile
-          push: false
-          load: true
+          dockerfile: runtimes/reporter/Dockerfile
           tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
-          cache-from: type=gha,scope=reporter
-          cache-to: type=gha,mode=max,scope=reporter
+          cache-scope: reporter
 
       - name: Build model-agnostic reference runtime image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          file: runtimes/reference/Dockerfile
-          push: false
-          load: true
+          dockerfile: runtimes/reference/Dockerfile
           tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
-          cache-from: type=gha,scope=reference
-          cache-to: type=gha,mode=max,scope=reference
+          cache-scope: reference
 
       - name: Build stdout-capture fixture image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: runtimes/stdout-fixture
-          push: false
-          load: true
+          dockerfile: runtimes/stdout-fixture/Dockerfile
           tags: ${{ env.KONTEXT_STDOUT_FIXTURE_IMAGE }}
-          cache-from: type=gha,scope=stdout-fixture
-          cache-to: type=gha,mode=max,scope=stdout-fixture
+          cache-scope: stdout-fixture
 
       - name: Create kind cluster
         uses: helm/kind-action@v1
@@ -307,36 +286,27 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build operator image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          push: false
-          load: true
           tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
-          cache-from: type=gha,scope=network-policy-operator
-          cache-to: type=gha,mode=max,scope=network-policy-operator
+          cache-scope: network-policy-operator
 
       - name: Build reusable reporter image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          file: runtimes/reporter/Dockerfile
-          push: false
-          load: true
+          dockerfile: runtimes/reporter/Dockerfile
           tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
-          cache-from: type=gha,scope=network-policy-reporter
-          cache-to: type=gha,mode=max,scope=network-policy-reporter
+          cache-scope: network-policy-reporter
 
       - name: Build model-agnostic reference runtime image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          file: runtimes/reference/Dockerfile
-          push: false
-          load: true
+          dockerfile: runtimes/reference/Dockerfile
           tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
-          cache-from: type=gha,scope=network-policy-reference
-          cache-to: type=gha,mode=max,scope=network-policy-reference
+          cache-scope: network-policy-reference
 
       - name: Run Calico NetworkPolicy acceptance
         run: ./scripts/e2e-kind-network-policy.sh

--- a/.github/workflows/provider-acceptance.yml
+++ b/.github/workflows/provider-acceptance.yml
@@ -70,25 +70,19 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build maintained operator image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          push: false
-          load: true
           tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
-          cache-from: type=gha,scope=provider-acceptance-operator
-          cache-to: type=gha,mode=max,scope=provider-acceptance-operator
+          cache-scope: provider-acceptance-operator
 
       - name: Build maintained reference runtime image
-        uses: docker/build-push-action@v6
+        uses: ./.github/actions/build-image
         with:
           context: .
-          file: runtimes/reference/Dockerfile
-          push: false
-          load: true
+          dockerfile: runtimes/reference/Dockerfile
           tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
-          cache-from: type=gha,scope=provider-acceptance-reference
-          cache-to: type=gha,mode=max,scope=provider-acceptance-reference
+          cache-scope: provider-acceptance-reference
 
       - name: Create ephemeral kind cluster
         uses: helm/kind-action@v1

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ REPORTER_IMG ?= kontext-reporter:dev
 REFERENCE_IMG ?= kontext-reference:dev
 STDOUT_FIXTURE_IMG ?= kontext-stdout-fixture:dev
 
+# Generic image-build inputs. Convenience targets below select these per image.
+DOCKERFILE ?= Dockerfile
+CONTEXT ?= .
+
 # Get the currently used golang version
 GO_VERSION ?= 1.26.5
 
@@ -96,29 +100,34 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 ##@ Build
 
+.PHONY: docker-build-image
+docker-build-image: ## Build IMAGE from DOCKERFILE and CONTEXT.
+	@test -n "$(IMAGE)" || { echo "IMAGE is required" >&2; exit 2; }
+	docker build -f "$(DOCKERFILE)" -t "$(IMAGE)" "$(CONTEXT)"
+
 .PHONY: docker-build
 docker-build: ## Build docker image for the operator.
-	docker build -t ${IMG} .
+	$(MAKE) docker-build-image IMAGE="$(IMG)" DOCKERFILE="Dockerfile" CONTEXT="."
 
 .PHONY: docker-build-echo
 docker-build-echo: ## Build docker image for the echo runtime.
-	docker build -t ${ECHO_IMG} runtimes/echo
+	$(MAKE) docker-build-image IMAGE="$(ECHO_IMG)" DOCKERFILE="runtimes/echo/Dockerfile" CONTEXT="runtimes/echo"
 
 .PHONY: docker-build-anthropic
 docker-build-anthropic: ## Build docker image for the Anthropic reference runtime.
-	docker build -t ${ANTHROPIC_IMG} runtimes/python-anthropic
+	$(MAKE) docker-build-image IMAGE="$(ANTHROPIC_IMG)" DOCKERFILE="runtimes/python-anthropic/Dockerfile" CONTEXT="runtimes/python-anthropic"
 
 .PHONY: docker-build-reporter
 docker-build-reporter: ## Build the reusable result reporter image.
-	docker build -f runtimes/reporter/Dockerfile -t ${REPORTER_IMG} .
+	$(MAKE) docker-build-image IMAGE="$(REPORTER_IMG)" DOCKERFILE="runtimes/reporter/Dockerfile" CONTEXT="."
 
 .PHONY: docker-build-reference
 docker-build-reference: ## Build the model-agnostic reference runtime image.
-	docker build -f runtimes/reference/Dockerfile -t ${REFERENCE_IMG} .
+	$(MAKE) docker-build-image IMAGE="$(REFERENCE_IMG)" DOCKERFILE="runtimes/reference/Dockerfile" CONTEXT="."
 
 .PHONY: docker-build-stdout-fixture
 docker-build-stdout-fixture: ## Build the generic image used by stdout-capture e2e.
-	docker build -t ${STDOUT_FIXTURE_IMG} runtimes/stdout-fixture
+	$(MAKE) docker-build-image IMAGE="$(STDOUT_FIXTURE_IMG)" DOCKERFILE="runtimes/stdout-fixture/Dockerfile" CONTEXT="runtimes/stdout-fixture"
 
 .PHONY: docker-build-all
 docker-build-all: docker-build docker-build-echo docker-build-anthropic docker-build-reporter docker-build-reference ## Build operator and runtime images.


### PR DESCRIPTION
## Summary
- route every local image target through one parameterized Make recipe
- centralize Buildx load, push, platform, digest, and cache behavior in a reusable repository action
- preserve the existing same-runner image builds and per-image cache scopes across CI and provider acceptance

## Test plan
- [x] `make verify`
- [x] `make docker-build-all`
- [x] `make docker-build-stdout-fixture`
- [x] verify `docker-build-image` rejects a missing `IMAGE`
- [x] parse updated action/workflow YAML
- [x] run actionlint on CI and provider workflows (excluding the provider workflow's pre-existing `runner.temp` job-env warning)

Closes #37