### PR TITLE
Gate releases on registry install and lifecycle verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,14 +213,12 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  release:
-    name: Create GitHub release
+  manifest:
+    name: Build release artifacts
     needs:
       - validate
       - images
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -253,6 +251,123 @@ jobs:
           make release-manifest IMAGE_DIGESTS=image-digests.json
           kubectl create --dry-run=client -f dist/install.yaml -o name
 
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          path: |
+            image-digests.json
+            dist/install.yaml
+          if-no-files-found: error
+          retention-days: 7
+
+  verify-install:
+    name: Verify registry install, upgrade, and uninstall
+    needs:
+      - validate
+      - manifest
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      KIND_CLUSTER_NAME: kontext-release-verification
+      KONTEXT_DIAG_DIR: ${{ github.workspace }}/.ci-diagnostics
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download current release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets
+
+      - name: Create clean kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          wait: 120s
+
+      - name: Download previous release manifest when available
+        id: previous
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          previous="$(
+            gh release list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --exclude-drafts \
+              --limit 100 \
+              --json tagName,publishedAt \
+              --jq 'sort_by(.publishedAt) | last | .tagName // ""'
+          )"
+          if [[ -z "${previous}" ]]; then
+            echo "available=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          mkdir -p previous-release
+          if ! gh release download "${previous}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern install.yaml \
+            --dir previous-release; then
+            echo "::warning::previous release ${previous} has no install manifest; skipping cross-version upgrade"
+            echo "available=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "available=true" >>"${GITHUB_OUTPUT}"
+          echo "version=${previous}" >>"${GITHUB_OUTPUT}"
+
+      - name: Verify release lifecycle
+        env:
+          CURRENT_VERSION: ${{ needs.validate.outputs.version }}
+          HAS_PREVIOUS: ${{ steps.previous.outputs.available }}
+          PREVIOUS_VERSION: ${{ steps.previous.outputs.version }}
+        run: |
+          args=(
+            release-assets/dist/install.yaml
+            "${CURRENT_VERSION}"
+          )
+          if [[ "${HAS_PREVIOUS}" == "true" ]]; then
+            args+=(
+              previous-release/install.yaml
+              "${PREVIOUS_VERSION}"
+            )
+          fi
+          ./scripts/verify-release-install.sh "${args[@]}"
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: ./scripts/collect-kind-diagnostics.sh "${KONTEXT_DIAG_DIR}"
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-install-diagnostics-${{ github.run_id }}
+          path: ${{ env.KONTEXT_DIAG_DIR }}
+          if-no-files-found: ignore
+
+      - name: Delete kind cluster
+        if: always()
+        run: kind delete cluster --name "${KIND_CLUSTER_NAME}" || true
+
+  release:
+    name: Create GitHub release
+    needs:
+      - validate
+      - manifest
+      - verify-install
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download verified release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets
+
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -268,5 +383,5 @@ jobs:
             --title "Kontext ${VERSION}" \
             --notes "Install with: kubectl apply -f https://github.com/${GITHUB_REPOSITORY}/releases/download/${VERSION}/install.yaml. See image-digests.json for immutable image references. This release serves the kontext.dev/v1alpha1 API." \
             "${flags[@]}" \
-            image-digests.json \
-            dist/install.yaml
+            release-assets/image-digests.json \
+            release-assets/dist/install.yaml

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ kubectl rollout status deployment/controller-manager \
 ```
 
 The release manifest pins the operator and trusted reporter images by digest.
-It does not require Docker, kind, or a repository clone.
+It does not require Docker, kind, or a repository clone. See
+[`docs/releases.md`](docs/releases.md) before upgrading or uninstalling because
+deleting the CRDs also deletes every `Agent` and `AgentRun`.
 
 ## Quickstart on kind
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,9 @@ Kontext provides generic `Agent` and `AgentRun` primitives. Consumer-specific co
   attached to the GitHub release.
 - Each release includes a single install manifest with digest-pinned operator
   and reporter images for standard Kubernetes clusters.
+- Release CI installs exclusively from public registry artifacts on a clean
+  cluster and verifies upgrade, CRD retention, and complete uninstall paths
+  before creating the GitHub release.
 
 ### M7 — External integration spike ✅
 - Validated a `Service` `Agent`, knowledge `ConfigMap`, and task `AgentRun` from an external client.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -59,6 +59,67 @@ the tagged source:
 make release-manifest IMAGE_DIGESTS=image-digests.json
 ```
 
