### PR TITLE
Streamline Go control-plane helpers

### DIFF
--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -20,7 +21,6 @@ import (
 	"github.com/MFS-code/Kontext/internal/podbuilder"
 	"github.com/MFS-code/Kontext/internal/runtimepolicy"
 	"github.com/MFS-code/Kontext/internal/status"
-	"github.com/MFS-code/Kontext/internal/util"
 )
 
 const (
@@ -50,9 +50,9 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	case kontextv1alpha1.AgentModeService:
 		return r.reconcileService(ctx, &agent)
 	case kontextv1alpha1.AgentModeTask, kontextv1alpha1.AgentModeScheduled:
-		return r.setAgentStatus(ctx, &agent, agent.Status, false, conditions.UnsupportedMode(string(agent.Spec.Mode))...)
+		return ctrl.Result{}, r.setAgentStatus(ctx, &agent, agent.Status, conditions.UnsupportedMode(string(agent.Spec.Mode))...)
 	default:
-		return r.setAgentStatus(ctx, &agent, agent.Status, false, conditions.InvalidMode(string(agent.Spec.Mode))...)
+		return ctrl.Result{}, r.setAgentStatus(ctx, &agent, agent.Status, conditions.InvalidMode(string(agent.Spec.Mode))...)
 	}
 }
 
