### PR TITLE
Publish versioned multi-arch images to GHCR

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: Optional comma-delimited target platforms
     required: false
     default: ""
+  labels:
+    description: Optional newline-delimited OCI image labels
+    required: false
+    default: ""
 
 outputs:
   digest:
@@ -45,5 +49,6 @@ runs:
         load: ${{ inputs.load }}
         push: ${{ inputs.push }}
         platforms: ${{ inputs.platforms }}
+        labels: ${{ inputs.labels }}
         cache-from: type=gha,scope=${{ inputs.cache-scope }}
         cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,256 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Check out repository history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate version and source commit
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME}"
+          core='v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+          prerelease_id='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+          pattern="^${core}(-${prerelease_id}(\.${prerelease_id})*)?$"
+          if [[ ! "${version}" =~ ${pattern} ]]; then
+            echo "::error::release tags must use vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-PRERELEASE"
+            exit 1
+          fi
+
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+            echo "::error::release tag ${version} does not point to a commit on main"
+            exit 1
+          fi
+          if gh release view "${version}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "::error::release ${version} already exists"
+            exit 1
+          fi
+
+          echo "version=${version}" >>"${GITHUB_OUTPUT}"
+
+  images:
+    name: Publish ${{ matrix.name }}
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: operator
+            package: kontext-operator
+            context: .
+            dockerfile: Dockerfile
+          - name: echo
+            package: kontext-echo
+            context: runtimes/echo
+            dockerfile: runtimes/echo/Dockerfile
+          - name: reporter
+            package: kontext-reporter
+            context: .
+            dockerfile: runtimes/reporter/Dockerfile
+          - name: reference
+            package: kontext-reference
+            context: .
+            dockerfile: runtimes/reference/Dockerfile
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Resolve existing immutable image
+        id: existing
+        env:
+          IMAGE: ghcr.io/mfs-code/${{ matrix.package }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          reference="${IMAGE}:${VERSION}"
+          if ! manifest="$(
+            docker buildx imagetools inspect "${reference}" \
+              --format '{{json .Manifest}}' 2>/dev/null
+          )"; then
+            echo "exists=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          images="$(docker buildx imagetools inspect "${reference}" --format '{{json .Image}}')"
+          for platform in linux/amd64 linux/arm64; do
+            revision="$(
+              jq -r \
+                --arg platform "${platform}" \
+                '.[$platform].config.Labels["org.opencontainers.image.revision"] // empty' \
+                <<<"${images}"
+            )"
+            if [[ "${revision}" != "${GITHUB_SHA}" ]]; then
+              echo "::error::${reference} already exists for revision ${revision:-unknown}; release tags are immutable"
+              exit 1
+            fi
+          done
+
+          echo "exists=true" >>"${GITHUB_OUTPUT}"
+          echo "digest=$(jq -r '.digest' <<<"${manifest}")" >>"${GITHUB_OUTPUT}"
+
+      - name: Build and push multi-arch image
+        id: build
+        if: steps.existing.outputs.exists != 'true'
+        uses: ./.github/actions/build-image
+        with:
+          context: ${{ matrix.context }}
+          dockerfile: ${{ matrix.dockerfile }}
+          tags: ghcr.io/mfs-code/${{ matrix.package }}:${{ needs.validate.outputs.version }}
+          cache-scope: release-${{ matrix.name }}
+          load: "false"
+          push: "true"
+          platforms: linux/amd64,linux/arm64
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+            org.opencontainers.image.licenses=MIT
+
+      - name: Make package public
+        env:
+          GH_TOKEN: ${{ secrets.PACKAGES_TOKEN || github.token }}
+          PACKAGE: ${{ matrix.package }}
+          OWNER_TYPE: ${{ github.event.repository.owner.type }}
+        run: |
+          if [[ "${OWNER_TYPE}" == "Organization" ]]; then
+            endpoint="orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${PACKAGE}"
+          else
+            endpoint="user/packages/container/${PACKAGE}"
+          fi
+
+          for attempt in 1 2 3 4 5; do
+            if gh api --method PATCH "${endpoint}" --field visibility=public >/dev/null &&
+              [[ "$(gh api "${endpoint}" --jq .visibility)" == "public" ]]; then
+              exit 0
+            fi
+            if [[ "${attempt}" -lt 5 ]]; then
+              sleep $((attempt * 2))
+            fi
+          done
+          echo "::error::could not make ghcr.io/mfs-code/${PACKAGE} public"
+          exit 1
+
+      - name: Verify anonymous multi-arch pull
+        env:
+          IMAGE: ghcr.io/mfs-code/${{ matrix.package }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          docker logout ghcr.io
+          manifest="$(docker buildx imagetools inspect "${IMAGE}:${VERSION}")"
+          [[ "${manifest}" == *"linux/amd64"* ]]
+          [[ "${manifest}" == *"linux/arm64"* ]]
+
+      - name: Record immutable image reference
+        env:
+          DIGEST: ${{ steps.existing.outputs.digest || steps.build.outputs.digest }}
+          IMAGE: ghcr.io/mfs-code/${{ matrix.package }}
+          IMAGE_NAME: ${{ matrix.name }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          mkdir -p image-metadata
+          jq -n \
+            --arg name "${IMAGE_NAME}" \
+            --arg image "${IMAGE}" \
+            --arg tag "${VERSION}" \
+            --arg digest "${DIGEST}" \
+            '{
+              name: $name,
+              image: $image,
+              tag: $tag,
+              reference: ($image + ":" + $tag),
+              digest: $digest,
+              immutableReference: ($image + "@" + $digest),
+              platforms: ["linux/amd64", "linux/arm64"]
+            }' >"image-metadata/${IMAGE_NAME}.json"
+
+      - name: Upload image metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-image-${{ matrix.name }}
+          path: image-metadata/${{ matrix.name }}.json
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Create GitHub release
+    needs:
+      - validate
+      - images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download image metadata
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-image-*
+          path: image-metadata
+          merge-multiple: true
+
+      - name: Assemble digest manifest
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          jq -s \
+            --arg releaseTag "${VERSION}" \
+            '{
+              apiVersion: "kontext.dev/release-images/v1alpha1",
+              releaseTag: $releaseTag,
+              controlPlaneAPI: "kontext.dev/v1alpha1",
+              images: sort_by(.name)
+            }' image-metadata/*.json >image-digests.json
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          flags=()
+          if [[ "${VERSION}" == *-* ]]; then
+            flags+=(--prerelease)
+          fi
+          gh release create "${VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --verify-tag \
+            --title "Kontext ${VERSION}" \
+            --notes "Versioned Kontext images for linux/amd64 and linux/arm64. See image-digests.json for immutable references. This release serves the kontext.dev/v1alpha1 API." \
+            "${flags[@]}" \
+            image-digests.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.tag.outputs.version }}
+      registry_owner: ${{ steps.tag.outputs.registry_owner }}
     steps:
       - name: Check out repository history
         uses: actions/checkout@v4
