### PR TITLE
Resolve canonical repository and registry identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.tag.outputs.version }}
+      github_owner: ${{ steps.tag.outputs.github_owner }}
+      registry: ${{ steps.tag.outputs.registry }}
       registry_owner: ${{ steps.tag.outputs.registry_owner }}
+      repository: ${{ steps.tag.outputs.repository }}
     steps:
       - name: Check out repository history
         uses: actions/checkout@v4
@@ -31,6 +34,12 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          source scripts/lib/common.sh
+          if [[ "${GITHUB_REPOSITORY}" != "${KONTEXT_GITHUB_REPOSITORY}" ]]; then
+            echo "::error::release workflow must run from ${KONTEXT_GITHUB_REPOSITORY}, got ${GITHUB_REPOSITORY}"
+            exit 1
+          fi
+
           version="${GITHUB_REF_NAME}"
           core='v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
           prerelease_id='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
@@ -49,20 +58,23 @@ jobs:
             echo "::error::release tag ${version} does not point to a commit on ${DEFAULT_BRANCH}"
             exit 1
           fi
-          if gh release view "${version}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          if gh release view "${version}" --repo "${KONTEXT_GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             echo "::error::release ${version} already exists"
             exit 1
           fi
 
           echo "version=${version}" >>"${GITHUB_OUTPUT}"
-          echo "registry_owner=${GITHUB_REPOSITORY_OWNER,,}" >>"${GITHUB_OUTPUT}"
+          echo "github_owner=${KONTEXT_GITHUB_OWNER}" >>"${GITHUB_OUTPUT}"
+          echo "registry=${KONTEXT_REGISTRY}" >>"${GITHUB_OUTPUT}"
+          echo "registry_owner=${KONTEXT_REGISTRY_OWNER}" >>"${GITHUB_OUTPUT}"
+          echo "repository=${KONTEXT_GITHUB_REPOSITORY}" >>"${GITHUB_OUTPUT}"
 
   images:
     name: Publish ${{ matrix.name }}
     needs: validate
     runs-on: ubuntu-latest
     env:
-      REGISTRY: ghcr.io
+      REGISTRY: ${{ needs.validate.outputs.registry }}
       REGISTRY_OWNER: ${{ needs.validate.outputs.registry_owner }}
     permissions:
       contents: read
@@ -100,7 +112,7 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
@@ -168,7 +180,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PACKAGES_TOKEN || github.token }}
           PACKAGE: ${{ matrix.package }}
           OWNER_TYPE: ${{ github.event.repository.owner.type }}
-          OWNER: ${{ github.repository_owner }}
+          OWNER: ${{ needs.validate.outputs.github_owner }}
         run: |
           # For user-owned repos, use /users/{owner}/... — not /user/..., which
           # targets the authenticated token identity (often not the package owner).
@@ -324,10 +336,11 @@ jobs:
         id: previous
         env:
           GH_TOKEN: ${{ github.token }}
+          KONTEXT_GITHUB_REPOSITORY: ${{ needs.validate.outputs.repository }}
         run: |
           releases="$(
             gh release list \
-              --repo "${GITHUB_REPOSITORY}" \
+              --repo "${KONTEXT_GITHUB_REPOSITORY}" \
               --exclude-drafts \
               --limit 1000 \
               --json tagName,publishedAt
@@ -344,7 +357,7 @@ jobs:
 
           mkdir -p previous-release
           if ! gh release download "${previous}" \
-            --repo "${GITHUB_REPOSITORY}" \
+            --repo "${KONTEXT_GITHUB_REPOSITORY}" \
             --pattern install.yaml \
             --dir previous-release; then
             echo "::warning::previous release ${previous} has no install manifest; skipping cross-version upgrade"
