### PR TITLE
Generate digest-pinned install manifests for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
             echo "::error::release tags must use vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-PRERELEASE"
             exit 1
           fi
+          if [[ "${#version}" -gt 63 ]]; then
+            echo "::error::release tags must fit the 63-character Kubernetes version label"
+            exit 1
+          fi
 
           git fetch origin "${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
           if ! git merge-base --is-ancestor "${GITHUB_SHA}" "origin/${DEFAULT_BRANCH}"; then
@@ -248,6 +252,12 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
+
       - name: Download image metadata
         uses: actions/download-artifact@v4
         with:
@@ -268,6 +278,11 @@ jobs:
               images: sort_by(.name)
             }' image-metadata/*.json >image-digests.json
 
+      - name: Render pinned install manifest
+        run: |
+          make release-manifest IMAGE_DIGESTS=image-digests.json
+          kubectl create --dry-run=client -f dist/install.yaml -o name
+
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -281,6 +296,7 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --verify-tag \
             --title "Kontext ${VERSION}" \
-            --notes "Versioned Kontext images for linux/amd64 and linux/arm64. See image-digests.json for immutable references. This release serves the kontext.dev/v1alpha1 API." \
+            --notes "Install with: kubectl apply -f https://github.com/${GITHUB_REPOSITORY}/releases/download/${VERSION}/install.yaml. See image-digests.json for immutable image references. This release serves the kontext.dev/v1alpha1 API." \
             "${flags[@]}" \
-            image-digests.json
+            image-digests.json \
+            dist/install.yaml

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ STDOUT_FIXTURE_IMG ?= kontext-stdout-fixture:dev
 # Generic image-build inputs. Convenience targets below select these per image.
 DOCKERFILE ?= Dockerfile
 CONTEXT ?= .
+DIST_DIR ?= dist
 
 # Get the currently used golang version
 GO_VERSION ?= 1.26.5
