### PR TITLE
Reject invalid wallclock budgets at admission

### DIFF
--- a/api/v1alpha1/agent_types.go
+++ b/api/v1alpha1/agent_types.go
@@ -96,6 +96,7 @@ type ResultSource string
 type ResultFormat string
 
 // BudgetSpec limits resource consumption for an agent run.
+// +kubebuilder:validation:XValidation:rule="!has(self.wallclock) || self.wallclock.size() == 0 || duration(self.wallclock) > duration('0s')",message="wallclock must be empty or a positive duration"
 type BudgetSpec struct {
 	Tokens    *int32   `json:"tokens,omitempty"`
 	Wallclock string   `json:"wallclock,omitempty"`

--- a/config/crd/bases/kontext.dev_agentruns.yaml
+++ b/config/crd/bases/kontext.dev_agentruns.yaml
@@ -70,6 +70,10 @@ spec:
                   wallclock:
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: wallclock must be empty or a positive duration
+                  rule: '!has(self.wallclock) || self.wallclock.size() == 0 || duration(self.wallclock)
+                    > duration(''0s'')'
               env:
                 items:
                   description: EnvVar is a name/value or Secret-backed value injected

--- a/config/crd/bases/kontext.dev_agents.yaml
+++ b/config/crd/bases/kontext.dev_agents.yaml
@@ -75,6 +75,10 @@ spec:
                   wallclock:
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: wallclock must be empty or a positive duration
+                  rule: '!has(self.wallclock) || self.wallclock.size() == 0 || duration(self.wallclock)
+                    > duration(''0s'')'
               env:
                 items:
                   description: EnvVar is a name/value or Secret-backed value injected

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -13,7 +13,6 @@ const (
 	Ready       = "Ready"
 	Progressing = "Progressing"
 	Complete    = "Complete"
-	BudgetValid = "BudgetValid"
 )
 
 // UnsupportedMode returns conditions for unimplemented Agent modes.
@@ -80,15 +79,5 @@ func ForAgentRunPhase(phase kontextv1alpha1.AgentRunPhase) []metav1.Condition {
 			Reason:  string(phase),
 			Message: "Agent run is starting.",
 		}}
-	}
-}
-
-// InvalidBudget returns a condition for a wallclock budget that cannot be enforced.
-func InvalidBudget(message string) metav1.Condition {
-	return metav1.Condition{
-		Type:    BudgetValid,
-		Status:  metav1.ConditionFalse,
-		Reason:  "InvalidWallclock",
-		Message: message,
 	}
 }

--- a/internal/conditions/conditions_test.go
+++ b/internal/conditions/conditions_test.go
@@ -70,19 +70,6 @@ func TestInvalidMode(t *testing.T) {
 	}
 }
 
-func TestInvalidBudgetUsesMessage(t *testing.T) {
-	condition := conditions.InvalidBudget("bad wallclock")
-	if condition.Status != metav1.ConditionFalse {
-		t.Fatalf("expected False, got %s", condition.Status)
-	}
-	if condition.Reason != "InvalidWallclock" {
-		t.Fatalf("unexpected reason: %s", condition.Reason)
-	}
-	if condition.Message != "bad wallclock" {
-		t.Fatalf("expected supplied message, got %q", condition.Message)
-	}
-}
-
 func TestForAgentRunPhaseTerminal(t *testing.T) {
 	merged := conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhaseSucceeded)
 

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -45,14 +45,24 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	pod := &corev1.Pod{}
 	podKey := client.ObjectKey{Namespace: run.Namespace, Name: podName}
 	err := r.Get(ctx, podKey, pod)
