### PR TITLE
Demote the legacy Python runtime to a source-only example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,12 @@ jobs:
       - name: Scan for known Go vulnerabilities
         run: make vulncheck
 
-  # Build optional runtime images independently so Dockerfile breakage is
-  # visible even when a specific image is not exercised by every kind scenario.
+  # Smoke maintained support and runtime images independently before kind.
   image-smoke:
     name: Image smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      KONTEXT_ANTHROPIC_IMAGE: kontext-runtime-anthropic:dev
       KONTEXT_REPORTER_IMAGE: kontext-reporter:dev
       KONTEXT_REFERENCE_IMAGE: kontext-reference:dev
     steps:
@@ -126,15 +124,6 @@ jobs:
           set -e
           [[ "${failure_code}" -eq 1 ]]
           [[ "${failure_output}" == *'"outcome":"Failed"'* ]]
-
-      - name: Build Anthropic reference runtime image
-        uses: ./.github/actions/build-image
-        with:
-          context: runtimes/python-anthropic
-          dockerfile: runtimes/python-anthropic/Dockerfile
-          tags: ${{ env.KONTEXT_ANTHROPIC_IMAGE }}
-          cache-scope: anthropic
-          load: "true"
 
   e2e:
     name: Kind e2e

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ docker-build-echo: ## Build docker image for the echo runtime.
 	$(MAKE) docker-build-image IMAGE="$(ECHO_IMG)" DOCKERFILE="runtimes/echo/Dockerfile" CONTEXT="runtimes/echo"
 
 .PHONY: docker-build-anthropic
-docker-build-anthropic: ## Build docker image for the Anthropic reference runtime.
+docker-build-anthropic: ## Build the unmaintained legacy Python example.
 	$(MAKE) docker-build-image IMAGE="$(ANTHROPIC_IMG)" DOCKERFILE="runtimes/python-anthropic/Dockerfile" CONTEXT="runtimes/python-anthropic"
 
 .PHONY: docker-build-reporter
@@ -130,7 +130,7 @@ docker-build-stdout-fixture: ## Build the generic image used by stdout-capture e
 	$(MAKE) docker-build-image IMAGE="$(STDOUT_FIXTURE_IMG)" DOCKERFILE="runtimes/stdout-fixture/Dockerfile" CONTEXT="runtimes/stdout-fixture"
 
 .PHONY: docker-build-all
-docker-build-all: docker-build docker-build-echo docker-build-anthropic docker-build-reporter docker-build-reference ## Build operator and runtime images.
+docker-build-all: docker-build docker-build-echo docker-build-reporter docker-build-reference ## Build operator and maintained runtime images.
 
 .PHONY: kind-install
 kind-install: docker-build docker-build-echo docker-build-reporter docker-build-reference docker-build-stdout-fixture ## Build kind images and install the operator into kind.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ kubectl get agentruns -w
 |---|---|
 | [`runtimes/echo/`](runtimes/echo) | Keyless control-plane conformance oracle. It still emits the accepted legacy termination payload during the v1alpha1 transition. |
 | [`runtimes/reference/`](runtimes/reference) | Maintained provider-neutral Go runtime with fake, Anthropic, and OpenAI-compatible transports plus a bounded built-in tool loop. |
-| [`runtimes/python-anthropic/`](runtimes/python-anthropic) | Legacy Anthropic behavior oracle retained for compatibility; not the maintained primary runtime. |
+| [`runtimes/python-anthropic/`](runtimes/python-anthropic) | Unmaintained source-only migration example. It predates the current runtime contract and is not published. |
 | [`runtimes/reporter/`](runtimes/reporter) | Reusable PID 1 supervisor. Preserves child logs and process semantics while producing the versioned result envelope. |
 
 Provider credentials are wired by the controller from a Kubernetes Secret into

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ Agents are workloads. Kontext is the Kubernetes-native control plane for running
 ## Decisions locked
 
 - **API model: Option B — `Agent` (definition) + `AgentRun` (execution).** Idiomatic K8s (mirrors `Deployment`/`CronJob` → `Job` → `Pod`). Gives run history + governance for free. See `SPEC.md`.
-- **Language: Go + kubebuilder.** Greenfield operator under `cmd/`, `internal/`, `config/`. Optional runtime images under `runtimes/` (echo, python-anthropic).
+- **Language: Go + kubebuilder.** Greenfield operator under `cmd/`, `internal/`, `config/`. Maintained runtime and support images live under `runtimes/` (echo, reference, reporter); the old Python Anthropic source remains only as an unmaintained migration example.
 - **Scope: MVP.** Prove the thesis and support real external workloads. Out of scope for now: A2A service mesh, `AgentTeam`, vcluster hypothesis-testing, KEDA autoscaling, web dashboard, OperatorHub, multi-provider sprawl.
 - **Delivery:** Milestones are incremental product slices with explicit completion criteria.
 