+## Upgrade between alpha releases
+
+`v1alpha1` does not imply compatibility between Kontext distribution versions.
+Read the target release notes first, especially any CRD schema, defaulting,
+runtime-contract, or status changes. Back up custom resources before upgrading:
+
+```bash
+kubectl get agents,agentruns --all-namespaces -o yaml \
+  > kontext-custom-resources-backup.yaml
+```
+
+Apply the new release manifest over the existing installation and wait for the
+controller rollout:
+
+```bash
+NEW_VERSION=v0.1.0-alpha.2
+kubectl apply -f \
+  "https://github.com/MFS-code/Kontext/releases/download/${NEW_VERSION}/install.yaml"
+kubectl rollout status deployment/controller-manager \
+  --namespace kontext-system \
+  --timeout=180s
+```
+
+Kubernetes updates the CRDs, RBAC, and Deployment declaratively; existing
+`Agent` and `AgentRun` resources remain. Downgrades are not supported. Release
+CI installs the previous published manifest when available, runs a workload,
+applies the candidate manifest in place, and runs the registry-backed suite
+before publishing the new GitHub release.
+
+## Uninstall
+
+To remove only the Kontext control plane while retaining the CRDs and custom
+resources in other namespaces:
+
+```bash
+kubectl delete clusterrolebinding manager-rolebinding \
+  --ignore-not-found=true
+kubectl delete clusterrole manager-role \
+  --ignore-not-found=true
+kubectl delete namespace kontext-system \
+  --ignore-not-found=true --wait=true
+```
+
+Deleting `kontext-system` removes the controller and its ServiceAccount.
+`Agent` and `AgentRun` resources in other namespaces remain stored and can be
+reconciled again by reapplying an install manifest. Any custom resources
+created inside `kontext-system` are deleted with that Namespace.
+
+To remove Kontext completely, including both CRDs:
+
+```bash
+VERSION=v0.1.0-alpha.1
+kubectl delete -f \
+  "https://github.com/MFS-code/Kontext/releases/download/${VERSION}/install.yaml" \
+  --ignore-not-found=true --wait=true
+```
+
+Deleting a CRD deletes **all** custom resources of that kind across the
+cluster. Back them up first if their history or results must be retained.
+Release CI verifies both the retention procedure and complete removal.
+
 ## API relationship
 
 The git tag, GitHub release, and image tags identify one version of the Kontext