@@ -408,6 +421,7 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
+          KONTEXT_GITHUB_REPOSITORY: ${{ needs.validate.outputs.repository }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           flags=()
@@ -415,10 +429,10 @@ jobs:
             flags+=(--prerelease)
           fi
           gh release create "${VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" \
+            --repo "${KONTEXT_GITHUB_REPOSITORY}" \
             --verify-tag \
             --title "Kontext ${VERSION}" \
-            --notes "Install with: kubectl apply -f https://github.com/${GITHUB_REPOSITORY}/releases/download/${VERSION}/install.yaml. See image-digests.json for immutable image references. This release serves the kontext.dev/v1alpha1 API." \
+            --notes "Install with: kubectl apply -f https://github.com/${KONTEXT_GITHUB_REPOSITORY}/releases/download/${VERSION}/install.yaml. See image-digests.json for immutable image references. This release serves the kontext.dev/v1alpha1 API." \
             "${flags[@]}" \
             release-assets/image-digests.json \
             release-assets/dist/install.yaml

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: verify
-verify: manifests generate ## Check generated artifacts and gofmt; fail on drift.
+verify: manifests generate test-release-identity ## Check generated artifacts, release identity, and gofmt; fail on drift.
 	@if ! git diff --quiet --exit-code -- \
 		api/v1alpha1/zz_generated.deepcopy.go \
 		config/crd/bases \
@@ -142,6 +142,10 @@ docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
 ##@ Release
+
+.PHONY: test-release-identity
+test-release-identity: ## Verify release tooling uses the canonical repository and registry.
+	./scripts/test-release-identity.sh
 
 .PHONY: release-manifest
 release-manifest: ## Render DIST_DIR/install.yaml from IMAGE_DIGESTS.

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@ domain: kontext.dev
 layout:
 - go.kubebuilder.io/v4
 projectName: kontext
-repo: github.com/kontext-dev/kontext
+repo: github.com/MFS-code/Kontext
 resources:
 - api:
     crdVersion: v1
@@ -11,7 +11,7 @@ resources:
   domain: kontext.dev
   group: kontext
   kind: Agent
-  path: github.com/kontext-dev/kontext/api/v1alpha1
+  path: github.com/MFS-code/Kontext/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -20,6 +20,6 @@ resources:
   domain: kontext.dev
   group: kontext
   kind: AgentRun
-  path: github.com/kontext-dev/kontext/api/v1alpha1
+  path: github.com/MFS-code/Kontext/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/cmd/kontext-eval/main.go
+++ b/cmd/kontext-eval/main.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/kontext-dev/kontext/internal/eval"
+	"github.com/MFS-code/Kontext/internal/eval"
 )
 
 func main() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,8 +14,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/controller"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/controller"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kontext-dev/kontext
+module github.com/MFS-code/Kontext
 
 go 1.26.5
 