@@ -65,7 +65,7 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 	}
 
 	if agent.Spec.Goal == "" {
-		return r.setAgentStatus(ctx, agent, runs.status(agent.Generation), false, metav1.Condition{
+		return ctrl.Result{}, r.setAgentStatus(ctx, agent, runs.status(agent.Generation), metav1.Condition{
 			Type:    conditions.Ready,
 			Status:  metav1.ConditionFalse,
 			Reason:  "MissingGoal",
@@ -74,7 +74,7 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 	}
 
 	if runs.current != nil && !status.IsTerminalPhase(runs.current.Status.Phase) {
-		return r.setAgentStatus(ctx, agent, runs.status(agent.Generation), false, metav1.Condition{
+		return ctrl.Result{}, r.setAgentStatus(ctx, agent, runs.status(agent.Generation), metav1.Condition{
 			Type:    conditions.Ready,
 			Status:  metav1.ConditionTrue,
 			Reason:  "RunActive",
@@ -92,7 +92,7 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 		delay := r.backoffDelay(*agent, runs.maxSuffix-1)
 		if since := time.Since(runs.current.Status.CompletionTime.Time); since < delay {
 			logger.Info("waiting before service recast", "delay", delay-since, "run", runs.current.Name)
-			if _, err := r.setAgentStatus(ctx, agent, runs.status(agent.Generation), false); err != nil {
+			if err := r.setAgentStatus(ctx, agent, runs.status(agent.Generation)); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{RequeueAfter: delay - since}, nil
@@ -126,7 +126,7 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 		nextStatus.LastRunName = runs.current.Name
 	}
 
-	return r.setAgentStatus(ctx, agent, nextStatus, true, metav1.Condition{
+	if err := r.setAgentStatus(ctx, agent, nextStatus, metav1.Condition{
 		Type:    conditions.Ready,
 		Status:  metav1.ConditionFalse,
 		Reason:  "Recasting",
@@ -136,7 +136,10 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 		Status:  metav1.ConditionTrue,
 		Reason:  "Recasting",
 		Message: "Service run is being created.",
-	})
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 }
 
 func (r *AgentReconciler) handleServiceRunAlreadyExists(
@@ -263,7 +266,7 @@ func (r *AgentReconciler) buildServiceRun(agent *kontextv1alpha1.Agent, runName 
 			Goal:     agent.Spec.Goal,
 			Provider: provider,
 			Model:    agent.Spec.Model,
-			Tools:    util.CloneSlice(agent.Spec.Tools),
+			Tools:    slices.Clone(agent.Spec.Tools),
 			Budget:   agent.Spec.Budget,
 			Runtime:  *agent.Spec.Runtime.DeepCopy(),
 			Env:      agentSpec.Env,
@@ -318,20 +321,16 @@ func (r *AgentReconciler) setAgentStatus(
 	ctx context.Context,
 	agent *kontextv1alpha1.Agent,
 	next kontextv1alpha1.AgentStatus,
-	requeue bool,
 	updates ...metav1.Condition,
-) (ctrl.Result, error) {
+) error {
 	next.Conditions = agent.Status.Conditions
 	setStatusConditions(&next.Conditions, agent.Generation, updates...)
 	if err := patchStatus(ctx, r.Client, agent, func() {
 		agent.Status = next
 	}); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
-	if requeue {
-		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
-	}
-	return ctrl.Result{}, nil
+	return nil
 }
 
 // SetupWithManager sets up the Manager.

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -7,7 +7,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -84,7 +83,7 @@ func (r *AgentRunReconciler) reconcileMissingPod(ctx context.Context, run *konte
 	}
 
 	if run.Status.PodName != "" {
-		return r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
+		return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
 			next.Phase = kontextv1alpha1.AgentRunPhaseFailed
 			next.PodName = podName
 			next.Message = "Pod lost before run completed."
@@ -101,7 +100,7 @@ func (r *AgentRunReconciler) reconcileMissingPod(ctx context.Context, run *konte
 		ReporterImage: r.ReporterImage,
 	})
 	if err != nil {
-		return r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
+		return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
 			next.Phase = kontextv1alpha1.AgentRunPhaseFailed
 			next.Message = fmt.Sprintf("Agent run configuration is invalid: %v.", err)
 			next.CompletionTime = nowPtr()
@@ -119,7 +118,7 @@ func (r *AgentRunReconciler) reconcileMissingPod(ctx context.Context, run *konte
 		return ctrl.Result{}, err
 	}
 
-	return r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
+	return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
 		next.Phase = kontextv1alpha1.AgentRunPhasePending
 		next.PodName = podName
 		next.Message = "Agent run pod requested."
@@ -134,7 +133,7 @@ func (r *AgentRunReconciler) reconcileMissingPod(ctx context.Context, run *konte
 func (r *AgentRunReconciler) syncPodObservation(ctx context.Context, run *kontextv1alpha1.AgentRun, pod *corev1.Pod, podName string) (ctrl.Result, error) {
 	observation := status.ObservePod(pod)
 
-	_, err := r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
+	err := r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
 		next.Phase = observation.Phase
 		next.PodName = podName
 		next.Message = observation.Message
@@ -146,7 +145,7 @@ func (r *AgentRunReconciler) syncPodObservation(ctx context.Context, run *kontex
 			next.Usage = observation.Usage
 		}
 		if next.StartTime == nil && observation.Phase == kontextv1alpha1.AgentRunPhaseRunning {
-			next.StartTime = runtimeContainerStartedAt(pod)
+			next.StartTime = observation.StartedAt
 			if next.StartTime == nil {
 				next.StartTime = nowPtr()
 			}
@@ -198,7 +197,7 @@ func (r *AgentRunReconciler) failInvalidWallclock(
 		}
 	}
 
-	return r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
+	return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
 		next.Phase = kontextv1alpha1.AgentRunPhaseFailed
 		if podExists {
 			next.PodName = pod.Name
@@ -236,7 +235,7 @@ func (r *AgentRunReconciler) enforceWallclock(
 		return ctrl.Result{}, false, nil
 	}
 
-	startedAt := runtimeContainerStartedAt(pod)
+	startedAt := status.ObservePod(pod).StartedAt
 	if startedAt == nil {
 		startedAt = run.Status.StartTime
 	}
@@ -250,7 +249,7 @@ func (r *AgentRunReconciler) enforceWallclock(
 		return ctrl.Result{RequeueAfter: remaining + time.Second}, false, nil
 	}
 
-	_, err := r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
+	err := r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
 		next.Phase = kontextv1alpha1.AgentRunPhaseBudgetExceeded
 		next.PodName = pod.Name
 		next.Message = fmt.Sprintf("Wallclock budget exceeded after %s.", *limit)
@@ -272,25 +271,13 @@ func (r *AgentRunReconciler) enforceWallclock(
 	return ctrl.Result{}, true, nil
 }
 
-func runtimeContainerStartedAt(pod *corev1.Pod) *metav1.Time {
-	for index := range pod.Status.ContainerStatuses {
-		containerStatus := &pod.Status.ContainerStatuses[index]
-		if containerStatus.Name == podbuilder.RuntimeContainerName &&
-			containerStatus.State.Running != nil {
-			startedAt := containerStatus.State.Running.StartedAt
-			return &startedAt
-		}
-	}
-	return nil
-}
-
-func (r *AgentRunReconciler) patchRunStatus(ctx context.Context, run *kontextv1alpha1.AgentRun, mutate func(*kontextv1alpha1.AgentRunStatus)) (ctrl.Result, error) {
+func (r *AgentRunReconciler) patchRunStatus(ctx context.Context, run *kontextv1alpha1.AgentRun, mutate func(*kontextv1alpha1.AgentRunStatus)) error {
 	if err := patchStatus(ctx, r.Client, run, func() {
 		mutate(&run.Status)
 	}); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
-	return ctrl.Result{}, nil
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -16,6 +16,7 @@ import (
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/internal/testsupport"
 )
 
 func TestAgentRunReconcilerCreatesPod(t *testing.T) {
@@ -327,7 +328,7 @@ func TestAgentRunReconcilerDeletesLegacyPodWithInvalidWallclock(t *testing.T) {
 		t.Fatalf("create run: %v", err)
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -391,7 +392,7 @@ func TestAgentRunReconcilerObservesSucceededPod(t *testing.T) {
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -463,7 +464,7 @@ func TestAgentRunReconcilerObservesRunningPodWithinWallclockBudget(t *testing.T)
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -528,7 +529,7 @@ func TestAgentRunReconcilerEnforcesWallclockBudget(t *testing.T) {
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -590,7 +591,7 @@ func TestAgentRunReconcilerKeepsWallclockBudgetExceededAuthoritative(t *testing.
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -701,7 +702,7 @@ func TestAgentRunReconcilerPreservesRuntimeCancellationBeforeWallclockEnforcemen
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}

--- a/internal/podbuilder/podbuilder.go
+++ b/internal/podbuilder/podbuilder.go
@@ -3,6 +3,7 @@ package podbuilder
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,7 +12,6 @@ import (
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 	"github.com/MFS-code/Kontext/internal/runtimepolicy"
-	"github.com/MFS-code/Kontext/internal/util"
 )
 
 const (
@@ -31,20 +31,6 @@ var invalidNameChars = regexp.MustCompile(`[^a-z0-9-]+`)
 
 type Config struct {
 	ReporterImage string
-}
-
-// BuildPod constructs a Pod without optional operator-managed integrations.
-// Tests and native-runtime callers may use this helper; result capture requires
-// BuildPodWithConfig so the trusted reporter image is explicit.
-func BuildPod(run *kontextv1alpha1.AgentRun) *corev1.Pod {
-	if run.Spec.Runtime.Result != nil {
-		panic("BuildPod: runtime.result requires BuildPodWithConfig")
-	}
-	pod, err := BuildPodWithConfig(run, Config{})
-	if err != nil {
-		panic(fmt.Sprintf("BuildPod: %v", err))
-	}
-	return pod
 }
 
 // BuildPodWithConfig constructs a Pod with operator-managed runtime integrations.
@@ -84,10 +70,10 @@ func BuildPodWithConfig(run *kontextv1alpha1.AgentRun, config Config) (*corev1.P
 		},
 	}
 	if len(run.Spec.Runtime.Command) > 0 {
-		container.Command = util.CloneSlice(run.Spec.Runtime.Command)
+		container.Command = slices.Clone(run.Spec.Runtime.Command)
 	}
 	if len(run.Spec.Runtime.Args) > 0 {
-		container.Args = util.CloneSlice(run.Spec.Runtime.Args)
+		container.Args = slices.Clone(run.Spec.Runtime.Args)
 	}
 
 	var initContainers []corev1.Container
@@ -182,7 +168,7 @@ func injectReporter(
 	if err != nil {
 		return container, nil, volumes, err
 	}
-	childCommand := append(util.CloneSlice(run.Spec.Runtime.Command), run.Spec.Runtime.Args...)
+	childCommand := append(slices.Clone(run.Spec.Runtime.Command), run.Spec.Runtime.Args...)
 	container.Command = append(
 		[]string{ReporterBinaryPath, "--format", format, "--"},
 		childCommand...,
@@ -251,9 +237,9 @@ func buildEnv(run *kontextv1alpha1.AgentRun) ([]corev1.EnvVar, error) {
 		{Name: "KONTEXT_PROVIDER", Value: provider},
 		{Name: "KONTEXT_MODEL", Value: run.Spec.Model},
 		{Name: "KONTEXT_TOOLS", Value: tools},
-		{Name: "KONTEXT_BUDGET_TOKENS", Value: budgetField(budget, "tokens")},
-		{Name: "KONTEXT_BUDGET_WALLCLOCK", Value: budgetField(budget, "wallclock")},
-		{Name: "KONTEXT_BUDGET_DOLLARS", Value: budgetField(budget, "dollars")},
+		{Name: "KONTEXT_BUDGET_TOKENS", Value: budgetTokens(budget)},
+		{Name: "KONTEXT_BUDGET_WALLCLOCK", Value: budgetWallclock(budget)},
+		{Name: "KONTEXT_BUDGET_DOLLARS", Value: budgetDollars(budget)},
 	}
 	reserved := make(map[string]struct{}, len(env))
 	for _, item := range env {
@@ -337,25 +323,25 @@ func agentName(run *kontextv1alpha1.AgentRun) string {
 	return run.Name
 }
 
-func budgetField(budget *kontextv1alpha1.BudgetSpec, field string) string {
+func budgetTokens(budget *kontextv1alpha1.BudgetSpec) string {
+	if budget == nil || budget.Tokens == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", *budget.Tokens)
+}
+
+func budgetWallclock(budget *kontextv1alpha1.BudgetSpec) string {
 	if budget == nil {
 		return ""
 	}
-	switch field {
-	case "tokens":
-		if budget.Tokens != nil {
-			return fmt.Sprintf("%d", *budget.Tokens)
-		}
-	case "wallclock":
-		return budget.Wallclock
-	case "dollars":
-		if budget.Dollars != nil {
-			return fmt.Sprintf("%g", *budget.Dollars)
-		}
-	default:
+	return budget.Wallclock
+}
+
+func budgetDollars(budget *kontextv1alpha1.BudgetSpec) string {
+	if budget == nil || budget.Dollars == nil {
 		return ""
 	}
-	return ""
+	return fmt.Sprintf("%g", *budget.Dollars)
 }
 
 // PodNameForRun returns a deterministic Pod name for an AgentRun.

--- a/internal/podbuilder/podbuilder_test.go
+++ b/internal/podbuilder/podbuilder_test.go
@@ -9,6 +9,7 @@ import (
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/internal/testsupport"
 )
 
 func TestBuildPodInjectsKontextEnv(t *testing.T) {
@@ -22,12 +23,12 @@ func TestBuildPodInjectsKontextEnv(t *testing.T) {
 				Image: "kontext-echo:dev",
 			},
 			Env: []kontextv1alpha1.EnvVar{
-				{Name: "KONTEXT_ZONE_ID", Value: envValue("agent:leaf:0001")},
+				{Name: "KONTEXT_CONTEXT_ID", Value: envValue("context:review:0001")},
 			},
 		},
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if pod.Name != "run-review-task" {
 		t.Fatalf("unexpected pod name: %s", pod.Name)
 	}
@@ -36,7 +37,7 @@ func TestBuildPodInjectsKontextEnv(t *testing.T) {
 	}
 
 	env := envMap(pod)
-	for _, key := range []string{"KONTEXT_RUN_NAME", "KONTEXT_GOAL", "KONTEXT_MODEL", "KONTEXT_ZONE_ID"} {
+	for _, key := range []string{"KONTEXT_RUN_NAME", "KONTEXT_GOAL", "KONTEXT_MODEL", "KONTEXT_CONTEXT_ID"} {
 		if env[key] == "" {
 			t.Fatalf("expected env %s to be set", key)
 		}
@@ -87,7 +88,7 @@ func TestBuildPodInjectsGenericSecretBackedEnv(t *testing.T) {
 			}},
 		},
 	}
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	var found *corev1.EnvVar
 	for index := range pod.Spec.Containers[0].Env {
 		if pod.Spec.Containers[0].Env[index].Name == "MCP_AUTH_TOKEN" {
@@ -138,7 +139,7 @@ func TestBuildPodMountsKnowledgeConfigMap(t *testing.T) {
 		},
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if len(pod.Spec.Volumes) != 1 {
 		t.Fatalf("expected one knowledge volume, got %d", len(pod.Spec.Volumes))
 	}
@@ -158,7 +159,7 @@ func TestBuildPodLeavesRuntimePermissionsUntouched(t *testing.T) {
 		},
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if pod.Spec.SecurityContext != nil {
 		t.Fatalf("expected no pod security context, got %+v", pod.Spec.SecurityContext)
 	}
@@ -200,7 +201,7 @@ func TestBuildPodAppliesExplicitRuntimeSecurityContext(t *testing.T) {
 			},
 		},
 	}
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	securityContext := pod.Spec.Containers[0].SecurityContext
 	if securityContext == nil ||
 		securityContext.RunAsNonRoot == nil ||
@@ -226,7 +227,7 @@ func TestBuildPodSetsRequestedServiceAccount(t *testing.T) {
 		},
 	}
 
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if pod.Spec.ServiceAccountName != "agent-sa" {
 		t.Fatalf("expected service account agent-sa, got %s", pod.Spec.ServiceAccountName)
 	}
@@ -266,7 +267,7 @@ func TestBuildPodInjectsProviderCredentials(t *testing.T) {
 					Runtime:  kontextv1alpha1.RuntimeSpec{Image: "runtime:dev"},
 				},
 			}
-			pod := podbuilder.BuildPod(run)
+			pod := testsupport.BuildPod(run)
 			var found *corev1.EnvVar
 			for i := range pod.Spec.Containers[0].Env {
 				if pod.Spec.Containers[0].Env[i].Name == tc.envName {
@@ -300,7 +301,7 @@ func TestBuildPodInjectsAllBedrockCredentials(t *testing.T) {
 			Runtime:  kontextv1alpha1.RuntimeSpec{Image: "runtime:dev"},
 		},
 	}
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 
 	expected := map[string]string{
 		"AWS_ACCESS_KEY_ID":     "AWS_ACCESS_KEY_ID",
@@ -357,7 +358,7 @@ func TestBuildPodPopulatesBudgetEnv(t *testing.T) {
 			},
 		},
 	}
-	env := envMap(podbuilder.BuildPod(run))
+	env := envMap(testsupport.BuildPod(run))
 	if env["KONTEXT_BUDGET_TOKENS"] != "1000" {
 		t.Fatalf("unexpected tokens budget: %q", env["KONTEXT_BUDGET_TOKENS"])
 	}
@@ -379,7 +380,7 @@ func TestBuildPodEmptyBudgetEnvWhenUnset(t *testing.T) {
 			Runtime:  kontextv1alpha1.RuntimeSpec{Image: "runtime:dev"},
 		},
 	}
-	env := envMap(podbuilder.BuildPod(run))
+	env := envMap(testsupport.BuildPod(run))
 	for _, key := range []string{"KONTEXT_BUDGET_TOKENS", "KONTEXT_BUDGET_WALLCLOCK", "KONTEXT_BUDGET_DOLLARS"} {
 		if env[key] != "" {
 			t.Fatalf("expected %s to be empty, got %q", key, env[key])
@@ -397,7 +398,7 @@ func TestBuildPodDefaultsAgentNameToRunName(t *testing.T) {
 			Runtime:  kontextv1alpha1.RuntimeSpec{Image: "runtime:dev"},
 		},
 	}
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if envMap(pod)["KONTEXT_AGENT_NAME"] != "standalone-run" {
 		t.Fatalf("expected agent name to default to run name")
 	}
@@ -417,7 +418,7 @@ func TestBuildPodUsesAgentRefName(t *testing.T) {
 			AgentRef: &kontextv1alpha1.AgentRef{Name: "echo-service"},
 		},
 	}
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if envMap(pod)["KONTEXT_AGENT_NAME"] != "echo-service" {
 		t.Fatalf("expected agent name from AgentRef")
 	}
@@ -441,7 +442,7 @@ func TestBuildPodAppliesRuntimeCommandArgsAndServiceAccount(t *testing.T) {
 			},
 		},
 	}
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	if pod.Spec.ServiceAccountName != "kontext-agent" {
 		t.Fatalf("expected service account, got %q", pod.Spec.ServiceAccountName)
 	}
@@ -554,7 +555,7 @@ func TestBuildPodRequiresConfiguredBuilderForResultCapture(t *testing.T) {
 			t.Fatalf("expected BuildPod to reject result capture without operator config")
 		}
 	}()
-	podbuilder.BuildPod(stdoutCaptureRun(kontextv1alpha1.ResultFormatLastLine))
+	testsupport.BuildPod(stdoutCaptureRun(kontextv1alpha1.ResultFormatLastLine))
 }
 
 func TestBuildPodRejectsInvalidReporterConfiguration(t *testing.T) {

--- a/internal/status/pod.go
+++ b/internal/status/pod.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
@@ -14,12 +15,12 @@ import (
 
 // PodObservation summarizes a Pod for AgentRun reconciliation.
 type PodObservation struct {
-	Phase    kontextv1alpha1.AgentRunPhase
-	Message  string
-	Result   string
-	Output   *kontextv1alpha1.OutputStatus
-	Usage    *kontextv1alpha1.UsageStatus
-	ExitCode *int32
+	Phase     kontextv1alpha1.AgentRunPhase
+	Message   string
+	Result    string
+	Output    *kontextv1alpha1.OutputStatus
+	Usage     *kontextv1alpha1.UsageStatus
+	StartedAt *metav1.Time
 }
 
 // ObservePod maps Pod status to AgentRun phase information.
@@ -34,9 +35,11 @@ func ObservePod(pod *corev1.Pod) PodObservation {
 	if containerStatus := runtimeContainerStatus(pod); containerStatus != nil {
 		state := containerStatus.State
 		if state.Running != nil {
+			startedAt := state.Running.StartedAt
 			return PodObservation{
-				Phase:   kontextv1alpha1.AgentRunPhaseRunning,
-				Message: "Agent run pod is streaming thoughts.",
+				Phase:     kontextv1alpha1.AgentRunPhaseRunning,
+				Message:   "Agent run pod is streaming thoughts.",
+				StartedAt: &startedAt,
 			}
 		}
 		if state.Terminated != nil {
@@ -96,7 +99,6 @@ func observationFromTermination(terminated *corev1.ContainerStateTerminated) Pod
 	output := outputStatus(parsed)
 	usage := usageStatus(parsed)
 	legacyResult := resultv1alpha1.ProjectLegacyResult(parsed.Output)
-	exitCode := terminated.ExitCode
 
 	if terminated.ExitCode == 0 {
 		if parseErr != nil {
@@ -104,9 +106,8 @@ func observationFromTermination(terminated *corev1.ContainerStateTerminated) Pod
 			// like JSON and failed to decode. Do not silently accept it as the
 			// result: mark the run failed so the malformed output is visible.
 			return PodObservation{
-				Phase:    kontextv1alpha1.AgentRunPhaseFailed,
-				Message:  fmt.Sprintf("Agent run exited 0 but the termination payload was malformed: %v", parseErr),
-				ExitCode: &exitCode,
+				Phase:   kontextv1alpha1.AgentRunPhaseFailed,
+				Message: fmt.Sprintf("Agent run exited 0 but the termination payload was malformed: %v", parseErr),
 			}
 		}
 		if parsed.Outcome == resultv1alpha1.OutcomeFailed {
@@ -115,21 +116,19 @@ func observationFromTermination(terminated *corev1.ContainerStateTerminated) Pod
 				message = fmt.Sprintf("%s %s", message, parsed.Error.Message)
 			}
 			return PodObservation{
-				Phase:    kontextv1alpha1.AgentRunPhaseFailed,
-				Message:  message,
-				Result:   legacyResult,
-				Output:   output,
-				Usage:    usage,
-				ExitCode: &exitCode,
+				Phase:   kontextv1alpha1.AgentRunPhaseFailed,
+				Message: message,
+				Result:  legacyResult,
+				Output:  output,
+				Usage:   usage,
 			}
 		}
 		return PodObservation{
-			Phase:    kontextv1alpha1.AgentRunPhaseSucceeded,
-			Message:  "Agent run completed successfully.",
-			Result:   legacyResult,
-			Output:   output,
-			Usage:    usage,
-			ExitCode: &exitCode,
+			Phase:   kontextv1alpha1.AgentRunPhaseSucceeded,
+			Message: "Agent run completed successfully.",
+			Result:  legacyResult,
+			Output:  output,
+			Usage:   usage,
 		}
 	}
 
@@ -143,12 +142,11 @@ func observationFromTermination(terminated *corev1.ContainerStateTerminated) Pod
 	}
 
 	return PodObservation{
-		Phase:    kontextv1alpha1.AgentRunPhaseFailed,
-		Message:  message,
-		Result:   legacyResult,
-		Output:   output,
-		Usage:    usage,
-		ExitCode: &exitCode,
+		Phase:   kontextv1alpha1.AgentRunPhaseFailed,
+		Message: message,
+		Result:  legacyResult,
+		Output:  output,
+		Usage:   usage,
 	}
 }
 

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -63,9 +63,6 @@ func TestObservePodMalformedTerminationOnSuccessFails(t *testing.T) {
 	if observation.Result != "" {
 		t.Fatalf("expected empty result for malformed payload, got %q", observation.Result)
 	}
-	if observation.ExitCode == nil || *observation.ExitCode != 0 {
-		t.Fatalf("expected exit code 0, got %#v", observation.ExitCode)
-	}
 	if !strings.Contains(observation.Message, "termination payload was malformed") {
 		t.Fatalf("expected malformed payload message, got %q", observation.Message)
 	}
@@ -101,12 +98,15 @@ func TestObservePodMalformedTerminationOnFailureNotesParseError(t *testing.T) {
 }
 
 func TestObservePodRunning(t *testing.T) {
+	startedAt := metav1.Now()
 	pod := &corev1.Pod{
 		Status: corev1.PodStatus{
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name:  podbuilder.RuntimeContainerName,
-					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+					Name: podbuilder.RuntimeContainerName,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{StartedAt: startedAt},
+					},
 				},
 			},
 		},
@@ -114,6 +114,9 @@ func TestObservePodRunning(t *testing.T) {
 	observation := status.ObservePod(pod)
 	if observation.Phase != kontextv1alpha1.AgentRunPhaseRunning {
 		t.Fatalf("expected Running, got %s", observation.Phase)
+	}
+	if observation.StartedAt == nil || !observation.StartedAt.Equal(&startedAt) {
+		t.Fatalf("expected runtime start %s, got %v", startedAt, observation.StartedAt)
 	}
 }
 
@@ -372,9 +375,6 @@ func TestObservePodTerminatedFailure(t *testing.T) {
 	observation := status.ObservePod(pod)
 	if observation.Phase != kontextv1alpha1.AgentRunPhaseFailed {
 		t.Fatalf("expected Failed, got %s", observation.Phase)
-	}
-	if observation.ExitCode == nil || *observation.ExitCode != 2 {
-		t.Fatalf("expected exit code 2, got %v", observation.ExitCode)
 	}
 	if observation.Result != "partial" {
 		t.Fatalf("expected result partial, got %q", observation.Result)

--- a/internal/testsupport/podbuilder.go
+++ b/internal/testsupport/podbuilder.go
@@ -1,0 +1,23 @@
+// Package testsupport provides helpers shared by Go tests.
+package testsupport
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+)
+
+// BuildPod constructs a Pod with the default test configuration.
+func BuildPod(run *kontextv1alpha1.AgentRun) *corev1.Pod {
+	if run.Spec.Runtime.Result != nil {
+		panic("BuildPod: runtime.result requires BuildPodWithConfig")
+	}
+	pod, err := podbuilder.BuildPodWithConfig(run, podbuilder.Config{})
+	if err != nil {
+		panic(fmt.Sprintf("BuildPod: %v", err))
+	}
+	return pod
+}

--- a/internal/util/slice.go
+++ b/internal/util/slice.go
@@ -1,6 +1,0 @@
-package util
-
-// CloneSlice returns a non-nil shallow copy to preserve API construction semantics.
-func CloneSlice[T any](in []T) []T {
-	return append([]T{}, in...)
-}

--- a/runtimes/reference/internal/mcpclient/podbuilder_integration_test.go
+++ b/runtimes/reference/internal/mcpclient/podbuilder_integration_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
-	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/internal/testsupport"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/mcpclient"
 )
@@ -46,7 +46,7 @@ func TestSecretBackedPodEnvAuthenticatesHTTPMCPWithoutLeaking(t *testing.T) {
 			}},
 		},
 	}
-	pod := podbuilder.BuildPod(run)
+	pod := testsupport.BuildPod(run)
 	var podEnvName string
 	for _, env := range pod.Spec.Containers[0].Env {
 		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil &&


### PR DESCRIPTION
## Summary
- replace `internal/util.CloneSlice` with `slices.Clone` and remove the utility package
- move runtime container start observation into `PodObservation.StartedAt` and remove dead `ExitCode` state
- replace string-selected budget formatting with typed helpers
- make status patch helpers return errors while reconciliation callers own `ctrl.Result`
- move the panicking Pod builder wrapper to test support so production only exposes the error-returning builder
- rename the zone-specific environment fixture to general Kontext vocabulary

Part of #64

## Tests
- `make verify`
- `make test`
- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.32.0 -p path)" go test ./internal/controller ./internal/status ./internal/podbuilder`