@@ -37,8 +37,8 @@ Kontext provides generic `Agent` and `AgentRun` primitives. Consumer-specific co
 
 ### M4 — Bring-your-own-runtime hardening (implementation complete)
 - The echo conformance oracle remains keyless and uses the accepted legacy
-  payload during the v1alpha1 transition. The Python Anthropic image is a
-  legacy behavior oracle, not the maintained primary runtime.
+  payload during the v1alpha1 transition. The Python Anthropic source is an
+  unmaintained, non-conformant migration example and is not published.
 - Versioned results, the reusable reporter, and optional stdout capture support existing Linux images with explicit commands.
 - The maintained Go reference runtime has a provider-neutral core, deterministic fake-provider path, and direct Anthropic and OpenAI-compatible HTTP transports.
 - The maintained runtime has a bounded provider-neutral loop with allowlisted knowledge, Kubernetes-read, and shell tools.

--- a/SPEC.md
+++ b/SPEC.md
@@ -304,7 +304,8 @@ user and security context remain unchanged.
 `runtimes/echo` is the deterministic control-plane conformance oracle. During
 the v1alpha1 transition it intentionally writes the legacy termination payload
 documented above. `runtimes/reference` is the maintained model-backed runtime.
-`runtimes/python-anthropic` is retained only as a legacy behavior oracle.
+`runtimes/python-anthropic` is retained only as an unmaintained source-level
+migration example; it does not conform to this contract and is not published.
 Arbitrary conforming images remain supported and need not use any of these
 implementations.
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -14,8 +14,9 @@ smallest integration that supplies the result semantics you need.
   Secrets. It emits versioned events and a
   `kontext.dev/result/v1alpha1` envelope.
 - Bring-your-own images are first-class. Kontext does not require the
-  maintained runtime. `runtimes/python-anthropic` is retained as a legacy
-  behavior oracle, not the maintained primary runtime.
+  maintained runtime. `runtimes/python-anthropic` is an unmaintained,
+  source-only migration example; it is neither contract-conformant nor
+  published.
 
 ## Result capture
 

--- a/runtimes/python-anthropic/README.md
+++ b/runtimes/python-anthropic/README.md
@@ -1,23 +1,23 @@
-# Legacy python-anthropic behavior oracle
+# Unmaintained Python Anthropic example
 
-This image is retained as a legacy behavior oracle. It is not the maintained
-primary runtime; new provider work and release acceptance target the Go
-`runtimes/reference` image.
+This source is retained only as a migration reference for the original Python
+runtime. It is not maintained, built by CI, or published with Kontext
+releases. New deployments and provider work should use the Go
+[`runtimes/reference`](../reference) image.
 
-It fulfills one `AgentRun` by sending the goal to the Anthropic Messages API
-and reporting through the accepted transition contract (see `SPEC.md`).
+The implementation predates the current runtime contract and intentionally
+preserves incompatible historical behavior:
 
-Contract surface used:
+- it aliases `KONTEXT_MODEL` values instead of treating them as opaque;
+- it invents and enforces a five-minute wallclock default inside the runtime;
+- it writes only the legacy termination payload rather than the versioned
+  result envelope.
 
-- Reads `KONTEXT_GOAL`, `KONTEXT_MODEL`, `KONTEXT_PROVIDER`, `KONTEXT_TOOLS`,
-  `KONTEXT_BUDGET_TOKENS`, `KONTEXT_BUDGET_WALLCLOCK`, `KONTEXT_AGENT_NAME`.
-- Expects `ANTHROPIC_API_KEY` injected from the Agent's `secretRef`.
-- Streams progress to stdout (`kubectl logs -f`).
-- Writes the legacy `{result, tokensUsed, dollarsUsed}` JSON payload to
-  `/dev/termination-log`, which the v1alpha1 controller still parses into
-  `AgentRun.status`.
+Do not use this image as evidence of conformance with [`SPEC.md`](../../SPEC.md).
+The v1alpha1 controller still accepts its legacy result payload solely for
+backward compatibility.
 
-Build:
+For historical investigation, build it explicitly:
 
 ```bash
 docker build -t kontext-runtime-anthropic:dev runtimes/python-anthropic


### PR DESCRIPTION
## Summary
- mark `runtimes/python-anthropic` as unmaintained, non-conformant, and source-only across product documentation
- document its model-alias, wallclock, and legacy-result incompatibilities explicitly
- remove the legacy image from maintained aggregate builds and CI image smoke so release work cannot publish it accidentally

## Test plan
- [x] `make verify`
- [x] `make -n docker-build-all` excludes the Python image
- [x] `make -n docker-build-anthropic` remains available for historical investigation
- [x] parse and actionlint the updated CI workflow
- [x] audit repository references for contradictory maintained/published claims

## Stack
- targets PR #45; merge after #45

Closes #39