--- a/scripts/verify-release-install.sh
+++ b/scripts/verify-release-install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Verify install, upgrade, retained-CRD removal, and complete removal on a clean cluster.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CURRENT_MANIFEST="${1:-}"
+CURRENT_VERSION="${2:-}"
+PREVIOUS_MANIFEST="${3:-}"
+PREVIOUS_VERSION="${4:-}"
+APPLY_EXAMPLE="${ROOT_DIR}/scripts/apply-example.sh"
+
+if [[ -z "${CURRENT_MANIFEST}" || ! -f "${CURRENT_MANIFEST}" || -z "${CURRENT_VERSION}" ]]; then
+  echo "usage: $0 <current-install.yaml> <current-version> [previous-install.yaml previous-version]" >&2
+  exit 2
+fi
+if [[ -n "${PREVIOUS_MANIFEST}" && (! -f "${PREVIOUS_MANIFEST}" || -z "${PREVIOUS_VERSION}") ]]; then
+  echo "previous manifest and version must be supplied together" >&2
+  exit 2
+fi
+
+wait_for_run_phase() {
+  local name="$1"
+  local expected="$2"
+  local phase=""
+  for _ in $(seq 1 90); do
+    phase="$(
+      kubectl get agentrun "${name}" \
+        -o jsonpath='{.status.phase}' 2>/dev/null || true
+    )"
+    if [[ "${phase}" == "${expected}" ]]; then
+      return 0
+    fi
+    case "${phase}" in
+      ""|Pending|Running) ;;
+      *)
+        echo "expected ${name} phase=${expected}, got ${phase}" >&2
+        return 1
+        ;;
+    esac
+    sleep 1
+  done
+  echo "${name} did not reach ${expected}; last phase=${phase}" >&2
+  return 1
+}
+
+install_release() {
+  local manifest="$1"
+  kubectl apply -f "${manifest}"
+  kubectl rollout status deployment/controller-manager \
+    --namespace kontext-system \
+    --timeout=180s
+
+  local operator_image=""
+  local reporter_image=""
+  operator_image="$(
+    kubectl get deployment controller-manager -n kontext-system \
+      -o jsonpath='{.spec.template.spec.containers[0].image}'
+  )"
+  reporter_image="$(
+    kubectl get deployment controller-manager -n kontext-system \
+      -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="KONTEXT_REPORTER_IMAGE")].value}'
+  )"
+  if [[ "${operator_image}" != *@sha256:* || "${reporter_image}" != *@sha256:* ]]; then
+    echo "install manifest did not deploy digest-pinned images" >&2
+    return 1
+  fi
+}
+
+smoke_release_runtime() {
+  local version="$1"
+  kubectl delete agentrun echo-review --ignore-not-found=true --wait=true
+  KONTEXT_RELEASE_TAG="${version}" "${APPLY_EXAMPLE}" echo-task-run.yaml
+  wait_for_run_phase echo-review Succeeded
+
+  local runtime_image=""
+  runtime_image="$(
+    kubectl get agentrun echo-review -o jsonpath='{.spec.runtime.image}'
+  )"
+  if [[ "${runtime_image}" != "ghcr.io/mfs-code/kontext-echo:${version}" ]]; then
+    echo "unexpected echo runtime image: ${runtime_image}" >&2
+    return 1
+  fi
+  kubectl delete agentrun echo-review --wait=true
+}
+
+if [[ -n "${PREVIOUS_MANIFEST}" ]]; then
+  echo "==> installing previous release ${PREVIOUS_VERSION}"
+  install_release "${PREVIOUS_MANIFEST}"
+  smoke_release_runtime "${PREVIOUS_VERSION}"
+fi
+
+echo "==> installing current release ${CURRENT_VERSION}"
+install_release "${CURRENT_MANIFEST}"
+smoke_release_runtime "${CURRENT_VERSION}"
+
+echo "==> running registry-backed keyless acceptance"
+KONTEXT_RELEASE_TAG="${CURRENT_VERSION}" "${ROOT_DIR}/scripts/e2e-kind.sh"
+
+echo "==> verifying control-plane removal with CR retention"
+cat <<EOF | kubectl apply -f -
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: retained-install-check
+  namespace: default
+spec:
+  mode: Task
+  goal: Verify custom-resource retention during control-plane removal.
+  model: echo-model
+  runtime:
+    image: ghcr.io/mfs-code/kontext-echo:${CURRENT_VERSION}
+EOF
+
+kubectl delete clusterrolebinding manager-rolebinding --ignore-not-found=true
+kubectl delete clusterrole manager-role --ignore-not-found=true
+kubectl delete namespace kontext-system --ignore-not-found=true --wait=true
+
+kubectl get crd agents.kontext.dev agentruns.kontext.dev >/dev/null
+kubectl get agent retained-install-check -n default >/dev/null
+
+echo "==> reinstalling after retained-CRD removal"
+install_release "${CURRENT_MANIFEST}"
+kubectl get agent retained-install-check -n default >/dev/null
+kubectl delete agent retained-install-check -n default --wait=true
+
+echo "==> verifying complete uninstall"
+kubectl delete -f "${CURRENT_MANIFEST}" --ignore-not-found=true --wait=true
+
+if kubectl get crd agents.kontext.dev >/dev/null 2>&1 ||
+  kubectl get crd agentruns.kontext.dev >/dev/null 2>&1 ||
+  kubectl get namespace kontext-system >/dev/null 2>&1 ||
+  kubectl get clusterrole manager-role >/dev/null 2>&1 ||
+  kubectl get clusterrolebinding manager-rolebinding >/dev/null 2>&1; then
+  echo "complete uninstall left Kontext resources behind" >&2
+  exit 1
+fi
+
+echo "release install, upgrade, retention, and uninstall verification passed"


### PR DESCRIPTION
## Summary
- split release publication into artifact generation, clean-cluster verification, and final GitHub release creation
- install exclusively from the generated manifest and public registry images, run the keyless suite, and upgrade from the previous published manifest when one exists
- verify CRD-preserving control-plane removal, reinstallation, complete uninstall, and document the corresponding operator procedures and data-loss boundary

## Test plan
- [x] `make verify`
- [x] actionlint and shell syntax checks
- [x] verify the release install job contains no `kind load` or local image build path
- [x] exercise CRD retention and reinstallation on the local disposable kind cluster
- [x] exercise complete manifest uninstall and assert CRDs, Namespace, ClusterRole, and ClusterRoleBinding are removed
- [x] restore and verify the local kind development installation after lifecycle testing

The anonymous registry pull and previous-release upgrade paths run on release tags after the images and manifest exist; GitHub release creation is blocked unless they pass.

## Stack
- targets PR #48; merge after #48

Closes #42