### PR TITLE
Fix GHCR public visibility for user-owned packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,11 +168,14 @@ jobs:
           GH_TOKEN: ${{ secrets.PACKAGES_TOKEN || github.token }}
           PACKAGE: ${{ matrix.package }}
           OWNER_TYPE: ${{ github.event.repository.owner.type }}
+          OWNER: ${{ github.repository_owner }}
         run: |
+          # For user-owned repos, use /users/{owner}/... — not /user/..., which
+          # targets the authenticated token identity (often not the package owner).
           if [[ "${OWNER_TYPE}" == "Organization" ]]; then
-            endpoint="orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${PACKAGE}"
+            endpoint="orgs/${OWNER}/packages/container/${PACKAGE}"
           else
-            endpoint="user/packages/container/${PACKAGE}"
+            endpoint="users/${OWNER}/packages/container/${PACKAGE}"
           fi
 
           for attempt in 1 2 3 4 5; do
@@ -184,7 +187,7 @@ jobs:
               sleep $((attempt * 2))
             fi
           done
-          echo "::error::could not make ${REGISTRY}/${REGISTRY_OWNER}/${PACKAGE} public"
+          echo "::error::could not make ${REGISTRY}/${REGISTRY_OWNER}/${PACKAGE} public via ${endpoint}"
           exit 1
 
       - name: Verify anonymous multi-arch pull


### PR DESCRIPTION
## Summary
- Echo publish failed at **Make package public** with `gh: Not Found (HTTP 404)` after a successful push
- `MFS-code` is a User account; the workflow used `user/packages/...` (Actions token identity) instead of `users/MFS-code/packages/...`
- Point the PATCH at `users/${OWNER}/packages/container/${PACKAGE}` for user-owned repos

## Test plan
- [ ] Merge this PR to `main`
- [ ] Re-run the failed Release workflow on tag `v0.1.0-alpha.1` (images already pushed for this SHA should be reused)
- [ ] Confirm all four `Publish *` jobs pass Make package public + anonymous pull
- [ ] Confirm the GitHub release is created with `install.yaml`