@@ -27,6 +28,7 @@ jobs:
       - name: Validate version and source commit
         id: tag
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
         run: |
           version="${GITHUB_REF_NAME}"
@@ -38,9 +40,9 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main
-          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
-            echo "::error::release tag ${version} does not point to a commit on main"
+          git fetch origin "${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" "origin/${DEFAULT_BRANCH}"; then
+            echo "::error::release tag ${version} does not point to a commit on ${DEFAULT_BRANCH}"
             exit 1
           fi
           if gh release view "${version}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
@@ -49,11 +51,15 @@ jobs:
           fi
 
           echo "version=${version}" >>"${GITHUB_OUTPUT}"
+          echo "registry_owner=${GITHUB_REPOSITORY_OWNER,,}" >>"${GITHUB_OUTPUT}"
 
   images:
     name: Publish ${{ matrix.name }}
     needs: validate
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      REGISTRY_OWNER: ${{ needs.validate.outputs.registry_owner }}
     permissions:
       contents: read
       packages: write
@@ -97,16 +103,25 @@ jobs:
       - name: Resolve existing immutable image
         id: existing
         env:
-          IMAGE: ghcr.io/mfs-code/${{ matrix.package }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.REGISTRY_OWNER }}/${{ matrix.package }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           reference="${IMAGE}:${VERSION}"
+          inspect_error="${RUNNER_TEMP}/inspect-${{ matrix.name }}.log"
           if ! manifest="$(
             docker buildx imagetools inspect "${reference}" \
-              --format '{{json .Manifest}}' 2>/dev/null
+              --format '{{json .Manifest}}' 2>"${inspect_error}"
           )"; then