-	if apierrors.IsNotFound(err) {
-		return r.reconcileMissingPod(ctx, &run, podName)
-	}
-	if err != nil {
+	podMissing := apierrors.IsNotFound(err)
+	if err != nil && !podMissing {
 		return ctrl.Result{}, err
 	}
 
-	wallclockResult, done, err := r.enforceWallclock(ctx, &run, pod)
+	var wallclockLimit *time.Duration
+	if !status.IsTerminalPhase(run.Status.Phase) {
+		wallclockLimit, err = parseWallclockBudget(run.Spec.Budget)
+		if err != nil {
+			return r.failInvalidWallclock(ctx, &run, pod, !podMissing, err)
+		}
+	}
+
+	if podMissing {
+		return r.reconcileMissingPod(ctx, &run, podName)
+	}
+
+	wallclockResult, done, err := r.enforceWallclock(ctx, &run, pod, wallclockLimit)
 	if err != nil || done {
 		return wallclockResult, err
 	}
@@ -156,36 +166,68 @@ func (r *AgentRunReconciler) syncPodObservation(ctx context.Context, run *kontex
 	return ctrl.Result{}, nil
 }
 
-func (r *AgentRunReconciler) enforceWallclock(ctx context.Context, run *kontextv1alpha1.AgentRun, pod *corev1.Pod) (ctrl.Result, bool, error) {
+func parseWallclockBudget(budget *kontextv1alpha1.BudgetSpec) (*time.Duration, error) {
+	if budget == nil || budget.Wallclock == "" {
+		return nil, nil
+	}
+
+	limit, err := time.ParseDuration(budget.Wallclock)
+	if err != nil {
+		return nil, fmt.Errorf("invalid wallclock budget %q: %w", budget.Wallclock, err)
+	}
+	if limit <= 0 {
+		return nil, fmt.Errorf(
+			"invalid wallclock budget %q: duration must be positive",
+			budget.Wallclock,
+		)
+	}
+	return &limit, nil
+}
+
+func (r *AgentRunReconciler) failInvalidWallclock(
+	ctx context.Context,
+	run *kontextv1alpha1.AgentRun,
+	pod *corev1.Pod,
+	podExists bool,
+	cause error,
+) (ctrl.Result, error) {
+	if podExists {
+		if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
+		next.Phase = kontextv1alpha1.AgentRunPhaseFailed
+		if podExists {
+			next.PodName = pod.Name
+		}
+		next.Message = fmt.Sprintf("Agent run configuration is invalid: %v.", cause)
+		next.CompletionTime = nowPtr()
+		setStatusConditions(
+			&next.Conditions,
+			run.Generation,
+			conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhaseFailed)...,
+		)
+	})
+}
+
+func (r *AgentRunReconciler) enforceWallclock(
+	ctx context.Context,
+	run *kontextv1alpha1.AgentRun,
+	pod *corev1.Pod,
+	limit *time.Duration,
+) (ctrl.Result, bool, error) {
 	if run.Status.Phase == kontextv1alpha1.AgentRunPhaseBudgetExceeded {
 		if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, true, err
 		}
 		return ctrl.Result{}, true, nil
 	}
-	if run.Spec.Budget == nil || run.Spec.Budget.Wallclock == "" {
+	if limit == nil {
 		return ctrl.Result{}, false, nil
 	}
 	if status.IsTerminalPhase(run.Status.Phase) {
-		return ctrl.Result{}, false, nil
-	}
-
-	limit, parseErr := status.ParseWallclock(run.Spec.Budget.Wallclock)
-	if parseErr != nil {
-		// AgentRun specs are immutable, so an invalid budget cannot become
-		// valid in place; applying a correction creates a new run.
-		_, err := r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
-			setStatusConditions(
-				&next.Conditions,
-				run.Generation,
-				conditions.InvalidBudget(
-					fmt.Sprintf("Wallclock budget is invalid and is not enforced: %v.", parseErr),
-				),
-			)
-		})
-		if err != nil {
-			return ctrl.Result{}, false, err
-		}
 		return ctrl.Result{}, false, nil
 	}
 
@@ -202,15 +244,15 @@ func (r *AgentRunReconciler) enforceWallclock(ctx context.Context, run *kontextv
 	}
 
 	elapsed := time.Since(startedAt.Time)