@@ -139,6 +140,14 @@ kind-install: docker-build docker-build-echo docker-build-reporter docker-build-
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+##@ Release
+
+.PHONY: release-manifest
+release-manifest: ## Render DIST_DIR/install.yaml from IMAGE_DIGESTS.
+	@test -f "$(IMAGE_DIGESTS)" || { echo "IMAGE_DIGESTS is required" >&2; exit 2; }
+	mkdir -p "$(DIST_DIR)"
+	./scripts/render-release-manifest.sh "$(IMAGE_DIGESTS)" >"$(DIST_DIR)/install.yaml"
 
 ##@ Deployment
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The thesis: **agents are workloads.** An agent should not live in a screen sessi
 After the [quickstart](#quickstart-on-kind) below, this is the whole workflow:
 
 ```bash
-kubectl apply -f deploy/examples/v1alpha1/echo-task-run.yaml
+./scripts/apply-example.sh deploy/examples/v1alpha1/echo-task-run.yaml
 kubectl get agentrun echo-review -w
 kubectl logs -f run-echo-review
 kubectl get agentrun echo-review -o jsonpath='{.status.result}'
@@ -34,6 +34,23 @@ consumers should read `.status.output`; `.status.result` remains its
 backward-compatible text projection. The full versioned contract is in
 [`SPEC.md`](SPEC.md).
 
+## Install a tagged release
+
+An existing Kubernetes cluster needs only kubectl and permission to create
+CRDs, cluster-scoped RBAC, a Namespace, and a Deployment:
+
+```bash
+VERSION=v0.1.0-alpha.1
+kubectl apply -f \
+  "https://github.com/MFS-code/Kontext/releases/download/${VERSION}/install.yaml"
+kubectl rollout status deployment/controller-manager \
+  --namespace kontext-system \
+  --timeout=120s
+```
+
+The release manifest pins the operator and trusted reporter images by digest.
+It does not require Docker, kind, or a repository clone.
+
 ## Quickstart on kind
 
 Requires Docker, [kind](https://kind.sigs.k8s.io/), and kubectl.
@@ -54,7 +71,7 @@ The e2e script proves the two core behaviors:
 ### Run a one-shot task
 
 ```bash
-kubectl apply -f deploy/examples/v1alpha1/echo-task-run.yaml
+./scripts/apply-example.sh deploy/examples/v1alpha1/echo-task-run.yaml
 kubectl get agentrun echo-review -w
 kubectl logs -f run-echo-review
 kubectl get agentrun echo-review -o jsonpath='{.status.result}'
@@ -63,7 +80,7 @@ kubectl get agentrun echo-review -o jsonpath='{.status.result}'
 ### Run a persistent service agent
 
 ```bash
-kubectl apply -f deploy/examples/v1alpha1/echo-service-agent.yaml
+./scripts/apply-example.sh deploy/examples/v1alpha1/echo-service-agent.yaml
 kubectl get agent echo-service -w
 kubectl logs -f $(kubectl get pod -l kontext.dev/agent=echo-service -o jsonpath='{.items[0].metadata.name}')
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,8 @@ Kontext provides generic `Agent` and `AgentRun` primitives. Consumer-specific co
 - Tag-driven releases publish version-matched operator, echo, reporter, and
   reference images for `linux/amd64` and `linux/arm64`, with immutable digests
   attached to the GitHub release.
+- Each release includes a single install manifest with digest-pinned operator
+  and reporter images for standard Kubernetes clusters.
 
 ### M7 — External integration spike ✅
 - Validated a `Service` `Agent`, knowledge `ConfigMap`, and task `AgentRun` from an external client.

--- a/config/overlays/release/README.md
+++ b/config/overlays/release/README.md
@@ -1,0 +1,9 @@
+# Release overlay
+
+This is the stable base for generated release artifacts. Do not apply it
+directly: the manager base still contains logical `controller:latest` and
+`reporter:latest` placeholders.
+
+`scripts/render-release-manifest.sh` layers the release tag and immutable
+operator/reporter digests from `image-digests.json`, then emits the complete
+install manifest.

--- a/config/overlays/release/kustomization.yaml
+++ b/config/overlays/release/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../default
+
+patches:
+  - path: manager_patch.yaml

--- a/config/overlays/release/manager_patch.yaml
+++ b/config/overlays/release/manager_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: kontext-system
+spec:
+  template:
+    metadata:
+      annotations:
+        kontext.dev/distribution: release

--- a/deploy/examples/v1alpha1/README.md
+++ b/deploy/examples/v1alpha1/README.md
@@ -1,15 +1,29 @@
 # v1alpha1 examples
 
-These manifests assume the Kontext CRDs and controller are installed. The kind
-quickstart builds and loads the local `kontext-*:dev` images; provider examples
-additionally require the named
-namespace-local Secret. Apply namespaced manifests with `kubectl apply -f`.
+These manifests assume the Kontext CRDs and controller are installed. Kontext
+images use the documented `RELEASE_TAG` placeholder rather than a mutable
+development tag.
+
+After the kind quickstart, map placeholders to the loaded local images:
+
+```bash
+./scripts/apply-example.sh deploy/examples/v1alpha1/echo-task-run.yaml
+```
+
+To apply an example with published images instead:
+
+```bash
+KONTEXT_RELEASE_TAG=v0.1.0-alpha.1 \
+  ./scripts/apply-example.sh deploy/examples/v1alpha1/reference-fake-run.yaml
+```
+
+Provider examples additionally require the named namespace-local Secret.
 
 ## Bring your own image
 
 | Path | Manifest | Prerequisite | Expected observation |
 |---|---|---|---|
-| Plain image, logs only | `plain-logs-run.yaml` | `kontext-stdout-fixture:dev` | `Succeeded`; ordinary `kubectl logs`; empty `status.result` and no `status.output`. No reporter is injected. |
+| Plain image, logs only | `plain-logs-run.yaml` | Digest-pinned BusyBox, or the local fixture selected by `apply-example.sh` | `Succeeded`; ordinary `kubectl logs`; empty `status.result` and no `status.output`. No reporter is injected. |
 | Injected final-line capture | `stdout-last-line-run.yaml` | Fixture and configured `KONTEXT_REPORTER_IMAGE` | `Succeeded`; logs remain available; `status.result` is `final answer from busybox`. |
 | Injected structured capture | `stdout-envelope-run.yaml` | Fixture and configured reporter image | `Succeeded`; the prefixed envelope supplies JSON output and measured usage. |
 | Native versioned envelope | `native-envelope-run.yaml` | Fixture image | `Succeeded`; the process writes `kontext.dev/result/v1alpha1` to `/dev/termination-log` itself. `runtime.result` is omitted, so the controller does not inject a reporter. |

--- a/deploy/examples/v1alpha1/echo-service-agent.yaml
+++ b/deploy/examples/v1alpha1/echo-service-agent.yaml
@@ -8,7 +8,7 @@ spec:
   provider: echo
   model: echo-model
   runtime:
-    image: kontext-echo:dev
+    image: ghcr.io/mfs-code/kontext-echo:RELEASE_TAG
     command: ["/entrypoint.sh"]
   env:
     - name: KONTEXT_MODE

--- a/deploy/examples/v1alpha1/echo-task-run.yaml
+++ b/deploy/examples/v1alpha1/echo-task-run.yaml
@@ -7,6 +7,6 @@ spec:
   provider: echo
   model: echo-model
   runtime:
-    image: kontext-echo:dev
+    image: ghcr.io/mfs-code/kontext-echo:RELEASE_TAG
   budget:
     wallclock: 2m

--- a/deploy/examples/v1alpha1/kustomizeconfig.yaml
+++ b/deploy/examples/v1alpha1/kustomizeconfig.yaml
@@ -1,0 +1,5 @@
+images:
+  - path: spec/runtime/image
+    kind: Agent
+  - path: spec/runtime/image
+    kind: AgentRun

--- a/deploy/examples/v1alpha1/native-envelope-run.yaml
+++ b/deploy/examples/v1alpha1/native-envelope-run.yaml
@@ -7,7 +7,7 @@ spec:
   provider: echo
   model: fixture-model
   runtime:
-    image: kontext-stdout-fixture:dev
+    image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
     command: ["/bin/sh", "-c"]
     args:
       - |

--- a/deploy/examples/v1alpha1/plain-logs-run.yaml
+++ b/deploy/examples/v1alpha1/plain-logs-run.yaml
@@ -7,7 +7,7 @@ spec:
   provider: echo
   model: fixture-model
   runtime:
-    image: kontext-stdout-fixture:dev
+    image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
     command: ["/bin/sh", "-c"]
     args:
       - |

--- a/deploy/examples/v1alpha1/reference-anthropic-run.yaml
+++ b/deploy/examples/v1alpha1/reference-anthropic-run.yaml
@@ -9,7 +9,7 @@ spec:
   secretRef:
     name: kontext-anthropic
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
   budget:
     # Leave headroom for provider input usage even on a one-turn example.
     tokens: 4096

--- a/deploy/examples/v1alpha1/reference-fake-run.yaml
+++ b/deploy/examples/v1alpha1/reference-fake-run.yaml
@@ -7,7 +7,7 @@ spec:
   provider: fake
   model: vendor/opaque-model@2026
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
   env:
     - name: KONTEXT_FAKE_SCENARIO
       value: success

--- a/deploy/examples/v1alpha1/reference-fake-tool-run.yaml
+++ b/deploy/examples/v1alpha1/reference-fake-tool-run.yaml
@@ -18,7 +18,7 @@ spec:
   knowledgeConfigMapRef:
     name: reference-tool-knowledge
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
   env:
     - name: KONTEXT_FAKE_SCENARIO
       value: tool

--- a/deploy/examples/v1alpha1/reference-kind-network-policy-runs.yaml
+++ b/deploy/examples/v1alpha1/reference-kind-network-policy-runs.yaml
@@ -10,7 +10,7 @@ spec:
   tools: [shell]
   serviceAccountName: reference-network-reader
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -50,7 +50,7 @@ spec:
   tools: [kubernetes_read]
   serviceAccountName: reference-network-reader
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/deploy/examples/v1alpha1/reference-kind-network-policy.yaml
+++ b/deploy/examples/v1alpha1/reference-kind-network-policy.yaml
@@ -62,7 +62,7 @@ spec:
       type: RuntimeDefault
   containers:
     - name: allowed
-      image: kontext-reference:dev
+      image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
       command: ["/bin/httpd"]
       args: ["-f", "-p", "8080", "-h", "/www"]
       ports:
@@ -79,7 +79,7 @@ spec:
           mountPath: /www
           readOnly: true
     - name: blocked
-      image: kontext-reference:dev
+      image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
       command: ["/bin/httpd"]
       args: ["-f", "-p", "8081", "-h", "/www"]
       ports:

--- a/deploy/examples/v1alpha1/reference-kind-policy-runs.yaml
+++ b/deploy/examples/v1alpha1/reference-kind-policy-runs.yaml
@@ -55,7 +55,7 @@ spec:
   tools: [kubernetes_read]
   serviceAccountName: reference-kubernetes-reader
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -94,7 +94,7 @@ spec:
   tools: [kubernetes_read]
   serviceAccountName: reference-kubernetes-reader
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -133,7 +133,7 @@ spec:
   tools: [kubernetes_read]
   serviceAccountName: reference-kubernetes-reader
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -172,7 +172,7 @@ spec:
   tools: [shell]
   serviceAccountName: reference-shell
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -211,7 +211,7 @@ spec:
   tools: [shell]
   serviceAccountName: reference-shell
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/deploy/examples/v1alpha1/reference-openai-compatible-run.yaml
+++ b/deploy/examples/v1alpha1/reference-openai-compatible-run.yaml
@@ -9,7 +9,7 @@ spec:
   secretRef:
     name: kontext-openai
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
   env:
     # Remove this override to use OpenAI's hosted Chat Completions endpoint.
     - name: KONTEXT_PROVIDER_BASE_URL

--- a/deploy/examples/v1alpha1/reference-playwright-browser-run.yaml
+++ b/deploy/examples/v1alpha1/reference-playwright-browser-run.yaml
@@ -14,7 +14,7 @@ spec:
     - browser_click
   serviceAccountName: reference-browser-runtime
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/deploy/examples/v1alpha1/reference-playwright-cancel-run.yaml
+++ b/deploy/examples/v1alpha1/reference-playwright-cancel-run.yaml
@@ -12,7 +12,7 @@ spec:
     - browser_wait_for
   serviceAccountName: reference-browser-runtime
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/deploy/examples/v1alpha1/reference-playwright-deny-run.yaml
+++ b/deploy/examples/v1alpha1/reference-playwright-deny-run.yaml
@@ -11,7 +11,7 @@ spec:
     - browser_navigate
   serviceAccountName: reference-browser-runtime
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/deploy/examples/v1alpha1/reference-playwright-fresh-run.yaml
+++ b/deploy/examples/v1alpha1/reference-playwright-fresh-run.yaml
@@ -12,7 +12,7 @@ spec:
     - browser_snapshot
   serviceAccountName: reference-browser-runtime
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/deploy/examples/v1alpha1/reference-playwright-mcp.yaml
+++ b/deploy/examples/v1alpha1/reference-playwright-mcp.yaml
@@ -112,7 +112,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: http
-          image: kontext-reference:dev
+          image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
           command: ["/bin/httpd"]
           args: ["-f", "-p", "8080", "-h", "/www"]
           ports:
@@ -176,7 +176,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: http
-          image: kontext-reference:dev
+          image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
           command: ["/bin/httpd"]
           args: ["-f", "-p", "8080", "-h", "/www"]
           ports:

--- a/deploy/examples/v1alpha1/reference-tools-run.yaml
+++ b/deploy/examples/v1alpha1/reference-tools-run.yaml
@@ -112,7 +112,7 @@ spec:
     name: reference-tool-knowledge
   serviceAccountName: kontext-reference-tools
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -148,7 +148,7 @@ spec:
     - shell
   serviceAccountName: kontext-reference-shell
   runtime:
-    image: kontext-reference:dev
+    image: ghcr.io/mfs-code/kontext-reference:RELEASE_TAG
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/deploy/examples/v1alpha1/stdout-envelope-run.yaml
+++ b/deploy/examples/v1alpha1/stdout-envelope-run.yaml
@@ -7,7 +7,7 @@ spec:
   provider: echo
   model: fixture-model
   runtime:
-    image: kontext-stdout-fixture:dev
+    image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
     command: ["/bin/sh", "-c"]
     args:
       - |

--- a/deploy/examples/v1alpha1/stdout-failure-run.yaml
+++ b/deploy/examples/v1alpha1/stdout-failure-run.yaml
@@ -7,7 +7,7 @@ spec:
   provider: echo
   model: fixture-model
   runtime:
-    image: kontext-stdout-fixture:dev
+    image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
     command: ["/bin/sh", "-c"]
     args:
       - |

--- a/deploy/examples/v1alpha1/stdout-last-line-run.yaml
+++ b/deploy/examples/v1alpha1/stdout-last-line-run.yaml
@@ -7,7 +7,7 @@ spec:
   provider: echo
   model: fixture-model
   runtime:
-    image: kontext-stdout-fixture:dev
+    image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
     command: ["/bin/sh", "-c"]
     args:
       - |

--- a/deploy/examples/v1alpha1/stdout-signal-run.yaml
+++ b/deploy/examples/v1alpha1/stdout-signal-run.yaml
@@ -7,7 +7,7 @@ spec:
   provider: echo
   model: fixture-model
   runtime:
-    image: kontext-stdout-fixture:dev
+    image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
     command: ["/bin/sh", "-c"]
     args:
       - |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -36,6 +36,29 @@ GitHub release is created if anonymous access cannot be verified.
 The unmaintained `runtimes/python-anthropic` migration example is not
 published.
 
+## Install
+
+Install a tagged release on an existing cluster without cloning the repository
+or building images:
+
+```bash
+VERSION=v0.1.0-alpha.1
+kubectl apply -f \
+  "https://github.com/MFS-code/Kontext/releases/download/${VERSION}/install.yaml"
+```
+
+`install.yaml` contains the CRDs, Namespace, RBAC, and controller Deployment.
+Its operator and trusted reporter references use the immutable digests recorded
+in `image-digests.json`, while `app.kubernetes.io/version` and
+`kontext.dev/release` retain the human-readable release tag.
+
+Given a downloaded digest manifest, the release artifact is reproducible from
+the tagged source:
+
+```bash
+make release-manifest IMAGE_DIGESTS=image-digests.json
+```
+
 ## API relationship
 
 The git tag, GitHub release, and image tags identify one version of the Kontext

--- a/scripts/apply-example.sh
+++ b/scripts/apply-example.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Apply one release-neutral example with either local dev or versioned images.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXAMPLES_DIR="${ROOT_DIR}/deploy/examples/v1alpha1"
+EXAMPLE_ARG="${1:-}"
+if [[ -n "${EXAMPLE_ARG}" && "${EXAMPLE_ARG}" != */* ]]; then
+  EXAMPLE_FILE="${EXAMPLES_DIR}/${EXAMPLE_ARG}"
+else
+  EXAMPLE_FILE="${EXAMPLE_ARG}"
+fi
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "missing required command: kubectl" >&2
+  exit 1
+fi
+
+if [[ -z "${EXAMPLE_FILE}" || ! -f "${EXAMPLE_FILE}" ]]; then
+  echo "usage: $0 <example.yaml|deploy/examples/v1alpha1/example.yaml> [kubectl apply options]" >&2
+  exit 2
+fi
+
+example_dir="$(cd "$(dirname "${EXAMPLE_FILE}")" && pwd)"
+if [[ "${example_dir}" != "${EXAMPLES_DIR}" ]]; then
+  echo "example must be a direct child of ${EXAMPLES_DIR}" >&2
+  exit 2
+fi
+example_name="$(basename "${EXAMPLE_FILE}")"
+
+overlay_dir="$(mktemp -d "${EXAMPLES_DIR}/.render.XXXXXX")"
+cleanup() {
+  rm -rf "${overlay_dir}"
+}
+trap cleanup EXIT
+
+cp "${EXAMPLE_FILE}" "${overlay_dir}/${example_name}"
+cp "${EXAMPLES_DIR}/kustomizeconfig.yaml" "${overlay_dir}/kustomizeconfig.yaml"
+
+cat >"${overlay_dir}/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ${example_name}
+
+configurations:
+  - kustomizeconfig.yaml
+
+images:
+EOF
+
+append_image() {
+  local original="$1"
+  local reference="$2"
+  local name=""
+  local tag=""
+  local digest=""
+  local final_component="${reference##*/}"
+
+  if [[ "${reference}" == *@* ]]; then
+    name="${reference%@*}"
+    digest="${reference#*@}"
+  elif [[ "${final_component}" == *:* ]]; then
+    name="${reference%:*}"
+    tag="${reference##*:}"
+  else
+    name="${reference}"
+    tag="latest"
+  fi
+
+  {
+    echo "  - name: ${original}"
+    echo "    newName: ${name}"
+    if [[ -n "${digest}" ]]; then
+      echo "    digest: ${digest}"
+    else
+      echo "    newTag: ${tag}"
+    fi
+  } >>"${overlay_dir}/kustomization.yaml"
+}
+
+if [[ -n "${KONTEXT_RELEASE_TAG:-}" ]]; then
+  core='v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+  prerelease_id='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+  release_pattern="^${core}(-${prerelease_id}(\.${prerelease_id})*)?$"
+  if [[ ! "${KONTEXT_RELEASE_TAG}" =~ ${release_pattern} ||
+    "${#KONTEXT_RELEASE_TAG}" -gt 63 ]]; then
+    echo "invalid KONTEXT_RELEASE_TAG: ${KONTEXT_RELEASE_TAG}" >&2
+    exit 2
+  fi
+
+  append_image \
+    "ghcr.io/mfs-code/kontext-echo" \
+    "ghcr.io/mfs-code/kontext-echo:${KONTEXT_RELEASE_TAG}"
+  append_image \
+    "ghcr.io/mfs-code/kontext-reference" \
+    "ghcr.io/mfs-code/kontext-reference:${KONTEXT_RELEASE_TAG}"
+else
+  append_image \
+    "ghcr.io/mfs-code/kontext-echo" \
+    "${KONTEXT_ECHO_IMAGE:-kontext-echo:dev}"
+  append_image \
+    "ghcr.io/mfs-code/kontext-reference" \
+    "${KONTEXT_REFERENCE_IMAGE:-kontext-reference:dev}"
+  append_image \
+    "busybox" \
+    "${KONTEXT_STDOUT_FIXTURE_IMAGE:-kontext-stdout-fixture:dev}"
+fi
+
+if [[ "${KONTEXT_RENDER_ONLY:-false}" == "true" ]]; then
+  kubectl kustomize "${overlay_dir}"
+  exit 0
+fi
+
+kubectl apply -k "${overlay_dir}" "${@:2}"

--- a/scripts/e2e-kind-network-policy.sh
+++ b/scripts/e2e-kind-network-policy.sh
@@ -16,6 +16,7 @@ CALICO_MANIFEST=""
 WORK_DIR=""
 CLUSTER_CREATED=false
 PREVIOUS_CONTEXT=""
+APPLY_EXAMPLE="${ROOT_DIR}/scripts/apply-example.sh"
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -438,8 +439,7 @@ KONTEXT_KIND_IMAGE_SET=network-policy \
   "${ROOT_DIR}/scripts/install-go-kind.sh"
 
 echo "==> applying NetworkPolicy fixture and policy"
-kubectl apply -f \
-  "${ROOT_DIR}/deploy/examples/v1alpha1/reference-kind-network-policy.yaml"
+"${APPLY_EXAMPLE}" reference-kind-network-policy.yaml
 kubernetes_service_ip="$(
   kubectl get service kubernetes -n default -o jsonpath='{.spec.clusterIP}'
 )"
@@ -481,8 +481,7 @@ kubectl wait --for=condition=Ready pod/network-policy-http \
   --timeout=120s
 
 echo "==> starting policy-selected runtime probes"
-kubectl apply -f \
-  "${ROOT_DIR}/deploy/examples/v1alpha1/reference-kind-network-policy-runs.yaml"
+"${APPLY_EXAMPLE}" reference-kind-network-policy-runs.yaml
 wait_for_run_phase reference-network-http Succeeded
 wait_for_run_phase reference-network-kubernetes Succeeded
 
@@ -512,8 +511,7 @@ if [[ "${kubernetes_logs}" != *'"name":"kubernetes_read"'* ||
 fi
 
 echo "==> applying restricted Playwright MCP and deterministic HTML fixtures"
-kubectl apply -f \
-  "${ROOT_DIR}/deploy/examples/v1alpha1/reference-playwright-mcp.yaml"
+"${APPLY_EXAMPLE}" reference-playwright-mcp.yaml
 kubectl rollout status deployment/playwright-fixture \
   -n "${NAMESPACE}" --timeout=180s
 kubectl rollout status deployment/unrelated-http \
@@ -530,8 +528,7 @@ assert_strict_pod_isolation "${playwright_pod}" mcp browser
 wait_for_no_browser_processes
 
 echo "==> running deterministic browser interaction"
-kubectl apply -f \
-  "${ROOT_DIR}/deploy/examples/v1alpha1/reference-playwright-browser-run.yaml"
+"${APPLY_EXAMPLE}" reference-playwright-browser-run.yaml
 wait_for_run_phase reference-playwright-browser Succeeded
 kubectl logs run-reference-playwright-browser -n "${NAMESPACE}" -c runtime \
   >"${WORK_DIR}/playwright-browser.log"
@@ -553,8 +550,7 @@ fi
 wait_for_no_browser_processes
 
 echo "==> proving browser profile isolation across AgentRuns"
-kubectl apply -f \
-  "${ROOT_DIR}/deploy/examples/v1alpha1/reference-playwright-fresh-run.yaml"
+"${APPLY_EXAMPLE}" reference-playwright-fresh-run.yaml
 wait_for_run_phase reference-playwright-fresh Succeeded
 kubectl logs run-reference-playwright-fresh -n "${NAMESPACE}" -c runtime \
   >"${WORK_DIR}/playwright-fresh.log"
@@ -575,8 +571,7 @@ fi
 wait_for_no_browser_processes
 
 echo "==> proving browser egress deny rules"
-kubectl apply -f \
-  "${ROOT_DIR}/deploy/examples/v1alpha1/reference-playwright-deny-run.yaml"
+"${APPLY_EXAMPLE}" reference-playwright-deny-run.yaml
 wait_for_run_phase reference-playwright-deny Succeeded
 kubectl logs run-reference-playwright-deny -n "${NAMESPACE}" -c runtime \
   >"${WORK_DIR}/playwright-deny.log"
@@ -597,8 +592,7 @@ fi
 wait_for_no_browser_processes
 
 echo "==> proving wallclock cancellation cleans the browser session"
-kubectl apply -f \
-  "${ROOT_DIR}/deploy/examples/v1alpha1/reference-playwright-cancel-run.yaml"
+"${APPLY_EXAMPLE}" reference-playwright-cancel-run.yaml
 kubectl wait --for=condition=Ready pod/run-reference-playwright-cancel \
   -n "${NAMESPACE}" --timeout=90s
 assert_strict_pod_isolation run-reference-playwright-cancel runtime runtime

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TOOLS_NAMESPACE="kontext-e2e-tools"
+APPLY_EXAMPLE="${ROOT_DIR}/scripts/apply-example.sh"
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -90,7 +91,7 @@ echo "==> cleaning previous e2e resources"
 cleanup_e2e_resources
 
 echo "==> applying standalone echo task run"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/echo-task-run.yaml"
+"${APPLY_EXAMPLE}" echo-task-run.yaml
 
 echo "==> waiting for AgentRun to succeed"
 phase=""
@@ -115,7 +116,7 @@ fi
 echo "task result: ${result}"
 
 echo "==> verifying plain image logs without structured result capture"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/plain-logs-run.yaml"
+"${APPLY_EXAMPLE}" plain-logs-run.yaml
 wait_for_run_phase plain-logs Succeeded
 plain_result="$(kubectl get agentrun plain-logs -o jsonpath='{.status.result}')"
 plain_output="$(kubectl get agentrun plain-logs -o jsonpath='{.status.output}')"
@@ -132,7 +133,7 @@ if [[ -n "${plain_result}" ||
 fi
 
 echo "==> verifying a native versioned termination envelope"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/native-envelope-run.yaml"
+"${APPLY_EXAMPLE}" native-envelope-run.yaml
 wait_for_run_phase native-envelope Succeeded
 native_result="$(kubectl get agentrun native-envelope -o jsonpath='{.status.result}')"
 native_input_tokens="$(
@@ -153,7 +154,7 @@ if [[ "${native_result}" != '{"answer":"native"}' ||
 fi
 
 echo "==> verifying last-line capture from an unmodified image"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/stdout-last-line-run.yaml"
+"${APPLY_EXAMPLE}" stdout-last-line-run.yaml
 wait_for_run_phase stdout-last-line Succeeded
 last_line_result="$(kubectl get agentrun stdout-last-line -o jsonpath='{.status.result}')"
 last_line_media_type="$(kubectl get agentrun stdout-last-line -o jsonpath='{.status.output.mediaType}')"
@@ -172,7 +173,7 @@ if [[ "${last_line_logs}" != *"ordinary workload log"* ]]; then
 fi
 
 echo "==> verifying structured envelope capture"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/stdout-envelope-run.yaml"
+"${APPLY_EXAMPLE}" stdout-envelope-run.yaml
 wait_for_run_phase stdout-envelope Succeeded
 structured_result="$(kubectl get agentrun stdout-envelope -o jsonpath='{.status.result}')"
 input_tokens="$(kubectl get agentrun stdout-envelope -o jsonpath='{.status.usage.inputTokens}')"
@@ -187,7 +188,7 @@ if [[ "${input_tokens}" != "0" || "${output_tokens}" != "7" ]]; then
 fi
 
 echo "==> verifying non-zero child exit propagation"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/stdout-failure-run.yaml"
+"${APPLY_EXAMPLE}" stdout-failure-run.yaml
 wait_for_run_phase stdout-failure Failed
 failure_exit_code="$(
   kubectl get pod run-stdout-failure \
@@ -199,7 +200,7 @@ if [[ "${failure_exit_code}" != "7" ]]; then
 fi
 
 echo "==> verifying SIGTERM forwarding to the child"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/stdout-signal-run.yaml"
+"${APPLY_EXAMPLE}" stdout-signal-run.yaml
 for _ in $(seq 1 60); do
   signal_phase="$(kubectl get pod run-stdout-signal -o jsonpath='{.status.phase}' 2>/dev/null || true)"
   if [[ "${signal_phase}" == "Running" ]]; then
@@ -220,7 +221,7 @@ if [[ "${signal_result}" != "signal reached child" ]]; then
 fi
 
 echo "==> verifying model-agnostic reference runtime"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/reference-fake-run.yaml"
+"${APPLY_EXAMPLE}" reference-fake-run.yaml
 wait_for_run_phase reference-fake Succeeded
 reference_result="$(kubectl get agentrun reference-fake -o jsonpath='{.status.result}')"
 reference_input_tokens="$(kubectl get agentrun reference-fake -o jsonpath='{.status.usage.inputTokens}')"
@@ -243,7 +244,7 @@ if [[ "${reference_logs}" != *'"apiVersion":"kontext.dev/event/v1alpha1"'* ]]; t
 fi
 
 echo "==> verifying bounded reference-runtime tool loop"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/reference-fake-tool-run.yaml"
+"${APPLY_EXAMPLE}" reference-fake-tool-run.yaml
 wait_for_run_phase reference-fake-tool Succeeded
 tool_result="$(kubectl get agentrun reference-fake-tool -o jsonpath='{.status.result}')"
 tool_logs="$(kubectl logs run-reference-fake-tool -c runtime)"
@@ -258,7 +259,7 @@ if [[ "${tool_logs}" != *'"type":"tool"'* ||
 fi
 
 echo "==> verifying Kubernetes read policy and restricted shell execution"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/reference-kind-policy-runs.yaml"
+"${APPLY_EXAMPLE}" reference-kind-policy-runs.yaml
 
 wait_for_run_phase reference-kubernetes-pods Succeeded "${TOOLS_NAMESPACE}"
 pods_logs="$(
@@ -347,7 +348,7 @@ if [[ "${wallclock_phase}" != "BudgetExceeded" || -n "${wallclock_pod}" ]]; then
 fi
 
 echo "==> applying service echo agent"
-kubectl apply -f "${ROOT_DIR}/deploy/examples/v1alpha1/echo-service-agent.yaml"
+"${APPLY_EXAMPLE}" echo-service-agent.yaml
 
 echo "==> waiting for live service run"
 for _ in $(seq 1 60); do

--- a/scripts/eval-kind.sh
+++ b/scripts/eval-kind.sh
@@ -10,6 +10,7 @@ RECORDS="${EVAL_DIR}/keyless.jsonl"
 SUMMARY="${EVAL_DIR}/keyless.summary.json"
 MARKER="${EVAL_DIR}/not-run.json"
 SERVICE_AGENT="echo-service"
+APPLY_EXAMPLE="${ROOT_DIR}/scripts/apply-example.sh"
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -206,8 +207,7 @@ if jq -s -e '
 fi
 
 echo "==> proving Service mode omits wallclock deadlines and recasts"
-kubectl apply -n "${EVAL_NAMESPACE}" \
-  -f "${ROOT_DIR}/deploy/examples/v1alpha1/echo-service-agent.yaml" >/dev/null
+"${APPLY_EXAMPLE}" echo-service-agent.yaml -n "${EVAL_NAMESPACE}" >/dev/null
 first_run="$(wait_for_service)"
 first_pod="$(
   kubectl get pod -n "${EVAL_NAMESPACE}" \

--- a/scripts/render-release-manifest.sh
+++ b/scripts/render-release-manifest.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Render a single install manifest from the digest metadata produced by release CI.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+METADATA_FILE="${1:-}"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need jq
+need kubectl
+
+if [[ -z "${METADATA_FILE}" || ! -f "${METADATA_FILE}" ]]; then
+  echo "usage: $0 <image-digests.json>" >&2
+  exit 2
+fi
+
+metadata_api="$(jq -er '.apiVersion' "${METADATA_FILE}")"
+if [[ "${metadata_api}" != "kontext.dev/release-images/v1alpha1" ]]; then
+  echo "unsupported release metadata API in ${METADATA_FILE}: ${metadata_api}" >&2
+  exit 1
+fi
+
+release_tag="$(jq -er '.releaseTag | select(type == "string" and length > 0)' "${METADATA_FILE}")"
+core='v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+prerelease_id='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+release_pattern="^${core}(-${prerelease_id}(\.${prerelease_id})*)?$"
+if [[ ! "${release_tag}" =~ ${release_pattern} || "${#release_tag}" -gt 63 ]]; then
+  echo "invalid release tag in ${METADATA_FILE}: ${release_tag}" >&2
+  exit 1
+fi
+
+control_plane_api="$(jq -er '.controlPlaneAPI' "${METADATA_FILE}")"
+if [[ "${control_plane_api}" != "kontext.dev/v1alpha1" ]]; then
+  echo "unsupported control-plane API in ${METADATA_FILE}: ${control_plane_api}" >&2
+  exit 1
+fi
+
+image_ref() {
+  local name="$1"
+  jq -er \
+    --arg name "${name}" \
+    '[
+      .images[]
+      | select(.name == $name)
+      | .immutableReference
+    ] | if length == 1 then .[0] else error("expected exactly one image named " + $name) end' \
+    "${METADATA_FILE}"
+}
+
+operator_image="$(image_ref operator)"
+reporter_image="$(image_ref reporter)"
+if [[ ! "${operator_image}" =~ ^ghcr\.io/mfs-code/kontext-operator@sha256:[0-9a-f]{64}$ ]]; then
+  echo "invalid operator image reference: ${operator_image}" >&2
+  exit 1
+fi
+if [[ ! "${reporter_image}" =~ ^ghcr\.io/mfs-code/kontext-reporter@sha256:[0-9a-f]{64}$ ]]; then
+  echo "invalid reporter image reference: ${reporter_image}" >&2
+  exit 1
+fi
+
+overlay_dir="$(mktemp -d "${ROOT_DIR}/config/overlays/.release.XXXXXX")"
+cleanup() {
+  rm -rf "${overlay_dir}"
+}
+trap cleanup EXIT
+
+cat >"${overlay_dir}/kustomization.yaml" <<'EOF'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../release
+
+patches:
+  - path: manager_patch.yaml
+EOF
+
+cat >"${overlay_dir}/manager_patch.yaml" <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: kontext-system
+  labels:
+    app.kubernetes.io/version: "${release_tag}"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: "${release_tag}"
+      annotations:
+        kontext.dev/release: "${release_tag}"
+    spec:
+      containers:
+        - name: manager
+          image: "${operator_image}"
+          env:
+            - name: KONTEXT_REPORTER_IMAGE
+              value: "${reporter_image}"
+EOF
+
+kubectl kustomize "${overlay_dir}"

--- a/scripts/testdata/release-image-digests.json
+++ b/scripts/testdata/release-image-digests.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "kontext.dev/release-images/v1alpha1",
+  "releaseTag": "v0.0.0-test.1",
+  "controlPlaneAPI": "kontext.dev/v1alpha1",
+  "images": [
+    {
+      "name": "echo",
+      "immutableReference": "ghcr.io/mfs-code/kontext-echo@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    },
+    {
+      "name": "operator",
+      "immutableReference": "ghcr.io/mfs-code/kontext-operator@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+    },
+    {
+      "name": "reference",
+      "immutableReference": "ghcr.io/mfs-code/kontext-reference@sha256:3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    {
+      "name": "reporter",
+      "immutableReference": "ghcr.io/mfs-code/kontext-reporter@sha256:4444444444444444444444444444444444444444444444444444444444444444"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- render a reproducible all-in-one install manifest from release image metadata and attach it to each GitHub release
- pin the operator and trusted reporter by digest while retaining the human-readable release tag in deployment metadata
- replace `:dev` assumptions in source examples with release placeholders or a digest-pinned public fixture, using one renderer for both local kind and tagged-release images

## Test plan
- [x] `make verify`
- [x] render `dist/install.yaml` from fixture metadata, validate all resources with client-side kubectl, and verify byte-for-byte reproducibility
- [x] render every example in development mode with no unresolved release images
- [x] render every example for `v0.1.0-alpha.1` with no `RELEASE_TAG` or `:dev` references
- [x] shell syntax checks and actionlint
- [x] `make kind-install`
- [x] `./scripts/e2e-kind.sh`
- [x] `./scripts/eval-kind.sh`

## Stack
- targets PR #47; merge after #47

Closes #41