-            echo "exists=false" >>"${GITHUB_OUTPUT}"
-            exit 0
+            error_message="$(<"${inspect_error}")"
+            normalized_error="${error_message,,}"
+            if [[ "${normalized_error}" == *"not found"* ||
+              "${normalized_error}" == *"manifest unknown"* ]]; then
+              echo "exists=false" >>"${GITHUB_OUTPUT}"
+              exit 0
+            fi
+            echo "::error::failed to inspect existing release image ${reference}"
+            printf '%s\n' "${error_message}" >&2
+            exit 1
           fi
 
           images="$(docker buildx imagetools inspect "${reference}" --format '{{json .Image}}')"
@@ -133,7 +148,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           dockerfile: ${{ matrix.dockerfile }}
-          tags: ghcr.io/mfs-code/${{ matrix.package }}:${{ needs.validate.outputs.version }}
+          tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_OWNER }}/${{ matrix.package }}:${{ needs.validate.outputs.version }}
           cache-scope: release-${{ matrix.name }}
           load: "false"
           push: "true"
@@ -165,23 +180,38 @@ jobs:
               sleep $((attempt * 2))
             fi
           done
-          echo "::error::could not make ghcr.io/mfs-code/${PACKAGE} public"
+          echo "::error::could not make ${REGISTRY}/${REGISTRY_OWNER}/${PACKAGE} public"
           exit 1
 
       - name: Verify anonymous multi-arch pull
         env:
-          IMAGE: ghcr.io/mfs-code/${{ matrix.package }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.REGISTRY_OWNER }}/${{ matrix.package }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          docker logout ghcr.io
-          manifest="$(docker buildx imagetools inspect "${IMAGE}:${VERSION}")"
-          [[ "${manifest}" == *"linux/amd64"* ]]
-          [[ "${manifest}" == *"linux/arm64"* ]]
+          anonymous_config="$(mktemp -d "${RUNNER_TEMP}/docker-anonymous.XXXXXX")"
+          trap 'rm -rf "${anonymous_config}"' EXIT
+          manifest="$(
+            DOCKER_CONFIG="${anonymous_config}" \
+              docker buildx imagetools inspect "${IMAGE}:${VERSION}" \
+              --format '{{json .Manifest}}'
+          )"
+          for platform in linux/amd64 linux/arm64; do
+            os="${platform%/*}"
+            architecture="${platform#*/}"
+            if ! jq -e \
+              --arg os "${os}" \
+              --arg architecture "${architecture}" \
+              'any(.manifests[]?; .platform.os == $os and .platform.architecture == $architecture)' \
+              <<<"${manifest}" >/dev/null; then
+              echo "::error::${IMAGE}:${VERSION} is missing ${platform}"
+              exit 1
+            fi
+          done
 
       - name: Record immutable image reference
         env:
           DIGEST: ${{ steps.existing.outputs.digest || steps.build.outputs.digest }}