-	if elapsed <= limit {
-		remaining := limit - elapsed
+	if elapsed <= *limit {
+		remaining := *limit - elapsed
 		return ctrl.Result{RequeueAfter: remaining + time.Second}, false, nil
 	}
 
 	_, err := r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
 		next.Phase = kontextv1alpha1.AgentRunPhaseBudgetExceeded
 		next.PodName = pod.Name
-		next.Message = fmt.Sprintf("Wallclock budget exceeded after %s.", limit)
+		next.Message = fmt.Sprintf("Wallclock budget exceeded after %s.", *limit)
 		recordedStart := *startedAt
 		next.StartTime = &recordedStart
 		next.CompletionTime = nowPtr()

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/conditions"
 	"github.com/kontext-dev/kontext/internal/podbuilder"
 )
 
@@ -377,71 +376,6 @@ func TestAgentRunReconcilerObservesSucceededPod(t *testing.T) {
 	}
 	if updated.Status.Usage == nil || updated.Status.Usage.Tokens == nil || *updated.Status.Usage.Tokens != 3 {
 		t.Fatalf("expected total token usage, got %#v", updated.Status.Usage)
-	}
-}
-
-func TestAgentRunReconcilerSurfacesInvalidWallclock(t *testing.T) {
-	ctx := context.Background()
-	podName := podbuilder.PodNameForRun("invalid-wallclock-run")
-	run := &kontextv1alpha1.AgentRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "invalid-wallclock-run",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentRunSpec{
-			Goal:     "hello",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-			Budget:   &kontextv1alpha1.BudgetSpec{Wallclock: "not-a-duration"},
-		},
-	}
-	if err := k8sClient.Create(ctx, run); err != nil {
-		t.Fatalf("create run: %v", err)
-	}
-	if err := updateAgentRunStatus(ctx, run, kontextv1alpha1.AgentRunStatus{
-		Phase:   kontextv1alpha1.AgentRunPhasePending,
-		PodName: podName,
-	}); err != nil {
-		t.Fatalf("update run status: %v", err)
-	}
-
-	pod := podbuilder.BuildPod(run)
-	if err := k8sClient.Create(ctx, pod); err != nil {
-		t.Fatalf("create pod: %v", err)
-	}
-
-	reconcileAgentRun(ctx, t, types.NamespacedName{Name: run.Name, Namespace: run.Namespace})
-
-	var updated kontextv1alpha1.AgentRun
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: run.Name, Namespace: run.Namespace}, &updated); err != nil {
-		t.Fatalf("get run: %v", err)
-	}
-	var invalidBudget *metav1.Condition
-	for _, condition := range updated.Status.Conditions {
-		if condition.Type == conditions.BudgetValid && condition.Status == metav1.ConditionFalse {
-			condition := condition
-			invalidBudget = &condition
-			break
-		}
-	}
-	if invalidBudget == nil {
-		t.Fatalf("expected BudgetValid=False condition, got %#v", updated.Status.Conditions)
-	}
-	if invalidBudget.ObservedGeneration != updated.Generation {
-		t.Fatalf(
-			"invalid budget observed generation %d, want %d",
-			invalidBudget.ObservedGeneration,
-			updated.Generation,
-		)
-	}
-	if !strings.Contains(invalidBudget.Message, "invalid") ||
-		!strings.Contains(invalidBudget.Message, "not enforced") ||
-		strings.Contains(invalidBudget.Message, "default") {
-		t.Fatalf("invalid budget condition is not truthful: %q", invalidBudget.Message)
-	}
-	if updated.Status.Phase == kontextv1alpha1.AgentRunPhaseBudgetExceeded {
-		t.Fatalf("invalid wallclock must not enforce a default budget")
 	}
 }
 