@@ -10,6 +10,7 @@ require (
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
 	sigs.k8s.io/controller-runtime v0.20.4
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -69,5 +70,4 @@ require (
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -5,8 +5,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/status"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/status"
 )
 
 const (

--- a/internal/conditions/conditions_test.go
+++ b/internal/conditions/conditions_test.go
@@ -6,8 +6,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/conditions"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/conditions"
 )
 
 func findCondition(conds []metav1.Condition, condType string) *metav1.Condition {

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -15,12 +15,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/conditions"
-	"github.com/kontext-dev/kontext/internal/podbuilder"
-	"github.com/kontext-dev/kontext/internal/runtimepolicy"
-	"github.com/kontext-dev/kontext/internal/status"
-	"github.com/kontext-dev/kontext/internal/util"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/conditions"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/internal/runtimepolicy"
+	"github.com/MFS-code/Kontext/internal/status"
+	"github.com/MFS-code/Kontext/internal/util"
 )
 
 const (

--- a/internal/controller/agent_controller_internal_test.go
+++ b/internal/controller/agent_controller_internal_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 )
 
 func TestBackoffDelaySaturatesForLargeRestartCount(t *testing.T) {

--- a/internal/controller/agent_controller_test.go
+++ b/internal/controller/agent_controller_test.go
@@ -13,10 +13,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/conditions"
-	"github.com/kontext-dev/kontext/internal/controller"
-	"github.com/kontext-dev/kontext/internal/podbuilder"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/conditions"
+	"github.com/MFS-code/Kontext/internal/controller"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
 )
 
 func TestAgentReconcilerMintsServiceRun(t *testing.T) {

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -13,10 +13,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/conditions"
-	"github.com/kontext-dev/kontext/internal/podbuilder"
-	"github.com/kontext-dev/kontext/internal/status"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/conditions"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/internal/status"
 )
 
 // AgentRunReconciler reconciles an AgentRun object.

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -14,8 +14,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/podbuilder"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
 )
 
 func TestAgentRunReconcilerCreatesPod(t *testing.T) {

--- a/internal/controller/budget_validation_test.go
+++ b/internal/controller/budget_validation_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 )
 
 func TestWallclockBudgetAPIValidation(t *testing.T) {

--- a/internal/controller/env_validation_test.go
+++ b/internal/controller/env_validation_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 )
 
 func TestGenericEnvAPIValidation(t *testing.T) {

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 )
 
 func TestSetStatusConditionsPreservesTransitionTimeForReasonAndMessageChanges(t *testing.T) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -17,8 +17,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/controller"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/controller"
 )
 
 var (

--- a/internal/eval/cli.go
+++ b/internal/eval/cli.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 )
 
 func Execute(ctx context.Context, args []string, stdout, stderr io.Writer) int {

--- a/internal/eval/observe.go
+++ b/internal/eval/observe.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
 )
 
 const (

--- a/internal/eval/observe_grader_test.go
+++ b/internal/eval/observe_grader_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 func TestParseLogsCollectsBoundedMetadataAndEnvelope(t *testing.T) {

--- a/internal/eval/output_judge_test.go
+++ b/internal/eval/output_judge_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
 )
 
 func TestWriteOutputsProducesJSONLAndSummary(t *testing.T) {

--- a/internal/eval/runner.go
+++ b/internal/eval/runner.go
@@ -19,9 +19,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 const (

--- a/internal/eval/runner_test.go
+++ b/internal/eval/runner_test.go
@@ -20,9 +20,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 func TestRunnerCollectsGradesJudgesThenCleansOnlyCreatedRun(t *testing.T) {

--- a/internal/eval/suite.go
+++ b/internal/eval/suite.go
@@ -14,9 +14,9 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 const defaultTimeout = 5 * time.Minute

--- a/internal/eval/types.go
+++ b/internal/eval/types.go
@@ -8,9 +8,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 const (

--- a/internal/podbuilder/podbuilder.go
+++ b/internal/podbuilder/podbuilder.go
@@ -9,9 +9,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/runtimepolicy"
-	"github.com/kontext-dev/kontext/internal/util"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/runtimepolicy"
+	"github.com/MFS-code/Kontext/internal/util"
 )
 
 const (

--- a/internal/podbuilder/podbuilder_test.go
+++ b/internal/podbuilder/podbuilder_test.go
@@ -7,8 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/podbuilder"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
 )
 
 func TestBuildPodInjectsKontextEnv(t *testing.T) {

--- a/internal/runtimepolicy/provider.go
+++ b/internal/runtimepolicy/provider.go
@@ -3,7 +3,7 @@ package runtimepolicy
 import (
 	"strings"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 )
 
 const DefaultProvider = "anthropic"

--- a/internal/runtimepolicy/provider_test.go
+++ b/internal/runtimepolicy/provider_test.go
@@ -3,8 +3,8 @@ package runtimepolicy_test
 import (
 	"testing"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/runtimepolicy"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/runtimepolicy"
 )
 
 func TestNormalizeProviderDefaults(t *testing.T) {

--- a/internal/status/phase.go
+++ b/internal/status/phase.go
@@ -1,6 +1,6 @@
 package status
 
-import kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
+import kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 
 // IsTerminalPhase reports whether an AgentRun phase is finished.
 func IsTerminalPhase(phase kontextv1alpha1.AgentRunPhase) bool {

--- a/internal/status/pod.go
+++ b/internal/status/pod.go
@@ -7,9 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/podbuilder"
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 // PodObservation summarizes a Pod for AgentRun reconciliation.

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -7,9 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/podbuilder"
-	"github.com/kontext-dev/kontext/internal/status"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/internal/status"
 )
 
 func TestObservePodPlainTextTermination(t *testing.T) {

--- a/pkg/event/v1alpha1/types_test.go
+++ b/pkg/event/v1alpha1/types_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
 )
 
 func TestParseValidatesVersionTypeTimestampAndShape(t *testing.T) {

--- a/pkg/result/v1alpha1/result_test.go
+++ b/pkg/result/v1alpha1/result_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 func TestParseVersionedEnvelopeWithArbitraryJSONOutput(t *testing.T) {

--- a/pkg/result/v1alpha1/stream_test.go
+++ b/pkg/result/v1alpha1/stream_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 func TestWriteEnvelopeLineRoundTripsThroughExtract(t *testing.T) {

--- a/runtimes/reference/internal/config/config_test.go
+++ b/runtimes/reference/internal/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 )
 
 func TestLoadPreservesOpaqueModelAndParsesOptionalInputs(t *testing.T) {

--- a/runtimes/reference/internal/config/mcp_test.go
+++ b/runtimes/reference/internal/config/mcp_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 )
 
 func TestLoadMCPConfigResolvesReferencesWithoutInheritingEnvironment(t *testing.T) {

--- a/runtimes/reference/internal/conversation/state.go
+++ b/runtimes/reference/internal/conversation/state.go
@@ -1,7 +1,7 @@
 package conversation
 
 import (
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 type State struct {

--- a/runtimes/reference/internal/conversation/state_test.go
+++ b/runtimes/reference/internal/conversation/state_test.go
@@ -3,8 +3,8 @@ package conversation_test
 import (
 	"testing"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/conversation"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/conversation"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 func TestStateTracksConversationWithoutExposingMutableSlices(t *testing.T) {

--- a/runtimes/reference/internal/engine/engine.go
+++ b/runtimes/reference/internal/engine/engine.go
@@ -9,12 +9,12 @@ import (
 	"time"
 	"unicode/utf8"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/tools"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/events"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/tools"
 )
 
 // Emitter publishes best-effort observability events. The result envelope is

--- a/runtimes/reference/internal/engine/engine_test.go
+++ b/runtimes/reference/internal/engine/engine_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/engine"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/engine"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/events"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 func TestRunnerCompletesFakeConversation(t *testing.T) {

--- a/runtimes/reference/internal/engine/envelope.go
+++ b/runtimes/reference/internal/engine/envelope.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 type Metadata struct {

--- a/runtimes/reference/internal/engine/envelope_test.go
+++ b/runtimes/reference/internal/engine/envelope_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/engine"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/engine"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 func TestSuccessPreservesStructuredUsageAndOpaqueModel(t *testing.T) {

--- a/runtimes/reference/internal/engine/loop.go
+++ b/runtimes/reference/internal/engine/loop.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/conversation"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/conversation"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/events"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 type loopState struct {

--- a/runtimes/reference/internal/events/emitter.go
+++ b/runtimes/reference/internal/events/emitter.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	eventv1alpha1 "github.com/kontext-dev/kontext/pkg/event/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
 )
 
 const APIVersion = eventv1alpha1.APIVersion

--- a/runtimes/reference/internal/events/emitter_test.go
+++ b/runtimes/reference/internal/events/emitter_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/events"
 )
 
 func TestEmitterWritesOneVersionedJSONEventPerLine(t *testing.T) {

--- a/runtimes/reference/internal/mcpclient/client.go
+++ b/runtimes/reference/internal/mcpclient/client.go
@@ -21,8 +21,8 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const (

--- a/runtimes/reference/internal/mcpclient/client_test.go
+++ b/runtimes/reference/internal/mcpclient/client_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 )
 
 func TestHTTPDiscoveryExecutionAuthBoundingAndClose(t *testing.T) {

--- a/runtimes/reference/internal/mcpclient/command.go
+++ b/runtimes/reference/internal/mcpclient/command.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 )
 
 var errMCPStdioFrameLimit = errors.New("mcp_stdio_frame_limit_exceeded")

--- a/runtimes/reference/internal/mcpclient/podbuilder_integration_test.go
+++ b/runtimes/reference/internal/mcpclient/podbuilder_integration_test.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	kontextv1alpha1 "github.com/kontext-dev/kontext/api/v1alpha1"
-	"github.com/kontext-dev/kontext/internal/podbuilder"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/mcpclient"
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/mcpclient"
 )
 
 func TestSecretBackedPodEnvAuthenticatesHTTPMCPWithoutLeaking(t *testing.T) {

--- a/runtimes/reference/internal/mcpclient/stdio_unix_test.go
+++ b/runtimes/reference/internal/mcpclient/stdio_unix_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 )
 
 func TestStdioDiscoveryCallAndProcessGroupCleanup(t *testing.T) {

--- a/runtimes/reference/internal/provider/anthropic.go
+++ b/runtimes/reference/internal/provider/anthropic.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const (

--- a/runtimes/reference/internal/provider/anthropic_test.go
+++ b/runtimes/reference/internal/provider/anthropic_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 func TestAnthropicCompletesAndNormalizesResponse(t *testing.T) {

--- a/runtimes/reference/internal/provider/http.go
+++ b/runtimes/reference/internal/provider/http.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"unicode"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const maxProviderResponseBytes = 4 << 20

--- a/runtimes/reference/internal/provider/openai.go
+++ b/runtimes/reference/internal/provider/openai.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const (

--- a/runtimes/reference/internal/provider/openai_test.go
+++ b/runtimes/reference/internal/provider/openai_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 func TestOpenAICompletesAgainstCompatibleBaseURL(t *testing.T) {

--- a/runtimes/reference/internal/provider/provider.go
+++ b/runtimes/reference/internal/provider/provider.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const (

--- a/runtimes/reference/internal/provider/provider_test.go
+++ b/runtimes/reference/internal/provider/provider_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/provider"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/provider"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 func TestResolveSelectsFakeProvider(t *testing.T) {

--- a/runtimes/reference/internal/runtimeapi/types_test.go
+++ b/runtimes/reference/internal/runtimeapi/types_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 func TestValidateResponse(t *testing.T) {

--- a/runtimes/reference/internal/tools/knowledge.go
+++ b/runtimes/reference/internal/tools/knowledge.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const defaultKnowledgeRoot = "/kontext/knowledge"

--- a/runtimes/reference/internal/tools/knowledge_test.go
+++ b/runtimes/reference/internal/tools/knowledge_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/tools"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/tools"
 )
 
 func TestReadKnowledgeReadsAndBoundsMountedFile(t *testing.T) {

--- a/runtimes/reference/internal/tools/kubernetes.go
+++ b/runtimes/reference/internal/tools/kubernetes.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"sync"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const (

--- a/runtimes/reference/internal/tools/kubernetes_test.go
+++ b/runtimes/reference/internal/tools/kubernetes_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/tools"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/tools"
 )
 
 func TestKubernetesReadUsesCurrentNamespaceAndServiceAccount(t *testing.T) {

--- a/runtimes/reference/internal/tools/shell.go
+++ b/runtimes/reference/internal/tools/shell.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const shellTerminationGrace = 2 * time.Second

--- a/runtimes/reference/internal/tools/shell_test.go
+++ b/runtimes/reference/internal/tools/shell_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/tools"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/tools"
 )
 
 func TestShellUsesExplicitDirectoryAndFilteredEnvironment(t *testing.T) {

--- a/runtimes/reference/internal/tools/tools.go
+++ b/runtimes/reference/internal/tools/tools.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/mcpclient"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/mcpclient"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const (

--- a/runtimes/reference/internal/tools/tools_test.go
+++ b/runtimes/reference/internal/tools/tools_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	runtimeapi "github.com/kontext-dev/kontext/runtimes/reference/internal/runtimeapi"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/tools"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/tools"
 )
 
 func TestRegistryExposesOnlyAllowedTools(t *testing.T) {

--- a/runtimes/reference/main.go
+++ b/runtimes/reference/main.go
@@ -10,11 +10,11 @@ import (
 	"syscall"
 	"time"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/config"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/engine"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/events"
-	"github.com/kontext-dev/kontext/runtimes/reference/internal/tools"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/engine"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/events"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/tools"
 )
 
 func main() {

--- a/runtimes/reference/main_test.go
+++ b/runtimes/reference/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 func TestRunEmitsJSONLAndVersionedResult(t *testing.T) {

--- a/runtimes/reporter/capture.go
+++ b/runtimes/reporter/capture.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 type CapturedResult struct {

--- a/runtimes/reporter/config.go
+++ b/runtimes/reporter/config.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 const (

--- a/runtimes/reporter/reporter.go
+++ b/runtimes/reporter/reporter.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 const (

--- a/runtimes/reporter/reporter_test.go
+++ b/runtimes/reporter/reporter_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	resultv1alpha1 "github.com/kontext-dev/kontext/pkg/result/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 func TestEnvelopeFromLastLine(t *testing.T) {

--- a/scripts/apply-example.sh
+++ b/scripts/apply-example.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/common.sh
+source "${ROOT_DIR}/scripts/lib/common.sh"
 EXAMPLES_DIR="${ROOT_DIR}/deploy/examples/v1alpha1"
 EXAMPLE_ARG="${1:-}"
 if [[ -n "${EXAMPLE_ARG}" && "${EXAMPLE_ARG}" != */* ]]; then
@@ -91,17 +93,17 @@ if [[ -n "${KONTEXT_RELEASE_TAG:-}" ]]; then
   fi
 
   append_image \
-    "ghcr.io/mfs-code/kontext-echo" \
-    "ghcr.io/mfs-code/kontext-echo:${KONTEXT_RELEASE_TAG}"
+    "$(kontext_image kontext-echo)" \
+    "$(kontext_image kontext-echo):${KONTEXT_RELEASE_TAG}"
   append_image \
-    "ghcr.io/mfs-code/kontext-reference" \
-    "ghcr.io/mfs-code/kontext-reference:${KONTEXT_RELEASE_TAG}"
+    "$(kontext_image kontext-reference)" \
+    "$(kontext_image kontext-reference):${KONTEXT_RELEASE_TAG}"
 else
   append_image \
-    "ghcr.io/mfs-code/kontext-echo" \
+    "$(kontext_image kontext-echo)" \
     "${KONTEXT_ECHO_IMAGE:-kontext-echo:dev}"
   append_image \
-    "ghcr.io/mfs-code/kontext-reference" \
+    "$(kontext_image kontext-reference)" \
     "${KONTEXT_REFERENCE_IMAGE:-kontext-reference:dev}"
   append_image \
     "busybox" \

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Shared, release-relevant Kontext repository and registry identity.
 
+if [[ "${_KONTEXT_COMMON_LOADED:-}" == "true" ]]; then
+  return 0
+fi
+readonly _KONTEXT_COMMON_LOADED="true"
+
 readonly KONTEXT_GITHUB_OWNER="MFS-code"
 readonly KONTEXT_REPOSITORY_NAME="Kontext"
 readonly KONTEXT_GITHUB_REPOSITORY="${KONTEXT_GITHUB_OWNER}/${KONTEXT_REPOSITORY_NAME}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Shared, release-relevant Kontext repository and registry identity.
+
+readonly KONTEXT_GITHUB_OWNER="MFS-code"
+readonly KONTEXT_REPOSITORY_NAME="Kontext"
+readonly KONTEXT_GITHUB_REPOSITORY="${KONTEXT_GITHUB_OWNER}/${KONTEXT_REPOSITORY_NAME}"
+readonly KONTEXT_REGISTRY="ghcr.io"
+readonly KONTEXT_REGISTRY_OWNER="mfs-code"
+readonly KONTEXT_IMAGE_REPOSITORY="${KONTEXT_REGISTRY}/${KONTEXT_REGISTRY_OWNER}"
+
+kontext_image() {
+  local package="${1:?image package is required}"
+  printf '%s/%s' "${KONTEXT_IMAGE_REPOSITORY}" "${package}"
+}

--- a/scripts/render-release-manifest.sh
+++ b/scripts/render-release-manifest.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/common.sh
+source "${ROOT_DIR}/scripts/lib/common.sh"
 METADATA_FILE="${1:-}"
 
 need() {
@@ -53,16 +55,25 @@ image_ref() {
     "${METADATA_FILE}"
 }
 
+validate_image_ref() {
+  local name="$1"
+  local package="$2"
+  local reference="$3"
+  local expected_prefix
+  local digest
+
+  expected_prefix="$(kontext_image "${package}")@sha256:"
+  digest="${reference#"${expected_prefix}"}"
+  if [[ "${reference}" != "${expected_prefix}"* || ! "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "invalid ${name} image reference: ${reference}" >&2
+    exit 1
+  fi
+}
+
 operator_image="$(image_ref operator)"
 reporter_image="$(image_ref reporter)"
-if [[ ! "${operator_image}" =~ ^ghcr\.io/mfs-code/kontext-operator@sha256:[0-9a-f]{64}$ ]]; then
-  echo "invalid operator image reference: ${operator_image}" >&2
-  exit 1
-fi
-if [[ ! "${reporter_image}" =~ ^ghcr\.io/mfs-code/kontext-reporter@sha256:[0-9a-f]{64}$ ]]; then
-  echo "invalid reporter image reference: ${reporter_image}" >&2
-  exit 1
-fi
+validate_image_ref operator kontext-operator "${operator_image}"
+validate_image_ref reporter kontext-reporter "${reporter_image}"
 
 overlay_dir="$(mktemp -d "${ROOT_DIR}/config/overlays/.release.XXXXXX")"
 cleanup() {

--- a/scripts/test-release-identity.sh
+++ b/scripts/test-release-identity.sh
@@ -11,17 +11,41 @@ fail() {
   exit 1
 }
 
+assert_workflow_registry_owner() {
+  local file="$1"
+  local expected='echo "registry_owner=${KONTEXT_REGISTRY_OWNER}" >>"${GITHUB_OUTPUT}"'
+  local assignments=0
+  local line
+  local trimmed
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    trimmed="${line#"${line%%[![:space:]]*}"}"
+    case "${trimmed}" in
+      'echo "registry_owner='*)
+        assignments=$((assignments + 1))
+        [[ "${trimmed}" == "${expected}" ]] ||
+          fail "${file} has an unexpected registry_owner output assignment"
+        ;;
+    esac
+  done <"${file}"
+  [[ "${assignments}" -eq 1 ]] ||
+    fail "${file} must assign registry_owner exactly once"
+}
+
+# Re-sourcing must preserve the original readonly identity without aborting.
+source "${ROOT_DIR}/scripts/lib/common.sh"
 [[ "${KONTEXT_GITHUB_REPOSITORY}" == "MFS-code/Kontext" ]] ||
   fail "unexpected GitHub repository ${KONTEXT_GITHUB_REPOSITORY}"
 [[ "${KONTEXT_IMAGE_REPOSITORY}" == "ghcr.io/mfs-code" ]] ||
   fail "unexpected image repository ${KONTEXT_IMAGE_REPOSITORY}"
+if (KONTEXT_GITHUB_OWNER="other-owner") 2>/dev/null; then
+  fail "canonical identity is mutable after re-sourcing"
+fi
 
 workflow="${ROOT_DIR}/.github/workflows/release.yml"
 grep -Fq "source scripts/lib/common.sh" "${workflow}" ||
   fail "release workflow does not source common identity"
-if grep -Fq "GITHUB_REPOSITORY_OWNER" "${workflow}"; then
-  fail "release workflow still derives the registry owner"
-fi
+assert_workflow_registry_owner "${workflow}"
 
 for script in \
   "${ROOT_DIR}/scripts/render-release-manifest.sh" \
@@ -39,6 +63,13 @@ cleanup() {
   rm -rf "${tmp_dir}"
 }
 trap cleanup EXIT
+
+workflow_with_comment="${tmp_dir}/release-with-comment.yml"
+cp "${workflow}" "${workflow_with_comment}"
+printf '%s\n' \
+  "# GITHUB_REPOSITORY_OWNER is intentionally not used for release images." \
+  >>"${workflow_with_comment}"
+assert_workflow_registry_owner "${workflow_with_comment}"
 
 cat >"${tmp_dir}/kubectl" <<'EOF'
 #!/usr/bin/env bash
@@ -64,9 +95,20 @@ grep -Fq "$(kontext_image kontext-operator)@sha256:" "${tmp_dir}/install.yaml" |
 grep -Fq "$(kontext_image kontext-reporter)@sha256:" "${tmp_dir}/install.yaml" ||
   fail "rendered manifest lacks canonical reporter image"
 
-jq \
-  '(.images[] | select(.name == "operator").immutableReference) |= sub("ghcr.io/mfs-code"; "ghcr.io/other-owner")' \
+jq --arg wrong_repository "ghcr.io/other-owner" \
+  '(.images[] | select(.name == "operator").immutableReference) |=
+    (. as $reference | $wrong_repository + "/" + ($reference | split("/") | last))' \
   "${metadata}" >"${tmp_dir}/wrong-owner.json"
+operator_suffix="$(
+  jq -er '.images[] | select(.name == "operator").immutableReference | split("/") | last' \
+    "${metadata}"
+)"
+wrong_operator_reference="$(
+  jq -er '.images[] | select(.name == "operator").immutableReference' \
+    "${tmp_dir}/wrong-owner.json"
+)"
+[[ "${wrong_operator_reference}" == "ghcr.io/other-owner/${operator_suffix}" ]] ||
+  fail "wrong-owner fixture was not updated structurally"
 if PATH="${tmp_dir}:${PATH}" \
   "${ROOT_DIR}/scripts/render-release-manifest.sh" "${tmp_dir}/wrong-owner.json" \
   >"${tmp_dir}/wrong-owner.yaml" 2>/dev/null; then

--- a/scripts/test-release-identity.sh
+++ b/scripts/test-release-identity.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Check that release tooling consumes the canonical repository and registry identity.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/common.sh
+source "${ROOT_DIR}/scripts/lib/common.sh"
+
+fail() {
+  echo "release identity test failed: $*" >&2
+  exit 1
+}
+
+[[ "${KONTEXT_GITHUB_REPOSITORY}" == "MFS-code/Kontext" ]] ||
+  fail "unexpected GitHub repository ${KONTEXT_GITHUB_REPOSITORY}"
+[[ "${KONTEXT_IMAGE_REPOSITORY}" == "ghcr.io/mfs-code" ]] ||
+  fail "unexpected image repository ${KONTEXT_IMAGE_REPOSITORY}"
+
+workflow="${ROOT_DIR}/.github/workflows/release.yml"
+grep -Fq "source scripts/lib/common.sh" "${workflow}" ||
+  fail "release workflow does not source common identity"
+if grep -Fq "GITHUB_REPOSITORY_OWNER" "${workflow}"; then
+  fail "release workflow still derives the registry owner"
+fi
+
+for script in \
+  "${ROOT_DIR}/scripts/render-release-manifest.sh" \
+  "${ROOT_DIR}/scripts/apply-example.sh" \
+  "${ROOT_DIR}/scripts/verify-release-install.sh"; do
+  grep -Fq 'source "${ROOT_DIR}/scripts/lib/common.sh"' "${script}" ||
+    fail "${script#${ROOT_DIR}/} does not source common identity"
+  if grep -Fq "ghcr.io/mfs-code" "${script}"; then
+    fail "${script#${ROOT_DIR}/} duplicates the registry owner"
+  fi
+done
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/kontext-release-identity.XXXXXX")"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+cat >"${tmp_dir}/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "kustomize" ]] || exit 2
+directory="${2:?kustomize directory is required}"
+file="${directory}/manager_patch.yaml"
+if [[ ! -f "${file}" ]]; then
+  file="${directory}/kustomization.yaml"
+fi
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  printf '%s\n' "${line}"
+done <"${file}"
+EOF
+chmod +x "${tmp_dir}/kubectl"
+
+metadata="${ROOT_DIR}/scripts/testdata/release-image-digests.json"
+PATH="${tmp_dir}:${PATH}" \
+  "${ROOT_DIR}/scripts/render-release-manifest.sh" "${metadata}" \
+  >"${tmp_dir}/install.yaml"
+grep -Fq "$(kontext_image kontext-operator)@sha256:" "${tmp_dir}/install.yaml" ||
+  fail "rendered manifest lacks canonical operator image"
+grep -Fq "$(kontext_image kontext-reporter)@sha256:" "${tmp_dir}/install.yaml" ||
+  fail "rendered manifest lacks canonical reporter image"
+
+jq \
+  '(.images[] | select(.name == "operator").immutableReference) |= sub("ghcr.io/mfs-code"; "ghcr.io/other-owner")' \
+  "${metadata}" >"${tmp_dir}/wrong-owner.json"
+if PATH="${tmp_dir}:${PATH}" \
+  "${ROOT_DIR}/scripts/render-release-manifest.sh" "${tmp_dir}/wrong-owner.json" \
+  >"${tmp_dir}/wrong-owner.yaml" 2>/dev/null; then
+  fail "renderer accepted an image from another registry owner"
+fi
+
+PATH="${tmp_dir}:${PATH}" \
+  KONTEXT_RELEASE_TAG=v0.0.0-test.1 \
+  KONTEXT_RENDER_ONLY=true \
+  "${ROOT_DIR}/scripts/apply-example.sh" echo-task-run.yaml \
+  >"${tmp_dir}/example.yaml"
+grep -Fq "name: $(kontext_image kontext-echo)" "${tmp_dir}/example.yaml" ||
+  fail "example renderer lacks canonical source image"
+grep -Fq "newName: $(kontext_image kontext-echo)" "${tmp_dir}/example.yaml" ||
+  fail "example renderer lacks canonical release image"
+
+echo "release identity test passed"

--- a/scripts/verify-release-install.sh
+++ b/scripts/verify-release-install.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/common.sh
+source "${ROOT_DIR}/scripts/lib/common.sh"
 CURRENT_MANIFEST="${1:-}"
 CURRENT_VERSION="${2:-}"
 PREVIOUS_MANIFEST="${3:-}"
@@ -77,7 +79,7 @@ smoke_release_runtime() {
   runtime_image="$(
     kubectl get agentrun echo-review -o jsonpath='{.spec.runtime.image}'
   )"
-  if [[ "${runtime_image}" != "ghcr.io/mfs-code/kontext-echo:${version}" ]]; then
+  if [[ "${runtime_image}" != "$(kontext_image kontext-echo):${version}" ]]; then
     echo "unexpected echo runtime image: ${runtime_image}" >&2
     return 1
   fi
@@ -109,7 +111,7 @@ spec:
   goal: Verify custom-resource retention during control-plane removal.
   model: echo-model
   runtime:
-    image: ghcr.io/mfs-code/kontext-echo:${CURRENT_VERSION}
+    image: $(kontext_image kontext-echo):${CURRENT_VERSION}
 EOF
 
 kubectl delete clusterrolebinding manager-rolebinding --ignore-not-found=true


### PR DESCRIPTION
## Summary
- switch the Go module, Kubebuilder metadata, and internal imports to `github.com/MFS-code/Kontext`
- centralize the canonical GitHub and GHCR identities in `scripts/lib/common.sh` for the release workflow and render/apply/verify scripts
- add regression coverage for release identity propagation and wrong-owner digest rejection

## Test plan and results
- [x] `go mod tidy`
- [x] `make verify`
- [x] `make test`
- [x] `make release-manifest IMAGE_DIGESTS=scripts/testdata/release-image-digests.json`
- [x] `kubectl create --dry-run=client -f dist/install.yaml -o name`
- [x] `bash -n scripts/lib/common.sh scripts/apply-example.sh scripts/render-release-manifest.sh scripts/verify-release-install.sh scripts/test-release-identity.sh`
- [ ] `shellcheck` and `actionlint` were unavailable locally; focused shell syntax and release identity tests passed

Closes #57