-          IMAGE: ghcr.io/mfs-code/${{ matrix.package }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.REGISTRY_OWNER }}/${{ matrix.package }}
           IMAGE_NAME: ${{ matrix.name }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |

--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ dispatch-only, environment-protected workflow; its short-lived artifact is the
 release evidence. A keyless or render-only run is not an authenticated
 provider acceptance. See [`docs/evals.md`](docs/evals.md).
 
+## Releases
+
+A SemVer-compatible git tag publishes version-matched operator, echo, reporter,
+and reference images for `linux/amd64` and `linux/arm64`. Release artifacts
+include immutable digests; mutable `latest` and `dev` tags are not published.
+See [`docs/releases.md`](docs/releases.md) for the tag, image, and `v1alpha1`
+compatibility contract.
+
 ## Governance
 
 Each `AgentRun` is isolated and auditable. Budgets and runtime limits are

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,6 +61,9 @@ Kontext provides generic `Agent` and `AgentRun` primitives. Consumer-specific co
 
 ### M6 — Packaging + observability
 - Kustomize install exists under `config/default`. Helm/metrics still open.
+- Tag-driven releases publish version-matched operator, echo, reporter, and
+  reference images for `linux/amd64` and `linux/arm64`, with immutable digests
+  attached to the GitHub release.
 
 ### M7 — External integration spike ✅
 - Validated a `Service` `Agent`, knowledge `ConfigMap`, and task `AgentRun` from an external client.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,50 @@
+# Release and image versioning
+
+Kontext releases use SemVer-compatible git tags:
+
+```text
+vMAJOR.MINOR.PATCH
+vMAJOR.MINOR.PATCH-PRERELEASE
+```
+
+Build metadata suffixes (`+...`) are not supported because they are not valid
+OCI tag characters. The first public alpha can therefore use a tag such as
+`v0.1.0-alpha.1`.
+
+## Published images
+
+Each release publishes the same tag for four public GHCR images:
+
+```text
+ghcr.io/mfs-code/kontext-operator:<release-tag>
+ghcr.io/mfs-code/kontext-echo:<release-tag>
+ghcr.io/mfs-code/kontext-reporter:<release-tag>
+ghcr.io/mfs-code/kontext-reference:<release-tag>
+```
+
+Every image index includes `linux/amd64` and `linux/arm64`. Releases do not
+publish mutable `latest` or `dev` tags. The workflow refuses to overwrite an
+existing release image tag, verifies anonymous pulls, and attaches an
+`image-digests.json` asset containing immutable `image@sha256:...` references.
+
+The workflow uses its repository token to make new GHCR packages public. If
+the account's package policy denies visibility changes to that token, configure
+a classic `PACKAGES_TOKEN` repository secret with `write:packages`; the
+workflow uses it only for the visibility operation. Publication fails before a
+GitHub release is created if anonymous access cannot be verified.
+
+The unmaintained `runtimes/python-anthropic` migration example is not
+published.
+
+## API relationship
+
+The git tag, GitHub release, and image tags identify one version of the Kontext
+distribution. They do not change the Kubernetes API group/version: current
+releases serve `kontext.dev/v1alpha1`, and maintained runtimes emit the
+versioned event and result contracts documented in [`SPEC.md`](../SPEC.md).
+
+`v1alpha1` is intentionally unstable. A new Kontext alpha release may make
+breaking CRD, runtime-contract, or status-shape changes while retaining the
+same Kubernetes API version. Consumers must read the release notes and follow
+the documented upgrade procedure rather than treating matching `v1alpha1`
+labels as compatibility guarantees.


### PR DESCRIPTION
## Summary
- publish operator, echo, reporter, and reference images for linux/amd64 and linux/arm64 from strict version tags
- prevent tag overwrites, fail closed on registry errors, and verify anonymous multi-platform pulls
- attach immutable digest metadata and document the release compatibility contract

This replaces #47 after the stacked branches were repaired.

## Test plan
- [x] workflow and action linting
- [x] strict tag and digest-manifest validation
- [x] multi-architecture builds for all published images