### PR TITLE
Consolidate bounded tool output contract

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -382,6 +382,17 @@ run by themselves. Only a successful terminal provider response without tool
 calls becomes final output. Cancellation, execution failures, or reaching a
 configured limit before final output fail the run.
 
+When tool content exceeds an effective positive byte limit, the runtime sets
+the tool result's `truncated` field to `true` and normally replaces `content`
+with `{"partial":"<UTF-8 prefix>"}`. The prefix is chosen so the complete
+encoded envelope, including JSON escaping and envelope overhead, does not
+exceed the limit. If the limit is too small for that envelope, the runtime
+returns the deterministic minimal JSON value `0` at one byte or `{}` when at
+least two bytes fit. Thus every positively bounded truncated result is valid
+UTF-8, valid JSON, and no larger than its effective limit. Providers preserve
+this bounded JSON as the tool-result content string alongside the explicit
+truncation metadata.
+
 The reference runtime emits versioned JSONL lifecycle, usage, tool, output, and
 error events to stdout. It retains conversation state only in memory for one
 run and does not provide retries, planning, persistent memory, retrieval,

--- a/internal/tooloutput/bound.go
+++ b/internal/tooloutput/bound.go
@@ -1,0 +1,62 @@
+// Package tooloutput applies the shared byte-bound contract for tool results.
+package tooloutput
+
+import (
+	"encoding/json"
+	"unicode/utf8"
+)
+
+const emptyPartial = `{"partial":""}`
+
+// Bound returns value unchanged when it is valid UTF-8 and within maxBytes.
+// Truncated values become a JSON partial envelope. Positive limits too small
+// for that envelope receive the smallest deterministic JSON value that fits.
+func Bound(value string, maxBytes int64) (content string, truncated bool) {
+	if utf8.ValidString(value) && int64(len(value)) <= maxBytes {
+		return value, false
+	}
+	if maxBytes <= 0 {
+		return "", true
+	}
+	if maxBytes == 1 {
+		return "0", true
+	}
+	if maxBytes < int64(len(emptyPartial)) {
+		return "{}", true
+	}
+
+	low, high := 0, len(value)
+	best := emptyPartial
+	for low <= high {
+		middle := low + (high-low)/2
+		prefix := TruncateUTF8(value, int64(middle))
+		encoded, err := json.Marshal(struct {
+			Partial string `json:"partial"`
+		}{Partial: prefix})
+		if err == nil && int64(len(encoded)) <= maxBytes {
+			best = string(encoded)
+			low = middle + 1
+			continue
+		}
+		high = middle - 1
+	}
+	return best, true
+}
+
+// TruncateUTF8 returns the longest valid UTF-8 prefix within maxBytes.
+func TruncateUTF8(value string, maxBytes int64) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if int64(len(value)) <= maxBytes && utf8.ValidString(value) {
+		return value
+	}
+	end := len(value)
+	if int64(end) > maxBytes {
+		end = int(maxBytes)
+	}
+	for end > 0 && !utf8.ValidString(value[:end]) {
+		end--
+	}
+	return value[:end]
+}