--- a/internal/controller/budget_validation_test.go
+++ b/internal/controller/budget_validation_test.go
@@ -1,0 +1,101 @@
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+)
+
+func TestWallclockBudgetAPIValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		budget    *kontextv1alpha1.BudgetSpec
+		wantValid bool
+	}{
+		{name: "omitted", wantValid: true},
+		{name: "empty", budget: &kontextv1alpha1.BudgetSpec{}, wantValid: true},
+		{
+			name:      "positive duration",
+			budget:    &kontextv1alpha1.BudgetSpec{Wallclock: "1h30m"},
+			wantValid: true,
+		},
+		{
+			name:   "invalid duration",
+			budget: &kontextv1alpha1.BudgetSpec{Wallclock: "five minutes"},
+		},
+		{
+			name:   "zero duration",
+			budget: &kontextv1alpha1.BudgetSpec{Wallclock: "0s"},
+		},
+		{
+			name:   "negative duration",
+			budget: &kontextv1alpha1.BudgetSpec{Wallclock: "-1s"},
+		},
+	}
+	objectFactories := []struct {
+		name string
+		new  func(string, *kontextv1alpha1.BudgetSpec) client.Object
+	}{
+		{
+			name: "Agent",
+			new: func(name string, budget *kontextv1alpha1.BudgetSpec) client.Object {
+				return &kontextv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+					Spec: kontextv1alpha1.AgentSpec{
+						Mode:    kontextv1alpha1.AgentModeService,
+						Goal:    "test wallclock validation",
+						Model:   "test/model",
+						Budget:  budget,
+						Runtime: echoRuntimeSpec(),
+					},
+				}
+			},
+		},
+		{
+			name: "AgentRun",
+			new: func(name string, budget *kontextv1alpha1.BudgetSpec) client.Object {
+				return &kontextv1alpha1.AgentRun{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+					Spec: kontextv1alpha1.AgentRunSpec{
+						Goal:    "test wallclock validation",
+						Model:   "test/model",
+						Budget:  budget,
+						Runtime: echoRuntimeSpec(),
+					},
+				}
+			},
+		},
+	}
+
+	for objectIndex, objectFactory := range objectFactories {
+		for testIndex, test := range tests {
+			t.Run(objectFactory.name+"/"+test.name, func(t *testing.T) {
+				name := fmt.Sprintf("wallclock-validation-%d-%d", objectIndex, testIndex)
+				object := objectFactory.new(name, test.budget)
+				err := k8sClient.Create(context.Background(), object)
+				if test.wantValid {
+					if err != nil {
+						t.Fatalf("expected valid object: %v", err)
+					}
+					if err := k8sClient.Delete(context.Background(), object); err != nil {
+						t.Fatalf("delete valid object: %v", err)
+					}
+					return
+				}
+				if !apierrors.IsInvalid(err) {
+					t.Fatalf("expected API validation error, got %v", err)
+				}
+				if !strings.Contains(err.Error(), "wallclock must be empty or a positive duration") {
+					t.Fatalf("validation error is not actionable: %v", err)
+				}
+			})
+		}
+	}
+}

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -112,7 +112,12 @@ func TestEnforceWallclockTreatsOmissionAsNoDeadline(t *testing.T) {
 	}
 
 	for _, run := range runs {
-		result, done, err := reconciler.enforceWallclock(context.Background(), run, &corev1.Pod{})
+		result, done, err := reconciler.enforceWallclock(
+			context.Background(),
+			run,
+			&corev1.Pod{},
+			nil,
+		)
 		if err != nil {
 			t.Fatalf("omitted wallclock returned error: %v", err)
 		}
@@ -122,6 +127,62 @@ func TestEnforceWallclockTreatsOmissionAsNoDeadline(t *testing.T) {
 		if len(run.Status.Conditions) != 0 {
 			t.Fatalf("omitted wallclock wrote conditions: %#v", run.Status.Conditions)
 		}
+	}
+}
+
+func TestParseWallclockBudget(t *testing.T) {
+	tests := []struct {
+		name    string
+		budget  *kontextv1alpha1.BudgetSpec
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "omitted"},
+		{name: "empty", budget: &kontextv1alpha1.BudgetSpec{}},
+		{
+			name:   "positive",
+			budget: &kontextv1alpha1.BudgetSpec{Wallclock: "5m"},
+			want:   5 * time.Minute,
+		},
+		{
+			name:    "invalid",
+			budget:  &kontextv1alpha1.BudgetSpec{Wallclock: "five minutes"},
+			wantErr: true,
+		},
+		{
+			name:    "zero",
+			budget:  &kontextv1alpha1.BudgetSpec{Wallclock: "0s"},
+			wantErr: true,
+		},
+		{
+			name:    "negative",
+			budget:  &kontextv1alpha1.BudgetSpec{Wallclock: "-1s"},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			limit, err := parseWallclockBudget(test.budget)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("expected wallclock parse error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse wallclock budget: %v", err)
+			}
+			if test.want == 0 {
+				if limit != nil {
+					t.Fatalf("expected no wallclock limit, got %s", *limit)
+				}
+				return
+			}
+			if limit == nil || *limit != test.want {
+				t.Fatalf("wallclock limit = %v, want %s", limit, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/status/pod.go
+++ b/internal/status/pod.go
@@ -3,7 +3,6 @@ package status
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -175,21 +174,4 @@ func usageStatus(parsed resultv1alpha1.ParsedResult) *kontextv1alpha1.UsageStatu
 		OutputTokens: parsed.Usage.OutputTokens,
 		Dollars:      parsed.Usage.Dollars,
 	}
-}
-
-// ParseWallclock parses a configured positive duration.
-func ParseWallclock(value string) (time.Duration, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return 0, fmt.Errorf("wallclock budget is empty")
-	}
-
-	duration, err := time.ParseDuration(value)
-	if err != nil {
-		return 0, fmt.Errorf("invalid wallclock budget %q: %w", value, err)
-	}
-	if duration <= 0 {
-		return 0, fmt.Errorf("invalid wallclock budget %q: duration must be positive", value)
-	}
-	return duration, nil
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -3,7 +3,6 @@ package status_test
 import (
 	"strings"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -283,26 +282,6 @@ func TestObservePodLegacyPayloadWithoutMetricsLeavesUsageAbsent(t *testing.T) {
 	}
 }
 
-func TestParseWallclock(t *testing.T) {
-	got, err := status.ParseWallclock("5m")
-	if err != nil {
-		t.Fatalf("parse valid wallclock: %v", err)
-	}
-	if got != 5*time.Minute {
-		t.Fatalf("expected 5m, got %v", got)
-	}
-}
-
-func TestParseWallclockInvalid(t *testing.T) {
-	duration, err := status.ParseWallclock("not-a-duration")
-	if err == nil {
-		t.Fatal("expected invalid wallclock error")
-	}
-	if duration != 0 {
-		t.Fatalf("invalid wallclock returned duration %s", duration)
-	}
-}
-
 func TestObservePodWaitingUsesReason(t *testing.T) {
 	pod := &corev1.Pod{
 		Status: corev1.PodStatus{
@@ -456,15 +435,5 @@ func TestObservePodUnknownPhaseDefaultsPending(t *testing.T) {
 	pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodUnknown}}
 	if got := status.ObservePod(pod).Phase; got != kontextv1alpha1.AgentRunPhasePending {
 		t.Fatalf("expected Pending, got %s", got)
-	}
-}
-
-func TestParseWallclockRejectsNonPositive(t *testing.T) {
-	duration, err := status.ParseWallclock("0s")
-	if err == nil {
-		t.Fatal("expected non-positive wallclock error")
-	}
-	if duration != 0 {
-		t.Fatalf("non-positive wallclock returned duration %s", duration)
 	}
 }


### PR DESCRIPTION
## Summary
- validate `budget.wallclock` as an empty or positive duration for both `Agent` and `AgentRun`
- remove the `BudgetValid` warning path that allowed malformed requested limits to run unbounded
- parse the admission-validated duration before Pod creation and fail closed for legacy invalid objects

## Test plan
- [x] `make test`
- [x] forced fresh controller envtests with `go test -count=1 ./internal/controller`
- [x] `make verify` after committing generated CRDs
- [x] verify generated artifacts remain stable across regeneration

## Stack
- targets PR #44; merge after #44

Closes #38