--- a/internal/tooloutput/bound_test.go
+++ b/internal/tooloutput/bound_test.go
@@ -1,0 +1,139 @@
+package tooloutput
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestBound(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         string
+		maxBytes      int64
+		want          string
+		wantTruncated bool
+		wantPartial   bool
+	}{
+		{
+			name:     "plain text within limit",
+			value:    "hello",
+			maxBytes: 5,
+			want:     "hello",
+		},
+		{
+			name:     "JSON within limit",
+			value:    `{"ok":true}`,
+			maxBytes: 11,
+			want:     `{"ok":true}`,
+		},
+		{
+			name:          "one byte uses JSON number",
+			value:         "oversized",
+			maxBytes:      1,
+			want:          "0",
+			wantTruncated: true,
+		},
+		{
+			name:          "tiny limit uses JSON object",
+			value:         "oversized",
+			maxBytes:      2,
+			want:          "{}",
+			wantTruncated: true,
+		},
+		{
+			name:          "plain text gets partial envelope",
+			value:         strings.Repeat("a", 64),
+			maxBytes:      24,
+			wantTruncated: true,
+			wantPartial:   true,
+		},
+		{
+			name:          "JSON gets partial envelope",
+			value:         `{"status":"ok","items":[1,2,3]}`,
+			maxBytes:      25,
+			wantTruncated: true,
+			wantPartial:   true,
+		},
+		{
+			name:          "escaping counts toward envelope",
+			value:         strings.Repeat(`"\`, 32),
+			maxBytes:      22,
+			wantTruncated: true,
+			wantPartial:   true,
+		},
+		{
+			name:          "multibyte boundary stays valid",
+			value:         strings.Repeat("é", 32),
+			maxBytes:      24,
+			wantTruncated: true,
+			wantPartial:   true,
+		},
+		{
+			name:          "invalid UTF-8 is removed",
+			value:         "ok\xfftail",
+			maxBytes:      24,
+			wantTruncated: true,
+			wantPartial:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, truncated := Bound(test.value, test.maxBytes)
+			if truncated != test.wantTruncated {
+				t.Fatalf("truncated=%t want %t; content=%q", truncated, test.wantTruncated, got)
+			}
+			if test.want != "" && got != test.want {
+				t.Fatalf("content=%q want %q", got, test.want)
+			}
+			if int64(len(got)) > test.maxBytes {
+				t.Fatalf("content is %d bytes, limit is %d", len(got), test.maxBytes)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("content is not valid UTF-8: %q", got)
+			}
+			if !truncated {
+				return
+			}
+			if !json.Valid([]byte(got)) {
+				t.Fatalf("truncated content is not valid JSON: %q", got)
+			}
+			if !test.wantPartial {
+				return
+			}
+			var envelope struct {
+				Partial string `json:"partial"`
+			}
+			if err := json.Unmarshal([]byte(got), &envelope); err != nil {
+				t.Fatalf("decode partial envelope: %v", err)
+			}
+			if envelope.Partial == "" || !strings.HasPrefix(test.value, envelope.Partial) {
+				t.Fatalf("partial %q is not a non-empty input prefix", envelope.Partial)
+			}
+		})
+	}
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		maxBytes int64
+		want     string
+	}{
+		{name: "disabled", value: "abc", maxBytes: 0, want: ""},
+		{name: "unchanged", value: "aéb", maxBytes: 4, want: "aéb"},
+		{name: "ASCII", value: "abcd", maxBytes: 3, want: "abc"},
+		{name: "multibyte boundary", value: "aéb", maxBytes: 2, want: "a"},
+		{name: "invalid suffix", value: "ok\xfftail", maxBytes: 8, want: "ok"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := TruncateUTF8(test.value, test.maxBytes); got != test.want {
+				t.Fatalf("TruncateUTF8(%q, %d)=%q want %q", test.value, test.maxBytes, got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/result/v1alpha1/compact.go
+++ b/pkg/result/v1alpha1/compact.go
@@ -5,7 +5,20 @@ import (
 	"fmt"
 )
 
-const truncatedOutputJSON = `{"truncated":true}`
+const (
+	// TruncatedOutputMediaType identifies the terminal marker used when output
+	// cannot fit in the Kubernetes termination message.
+	TruncatedOutputMediaType = "application/vnd.kontext.truncated+json"
+	truncatedOutputJSON      = `{"truncated":true}`
+)
+
+// TruncatedOutput returns a fresh copy of the terminal output truncation marker.
+func TruncatedOutput() *Output {
+	return &Output{
+		MediaType: TruncatedOutputMediaType,
+		Value:     json.RawMessage(truncatedOutputJSON),
+	}
+}
 
 // Compact serializes an envelope within maxBytes. It removes the least
 // status-relevant data first and always marks data loss explicitly.
@@ -46,10 +59,7 @@ func Compact(envelope Envelope, maxBytes int) ([]byte, error) {
 		}
 	}
 	if compacted.Output != nil {
-		compacted.Output = &Output{
-			MediaType: "application/vnd.kontext.truncated+json",
-			Value:     json.RawMessage(truncatedOutputJSON),
-		}
+		compacted.Output = TruncatedOutput()
 		compacted.Truncation.OutputTruncated = true
 		if encoded, ok := marshalWithin(compacted, maxBytes); ok {
 			return encoded, nil

--- a/pkg/result/v1alpha1/result_test.go
+++ b/pkg/result/v1alpha1/result_test.go
@@ -185,6 +185,13 @@ func TestCompactProducesValidBoundedEnvelope(t *testing.T) {
 	if parsed.Envelope.Truncation == nil || !parsed.Envelope.Truncation.OutputTruncated {
 		t.Fatalf("expected explicit output truncation, got %#v", parsed.Envelope.Truncation)
 	}
+	marker := resultv1alpha1.TruncatedOutput()
+	if parsed.Envelope.Output == nil ||
+		parsed.Envelope.Output.MediaType != resultv1alpha1.TruncatedOutputMediaType ||
+		parsed.Envelope.Output.MediaType != marker.MediaType ||
+		string(parsed.Envelope.Output.Value) != string(marker.Value) {
+		t.Fatalf("compaction did not use the shared truncation marker: %#v", parsed.Envelope.Output)
+	}
 }
 
 func TestCompactLeavesSmallEnvelopeUnchanged(t *testing.T) {

--- a/runtimes/reference/Dockerfile
+++ b/runtimes/reference/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /workspace
 COPY go.mod go.sum ./
 RUN go mod download
 
+COPY internal/ internal/
 COPY pkg/result/ pkg/result/
 COPY pkg/event/ pkg/event/
 COPY runtimes/reporter/ runtimes/reporter/

--- a/runtimes/reference/internal/engine/engine.go
+++ b/runtimes/reference/internal/engine/engine.go
@@ -2,13 +2,12 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
 	"time"
-	"unicode/utf8"
 
+	"github.com/MFS-code/Kontext/internal/tooloutput"
 	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/events"
@@ -181,7 +180,7 @@ func (runner Runner) cleanupToolExecutor(
 	defer cancel()
 	if err := closer.Close(cleanupCtx); err != nil {
 		const code = "tool_cleanup_failed"
-		message := truncateUTF8(fmt.Sprintf("tool cleanup failed: %v", err), 4<<10)
+		message := tooloutput.TruncateUTF8(fmt.Sprintf("tool cleanup failed: %v", err), 4<<10)
 		if result.ExitCode == 0 {
 			failure := state.failure(
 				runner,
@@ -309,61 +308,12 @@ func applyToolOutputLimits(
 	if maxBytes < 0 {
 		maxBytes = 0
 	}
-	if int64(len(result.Content)) > maxBytes {
-		result.Content = truncateToolContent(result.Content, maxBytes)
+	if content, truncated := tooloutput.Bound(result.Content, maxBytes); truncated {
+		result.Content = content
 		result.Truncated = true
 	}
 	*totalBytes += int64(len(result.Content))
 	return result
-}
-
-func truncateToolContent(value string, maxBytes int64) string {
-	if !json.Valid([]byte(value)) {
-		return truncateUTF8(value, maxBytes)
-	}
-	if maxBytes <= 0 {
-		return ""
-	}
-	if maxBytes == 1 {
-		return "0"
-	}
-
-	const emptyPartial = `{"partial":""}`
-	if maxBytes < int64(len(emptyPartial)) {
-		return "{}"
-	}
-
-	low := 0
-	high := len(value)
-	best := emptyPartial
-	for low <= high {
-		middle := low + (high-low)/2
-		prefix := truncateUTF8(value, int64(middle))
-		encoded, _ := json.Marshal(struct {
-			Partial string `json:"partial"`
-		}{Partial: prefix})
-		if int64(len(encoded)) <= maxBytes {
-			best = string(encoded)
-			low = middle + 1
-			continue
-		}
-		high = middle - 1
-	}
-	return best
-}
-
-func truncateUTF8(value string, maxBytes int64) string {
-	if maxBytes <= 0 {
-		return ""
-	}
-	if int64(len(value)) <= maxBytes {
-		return value
-	}
-	end := int(maxBytes)
-	for end > 0 && !utf8.ValidString(value[:end]) {
-		end--
-	}
-	return value[:end]
 }
 
 func (runner Runner) limitFailure(

--- a/runtimes/reference/internal/engine/engine_test.go
+++ b/runtimes/reference/internal/engine/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
@@ -481,8 +482,11 @@ func TestRunnerBoundsToolOutputAndReturnsToolErrors(t *testing.T) {
 			selectedProvider.requests[1].Messages[len(selectedProvider.requests[1].Messages)-1],
 		)
 		if len(results) != 2 ||
-			results[0].Content != "abcd" ||
-			results[1].Content != "ab" ||
+			results[0].Content != "{}" ||
+			results[1].Content != "{}" ||
+			int64(len(results[0].Content)+len(results[1].Content)) > totalOutput ||
+			int64(len(results[0].Content)) > perResult ||
+			int64(len(results[1].Content)) > perResult ||
 			!results[0].Truncated ||
 			!results[1].Truncated {
 			t.Fatalf("unexpected bounded results %#v", results)
@@ -514,6 +518,7 @@ func TestRunnerBoundsToolOutputAndReturnsToolErrors(t *testing.T) {
 		)
 		if len(results) != 1 ||
 			results[0].Content != "0" ||
+			int64(len(results[0].Content)) > perResult ||
 			!json.Valid([]byte(results[0].Content)) ||
 			!results[0].Truncated {
 			t.Fatalf("unexpected tiny structured result %#v", results)
@@ -552,6 +557,44 @@ func TestRunnerBoundsToolOutputAndReturnsToolErrors(t *testing.T) {
 		if err := json.Unmarshal([]byte(results[0].Content), &bounded); err != nil ||
 			bounded["partial"] == "" {
 			t.Fatalf("structured prefix was not preserved: content=%q err=%v", results[0].Content, err)
+		}
+	})
+
+	t.Run("plain UTF-8 result uses partial envelope", func(t *testing.T) {
+		selectedProvider := &scriptedProvider{
+			responses: []runtimeapi.CompletionResponse{
+				toolCallResponse("call-1"),
+				finalResponse("done"),
+			},
+		}
+		executor := lookupExecutor(runtimeapi.ToolResult{Content: "éééééééééé"})
+		runtimeConfig := baseConfig()
+		perResult := int64(18)
+		runtimeConfig.MaxToolResultBytes = &perResult
+		result := runnerWithTools(selectedProvider, executor).Run(
+			context.Background(),
+			runtimeConfig,
+		)
+		if result.ExitCode != 0 {
+			t.Fatalf("unexpected failure %#v", result.Envelope.Error)
+		}
+		results := runtimeapi.MessageToolResults(
+			selectedProvider.requests[1].Messages[len(selectedProvider.requests[1].Messages)-1],
+		)
+		if len(results) != 1 ||
+			!results[0].Truncated ||
+			int64(len(results[0].Content)) > perResult ||
+			!utf8.ValidString(results[0].Content) ||
+			!json.Valid([]byte(results[0].Content)) {
+			t.Fatalf("unexpected UTF-8 result %#v", results)
+		}
+		var bounded struct {
+			Partial string `json:"partial"`
+		}
+		if err := json.Unmarshal([]byte(results[0].Content), &bounded); err != nil ||
+			bounded.Partial == "" ||
+			!utf8.ValidString(bounded.Partial) {
+			t.Fatalf("unexpected partial envelope content=%q err=%v", results[0].Content, err)
 		}
 	})
 

--- a/runtimes/reference/internal/mcpclient/client.go
+++ b/runtimes/reference/internal/mcpclient/client.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
+	"github.com/MFS-code/Kontext/internal/tooloutput"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -384,7 +384,7 @@ func (current *server) call(
 			Content:   normalizeErr.Message,
 		}, nil
 	}
-	content, truncated := boundContent(content, maxCapturedBytes)
+	content, truncated := tooloutput.Bound(content, maxCapturedBytes)
 	return Result{
 		Content:   content,
 		IsError:   response.IsError,
@@ -929,7 +929,7 @@ func newRedactor(values []string) redactor {
 }
 
 func (redactor redactor) clean(value string) string {
-	return truncateUTF8(redactor.replace(value), maxExternalErrorBytes)
+	return tooloutput.TruncateUTF8(redactor.replace(value), maxExternalErrorBytes)
 }
 
 func (redactor redactor) replace(value string) string {
@@ -1062,47 +1062,4 @@ func waitForMCPProcessGroup(ctx context.Context, processGroupID int, limit time.
 		case <-ticker.C:
 		}
 	}
-}
-
-func boundContent(value string, maxBytes int64) (string, bool) {
-	if int64(len(value)) <= maxBytes {
-		return value, false
-	}
-	if !json.Valid([]byte(value)) {
-		return truncateUTF8(value, maxBytes), true
-	}
-	const emptyPartial = `{"partial":""}`
-	if maxBytes < int64(len(emptyPartial)) {
-		return "{}", true
-	}
-	low, high := 0, len(value)
-	best := emptyPartial
-	for low <= high {
-		middle := low + (high-low)/2
-		prefix := truncateUTF8(value, int64(middle))
-		encoded, _ := json.Marshal(struct {
-			Partial string `json:"partial"`
-		}{Partial: prefix})
-		if int64(len(encoded)) <= maxBytes {
-			best = string(encoded)
-			low = middle + 1
-		} else {
-			high = middle - 1
-		}
-	}
-	return best, true
-}
-
-func truncateUTF8(value string, maxBytes int64) string {
-	if maxBytes <= 0 {
-		return ""
-	}
-	if int64(len(value)) <= maxBytes {
-		return value
-	}
-	end := int(maxBytes)
-	for end > 0 && !utf8.ValidString(value[:end]) {
-		end--
-	}
-	return value[:end]
 }

--- a/runtimes/reference/internal/mcpclient/client_test.go
+++ b/runtimes/reference/internal/mcpclient/client_test.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -65,7 +66,9 @@ func TestHTTPDiscoveryExecutionAuthBoundingAndClose(t *testing.T) {
 		&mcp.Tool{Name: "large", InputSchema: json.RawMessage(`{"type":"object"}`)},
 		func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: strings.Repeat("x", (8<<20)+1024)}},
+				Content: []mcp.Content{
+					&mcp.TextContent{Text: strings.Repeat("é", (8<<19)+1024)},
+				},
 			}, nil
 		},
 	)
@@ -139,8 +142,20 @@ func TestHTTPDiscoveryExecutionAuthBoundingAndClose(t *testing.T) {
 	}
 
 	large, err := manager.Execute(context.Background(), "large", json.RawMessage(`{}`))
-	if err != nil || !large.Truncated || len(large.Content) > 8<<20 {
+	if err != nil ||
+		!large.Truncated ||
+		int64(len(large.Content)) > maxCapturedBytes ||
+		!utf8.ValidString(large.Content) ||
+		!json.Valid([]byte(large.Content)) {
 		t.Fatalf("large output was not bounded: bytes=%d result=%#v err=%v", len(large.Content), large, err)
+	}
+	var bounded struct {
+		Partial string `json:"partial"`
+	}
+	if err := json.Unmarshal([]byte(large.Content), &bounded); err != nil ||
+		bounded.Partial == "" ||
+		!utf8.ValidString(bounded.Partial) {
+		t.Fatalf("large output did not use a UTF-8 partial envelope: content=%q err=%v", large.Content, err)
 	}
 
 	toolError, err := manager.Execute(context.Background(), "tool_error", json.RawMessage(`{}`))

--- a/runtimes/reference/internal/provider/anthropic_test.go
+++ b/runtimes/reference/internal/provider/anthropic_test.go
@@ -307,6 +307,7 @@ func TestAnthropicSerializesToolsCallsAndResults(t *testing.T) {
 			InputSchema: json.RawMessage(`{"type":"object"}`),
 		},
 	}
+	const boundedContent = `{"partial":"{\"status\":"}`
 	request.Messages = append(request.Messages,
 		runtimeapi.Message{
 			Role: runtimeapi.RoleAssistant,
@@ -329,7 +330,7 @@ func TestAnthropicSerializesToolsCallsAndResults(t *testing.T) {
 					ToolResult: &runtimeapi.ToolResult{
 						CallID:    "call-1",
 						Name:      "lookup",
-						Content:   `{"partial":"{\"status\":"}`,
+						Content:   boundedContent,
 						Truncated: true,
 					},
 				},
@@ -361,7 +362,9 @@ func TestAnthropicSerializesToolsCallsAndResults(t *testing.T) {
 	); err != nil {
 		t.Fatalf("decode tool result: %v", err)
 	}
-	if !toolResult.Truncated || !json.Valid([]byte(toolResult.Content)) {
+	if !toolResult.Truncated ||
+		toolResult.Content != boundedContent ||
+		!json.Valid([]byte(toolResult.Content)) {
 		t.Fatalf("invalid truncated tool result %#v", toolResult)
 	}
 }

--- a/runtimes/reference/internal/provider/openai_test.go
+++ b/runtimes/reference/internal/provider/openai_test.go
@@ -359,6 +359,7 @@ func TestOpenAISerializesToolsCallsAndResults(t *testing.T) {
 			InputSchema: json.RawMessage(`{"type":"object"}`),
 		},
 	}
+	const boundedContent = `{"partial":"{\"exitCode\":0"}`
 	request.Messages = append(request.Messages,
 		runtimeapi.Message{
 			Role: runtimeapi.RoleAssistant,
@@ -381,7 +382,7 @@ func TestOpenAISerializesToolsCallsAndResults(t *testing.T) {
 					ToolResult: &runtimeapi.ToolResult{
 						CallID:    "call-1",
 						Name:      "lookup",
-						Content:   `{"partial":"{\"exitCode\":0"}`,
+						Content:   boundedContent,
 						IsError:   true,
 						ErrorCode: "lookup_failed",
 						Truncated: true,
@@ -416,7 +417,7 @@ func TestOpenAISerializesToolsCallsAndResults(t *testing.T) {
 		t.Fatalf("tool error metadata was lost: %#v", toolResult)
 	}
 	content, ok := toolResult["content"].(string)
-	if !ok || !json.Valid([]byte(content)) {
+	if !ok || content != boundedContent || !json.Valid([]byte(content)) {
 		t.Fatalf("structured tool content became invalid: %#v", toolResult["content"])
 	}
 }

--- a/runtimes/reference/internal/tools/knowledge.go
+++ b/runtimes/reference/internal/tools/knowledge.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/MFS-code/Kontext/internal/tooloutput"
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
@@ -135,32 +136,29 @@ func (tool *knowledgeTool) Execute(
 			Message: fmt.Sprintf("read knowledge file: %v", err),
 		}
 	}
-	truncated := int64(len(data)) > tool.maxBytes
-	if truncated {
-		end := int(tool.maxBytes)
-		minimum := end - (utf8.UTFMax - 1)
-		if minimum < 0 {
-			minimum = 0
-		}
-		for end > minimum && !utf8.Valid(data[:end]) {
-			end--
-		}
-		if !utf8.Valid(data[:end]) {
-			return outcome{}, &Error{
-				Code:    "knowledge_invalid_encoding",
-				Message: "knowledge file must contain UTF-8 text",
-			}
-		}
-		data = data[:end]
-	}
-	if !utf8.Valid(data) {
+	oversized := int64(len(data)) > tool.maxBytes
+	if !oversized && !utf8.Valid(data) {
 		return outcome{}, &Error{
 			Code:    "knowledge_invalid_encoding",
 			Message: "knowledge file must contain UTF-8 text",
 		}
 	}
+	if oversized {
+		prefix := tooloutput.TruncateUTF8(string(data), tool.maxBytes)
+		minimum := tool.maxBytes - (utf8.UTFMax - 1)
+		if minimum < 0 {
+			minimum = 0
+		}
+		if int64(len(prefix)) < minimum {
+			return outcome{}, &Error{
+				Code:    "knowledge_invalid_encoding",
+				Message: "knowledge file must contain UTF-8 text",
+			}
+		}
+	}
+	content, truncated := tooloutput.Bound(string(data), tool.maxBytes)
 	return outcome{
-		Content:   string(data),
+		Content:   content,
 		Truncated: truncated,
 	}, nil
 }

--- a/runtimes/reference/internal/tools/knowledge_test.go
+++ b/runtimes/reference/internal/tools/knowledge_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/tools"
@@ -26,7 +28,7 @@ func TestReadKnowledgeReadsAndBoundsMountedFile(t *testing.T) {
 	registry, err := tools.New(tools.Config{
 		Allowed:          []string{tools.NameReadKnowledge},
 		KnowledgeRoot:    root,
-		MaxCapturedBytes: 9,
+		MaxCapturedBytes: 16,
 	})
 	if err != nil {
 		t.Fatalf("create registry: %v", err)
@@ -39,8 +41,18 @@ func TestReadKnowledgeReadsAndBoundsMountedFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if result.Content != "reference" || !result.Truncated || result.IsError {
+	if result.IsError || !result.Truncated ||
+		int64(len(result.Content)) > 16 ||
+		!json.Valid([]byte(result.Content)) {
 		t.Fatalf("unexpected result %#v", result)
+	}
+	var bounded struct {
+		Partial string `json:"partial"`
+	}
+	if err := json.Unmarshal([]byte(result.Content), &bounded); err != nil ||
+		bounded.Partial == "" ||
+		!strings.HasPrefix("reference contract", bounded.Partial) {
+		t.Fatalf("unexpected partial envelope content=%q err=%v", result.Content, err)
 	}
 }
 
@@ -48,7 +60,7 @@ func TestReadKnowledgeTruncatesAtUTF8Boundary(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(root, "unicode.txt"),
-		[]byte("aéb"),
+		[]byte(strings.Repeat("é", 16)),
 		0o600,
 	); err != nil {
 		t.Fatalf("write knowledge: %v", err)
@@ -56,7 +68,7 @@ func TestReadKnowledgeTruncatesAtUTF8Boundary(t *testing.T) {
 	registry, err := tools.New(tools.Config{
 		Allowed:          []string{tools.NameReadKnowledge},
 		KnowledgeRoot:    root,
-		MaxCapturedBytes: 2,
+		MaxCapturedBytes: 20,
 	})
 	if err != nil {
 		t.Fatalf("create registry: %v", err)
@@ -69,8 +81,19 @@ func TestReadKnowledgeTruncatesAtUTF8Boundary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if result.IsError || result.Content != "a" || !result.Truncated {
+	if result.IsError || !result.Truncated ||
+		int64(len(result.Content)) > 20 ||
+		!utf8.ValidString(result.Content) ||
+		!json.Valid([]byte(result.Content)) {
 		t.Fatalf("unexpected result %#v", result)
+	}
+	var bounded struct {
+		Partial string `json:"partial"`
+	}
+	if err := json.Unmarshal([]byte(result.Content), &bounded); err != nil ||
+		bounded.Partial == "" ||
+		!utf8.ValidString(bounded.Partial) {
+		t.Fatalf("unexpected UTF-8 partial content=%q err=%v", result.Content, err)
 	}
 }
 

--- a/runtimes/reference/internal/tools/kubernetes.go
+++ b/runtimes/reference/internal/tools/kubernetes.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/MFS-code/Kontext/internal/tooloutput"
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
@@ -229,19 +230,8 @@ func (tool *kubernetesTool) Execute(
 			Message: fmt.Sprintf("read Kubernetes API response: %v", err),
 		}
 	}
-	truncated := int64(len(body)) > tool.maxBytes
-	if truncated {
-		body = body[:tool.maxBytes]
-		body, err = json.Marshal(struct {
-			Partial string `json:"partial"`
-		}{Partial: string(body)})
-		if err != nil {
-			return outcome{}, &Error{
-				Code:    "kubernetes_response_failed",
-				Message: fmt.Sprintf("encode truncated Kubernetes response: %v", err),
-			}
-		}
-	}
+	content, truncated := tooloutput.Bound(string(body), tool.maxBytes)
+	body = []byte(content)
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		code := "kubernetes_request_rejected"
 		switch response.StatusCode {

--- a/runtimes/reference/internal/tools/kubernetes_test.go
+++ b/runtimes/reference/internal/tools/kubernetes_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/tools"
@@ -234,15 +235,56 @@ func TestKubernetesReadReturnsRBACDenialToModel(t *testing.T) {
 	if !result.IsError ||
 		result.ErrorCode != "kubernetes_rbac_denied" ||
 		!result.Truncated ||
-		!json.Valid([]byte(result.Content)) {
+		!json.Valid([]byte(result.Content)) ||
+		!utf8.ValidString(result.Content) ||
+		int64(len(result.Content)) > 8 {
 		t.Fatalf("unexpected result %#v", result)
+	}
+	if result.Content != "{}" {
+		t.Fatalf("unexpected tiny-limit response content=%q", result.Content)
+	}
+}
+
+func TestKubernetesReadBoundsUTF8Response(t *testing.T) {
+	const maxBytes = int64(20)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		_, _ = writer.Write([]byte(`"éééééééééééé"`))
+	}))
+	defer server.Close()
+	registry, err := tools.New(tools.Config{
+		Allowed:          []string{tools.NameKubernetesRead},
+		MaxCapturedBytes: maxBytes,
+		Kubernetes: tools.KubernetesConfig{
+			BaseURL:   server.URL,
+			Namespace: "current",
+			Token:     "token",
+			Client:    server.Client(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create registry: %v", err)
+	}
+	result, err := registry.Execute(context.Background(), runtimeapi.ToolCall{
+		ID:        "kube-unicode",
+		Name:      tools.NameKubernetesRead,
+		Arguments: json.RawMessage(`{"operation":"get","resource":"pods","name":"pod-1"}`),
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if result.IsError || !result.Truncated ||
+		int64(len(result.Content)) > maxBytes ||
+		!utf8.ValidString(result.Content) ||
+		!json.Valid([]byte(result.Content)) {
+		t.Fatalf("unexpected bounded result %#v", result)
 	}
 	var bounded struct {
 		Partial string `json:"partial"`
 	}
 	if err := json.Unmarshal([]byte(result.Content), &bounded); err != nil ||
-		bounded.Partial != `{"messag` {
-		t.Fatalf("unexpected truncated response content=%q err=%v", result.Content, err)
+		bounded.Partial == "" ||
+		!utf8.ValidString(bounded.Partial) {
+		t.Fatalf("unexpected partial envelope content=%q err=%v", result.Content, err)
 	}
 }
 

--- a/runtimes/reporter/reporter.go
+++ b/runtimes/reporter/reporter.go
@@ -12,10 +12,8 @@ import (
 )
 
 const (
-	reporterFailureExitCode  = 125
-	childStartExitCode       = 126
-	truncatedOutputMediaType = "application/vnd.kontext.truncated+json"
-	truncatedOutputJSON      = `{"truncated":true}`
+	reporterFailureExitCode = 125
+	childStartExitCode      = 126
 )
 
 func runReporter(
@@ -59,10 +57,7 @@ func envelopeFromCapture(format CaptureFormat, captured CapturedResult, childExi
 			Outcome:    resultv1alpha1.OutcomeSucceeded,
 		}
 		if captured.Truncated {
-			envelope.Output = &resultv1alpha1.Output{
-				MediaType: truncatedOutputMediaType,
-				Value:     json.RawMessage(truncatedOutputJSON),
-			}
+			envelope.Output = resultv1alpha1.TruncatedOutput()
 			envelope.Truncation = &resultv1alpha1.Truncation{
 				OriginalBytes:   captured.OriginalBytes,
 				OutputTruncated: true,

--- a/runtimes/reporter/reporter_test.go
+++ b/runtimes/reporter/reporter_test.go
@@ -63,8 +63,11 @@ func TestEnvelopeFromLastLine(t *testing.T) {
 		truncated.Truncation.OriginalBytes != 8192 {
 		t.Fatalf("expected explicit truncation metadata, got %#v", truncated.Truncation)
 	}
-	if truncated.Output == nil || truncated.Output.MediaType != truncatedOutputMediaType ||
-		string(truncated.Output.Value) != truncatedOutputJSON {
+	marker := resultv1alpha1.TruncatedOutput()
+	if truncated.Output == nil ||
+		truncated.Output.MediaType != resultv1alpha1.TruncatedOutputMediaType ||
+		truncated.Output.MediaType != marker.MediaType ||
+		string(truncated.Output.Value) != string(marker.Value) {
 		t.Fatalf("unexpected truncated output %#v", truncated.Output)
 	}
 }


### PR DESCRIPTION
## Summary
- centralize UTF-8-safe tool-output bounding with exact encoded byte caps and deterministic tiny-limit JSON
- apply the shared partial-envelope contract across MCP, engine, Kubernetes, and knowledge results
- export one termination truncation marker for compaction and reporter use, and include root-internal packages in the reference image build

## Test results
- PASS: `gofmt -w` on all modified Go files
- PASS: `go test ./internal/tooloutput ./pkg/result/v1alpha1 ./runtimes/reporter ./runtimes/reference/internal/tools ./runtimes/reference/internal/mcpclient ./runtimes/reference/internal/engine ./runtimes/reference/internal/provider`
- PASS: `make verify`
- PASS: `make test`
- PASS: `make docker-build-reference REFERENCE_IMG=kontext-reference:issue59`
- PASS: `docker buildx build --platform linux/amd64 --load --file runtimes/reference/Dockerfile --tag kontext-reference:issue59-amd64 .`
- PASS: CI reference runtime smoke assertions against `kontext-reference:issue59-amd64`

Closes #59