### PR TITLE
Refactor eval grader dispatch and event parsing

### DIFF
--- a/internal/eval/fakes_test.go
+++ b/internal/eval/fakes_test.go
@@ -1,0 +1,375 @@
+package eval
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
+)
+
+type terminalClient struct {
+	client.Client
+	deletes int
+	podGets int
+	phase   kontextv1alpha1.AgentRunPhase
+	message string
+}
+
+func (cluster *terminalClient) Create(
+	ctx context.Context,
+	object client.Object,
+	options ...client.CreateOption,
+) error {
+	if err := cluster.Client.Create(ctx, object, options...); err != nil {
+		return err
+	}
+	run, ok := object.(*kontextv1alpha1.AgentRun)
+	if !ok {
+		return nil
+	}
+	exitCode := int32(0)
+	pod := &corev1.Pod{}
+	pod.Namespace = run.Namespace
+	pod.Name = "pod-" + run.Name
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "runtime",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			ExitCode: exitCode,
+		}},
+	}}
+	return cluster.Client.Create(ctx, pod)
+}
+
+func (cluster *terminalClient) Get(
+	ctx context.Context,
+	key types.NamespacedName,
+	object client.Object,
+	options ...client.GetOption,
+) error {
+	if err := cluster.Client.Get(ctx, key, object, options...); err != nil {
+		return err
+	}
+	if run, ok := object.(*kontextv1alpha1.AgentRun); ok {
+		phase := cluster.phase
+		if phase == "" {
+			phase = kontextv1alpha1.AgentRunPhaseSucceeded
+		}
+		run.Status.Phase = phase
+		run.Status.Message = cluster.message
+		if run.Status.Message == "" {
+			run.Status.Message = "successful status message"
+		}
+		run.Status.PodName = "pod-" + run.Name
+		run.Status.Result = "sensitive model output"
+		value := int64(7)
+		run.Status.Usage = &kontextv1alpha1.UsageStatus{Tokens: &value}
+		run.Status.Output = &kontextv1alpha1.OutputStatus{
+			MediaType: "text/plain",
+			Value:     runtime.RawExtension{Raw: []byte(`"sensitive model output"`)},
+		}
+	}
+	if pod, ok := object.(*corev1.Pod); ok {
+		cluster.podGets++
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name: "runtime",
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Message:  successfulEnvelopeMessage(),
+			}},
+		}}
+	}
+	return nil
+}
+
+func (cluster *terminalClient) Delete(
+	ctx context.Context,
+	object client.Object,
+	options ...client.DeleteOption,
+) error {
+	cluster.deletes++
+	return cluster.Client.Delete(ctx, object, options...)
+}
+
+type createFailClient struct {
+	client.Client
+	deletes int
+}
+
+func (cluster *createFailClient) Create(
+	context.Context,
+	client.Object,
+	...client.CreateOption,
+) error {
+	return apierrors.NewForbidden(
+		schema.GroupResource{Group: "kontext.dev", Resource: "agentruns"},
+		"case",
+		errors.New("forbidden"),
+	)
+}
+
+func (cluster *createFailClient) Delete(
+	context.Context,
+	client.Object,
+	...client.DeleteOption,
+) error {
+	cluster.deletes++
+	return nil
+}
+
+type staticLogs struct {
+	data      []byte
+	err       error
+	truncated bool
+	calls     int
+}
+
+func (logs *staticLogs) Fetch(context.Context, string, string, string) (LogCollection, error) {
+	logs.calls++
+	return LogCollection{
+		Data:      append([]byte(nil), logs.data...),
+		Truncated: logs.truncated,
+	}, logs.err
+}
+
+type orderingJudge struct {
+	t      *testing.T
+	called bool
+}
+
+func (judge *orderingJudge) Evaluate(
+	_ context.Context,
+	observation JudgeObservation,
+) (JudgeResult, error) {
+	judge.called = true
+	if len(observation.Grades) == 0 {
+		judge.t.Fatal("judge ran before deterministic graders")
+	}
+	return JudgeResult{Configured: true, Pass: true, Score: 1, Rationale: "ok"}, nil
+}
+
+func successfulLogs(t *testing.T) []byte {
+	t.Helper()
+	var logs bytes.Buffer
+	logs.WriteString(
+		`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"lifecycle","data":{"phase":"started"}}` + "\n",
+	)
+	return logs.Bytes()
+}
+
+func successfulEnvelopeMessage() string {
+	output, _ := json.Marshal("private output")
+	extension, _ := json.Marshal("secret-extension")
+	turns := int32(2)
+	tools := int32(1)
+	envelope := resultv1alpha1.Envelope{
+		APIVersion: resultv1alpha1.APIVersion,
+		Outcome:    resultv1alpha1.OutcomeSucceeded,
+		Output: &resultv1alpha1.Output{
+			MediaType: "text/plain",
+			Value:     output,
+		},
+		Execution: &resultv1alpha1.Execution{
+			Provider:  "private-provider",
+			Model:     "model",
+			RequestID: "request-secret",
+			Turns:     &turns,
+			ToolCalls: &tools,
+		},
+		Artifacts: []resultv1alpha1.Artifact{{
+			Name: "artifact-secret", URI: "memory://artifact",
+		}},
+		Extensions: map[string]json.RawMessage{
+			"example.com/private": extension,
+		},
+	}
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
+func int32Pointer(value int32) *int32 {
+	return &value
+}
+
+func mustArtifactRequirements(t *testing.T, graders []Grader) artifactRequirements {
+	t.Helper()
+	requirements, err := requirementsForGraders(graders)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return requirements
+}
+
+type cleanupContextClient struct {
+	client.Client
+	deletes          int
+	deleteContextErr error
+	hadDeadline      bool
+}
+
+func (cluster *cleanupContextClient) Delete(
+	ctx context.Context,
+	object client.Object,
+	options ...client.DeleteOption,
+) error {
+	cluster.deletes++
+	cluster.deleteContextErr = ctx.Err()
+	_, cluster.hadDeadline = ctx.Deadline()
+	return cluster.Client.Delete(ctx, object, options...)
+}
+
+type sequencedGetClient struct {
+	client.Client
+	agentErrors []error
+	podErrors   []error
+	agentGets   int
+	podGets     int
+}
+
+func (cluster *sequencedGetClient) Get(
+	ctx context.Context,
+	key types.NamespacedName,
+	object client.Object,
+	options ...client.GetOption,
+) error {
+	switch object.(type) {
+	case *kontextv1alpha1.AgentRun:
+		cluster.agentGets++
+		if len(cluster.agentErrors) > 0 {
+			err := cluster.agentErrors[0]
+			cluster.agentErrors = cluster.agentErrors[1:]
+			return err
+		}
+	case *corev1.Pod:
+		cluster.podGets++
+		if len(cluster.podErrors) > 0 {
+			err := cluster.podErrors[0]
+			cluster.podErrors = cluster.podErrors[1:]
+			return err
+		}
+	}
+	return cluster.Client.Get(ctx, key, object, options...)
+}
+
+func newFakeEvalClient(t *testing.T) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := kontextv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).Build()
+}
+
+type blockingCreateClient struct {
+	client.Client
+}
+
+func (cluster *blockingCreateClient) Create(
+	ctx context.Context,
+	_ client.Object,
+	_ ...client.CreateOption,
+) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+type blockingPodGetClient struct {
+	client.Client
+}
+
+func (cluster *blockingPodGetClient) Get(
+	ctx context.Context,
+	key types.NamespacedName,
+	object client.Object,
+	options ...client.GetOption,
+) error {
+	if _, ok := object.(*corev1.Pod); ok {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return cluster.Client.Get(ctx, key, object, options...)
+}
+
+type blockingLogs struct{}
+
+func (blockingLogs) Fetch(
+	ctx context.Context,
+	_, _, _ string,
+) (LogCollection, error) {
+	<-ctx.Done()
+	return LogCollection{}, ctx.Err()
+}
+
+type blockingJudge struct{}
+
+func (blockingJudge) Evaluate(
+	ctx context.Context,
+	_ JudgeObservation,
+) (JudgeResult, error) {
+	<-ctx.Done()
+	return JudgeResult{}, ctx.Err()
+}
+
+type ambiguousCreateClient struct {
+	client.Client
+	unowned            bool
+	probeNotFoundCount int
+	deletes            int
+}
+
+func (cluster *ambiguousCreateClient) Create(
+	ctx context.Context,
+	object client.Object,
+	_ ...client.CreateOption,
+) error {
+	run := object.(*kontextv1alpha1.AgentRun).DeepCopy()
+	if cluster.unowned {
+		run.Labels = map[string]string{"owner": "user"}
+	}
+	if err := cluster.Client.Create(ctx, run); err != nil {
+		return err
+	}
+	return apierrors.NewTimeoutError("create response lost", 0)
+}
+
+func (cluster *ambiguousCreateClient) Get(
+	ctx context.Context,
+	key types.NamespacedName,
+	object client.Object,
+	options ...client.GetOption,
+) error {
+	if _, ok := object.(*kontextv1alpha1.AgentRun); ok && cluster.probeNotFoundCount > 0 {
+		cluster.probeNotFoundCount--
+		return apierrors.NewNotFound(
+			schema.GroupResource{Group: "kontext.dev", Resource: "agentruns"},
+			key.Name,
+		)
+	}
+	return cluster.Client.Get(ctx, key, object, options...)
+}
+
+func (cluster *ambiguousCreateClient) Delete(
+	ctx context.Context,
+	object client.Object,
+	options ...client.DeleteOption,
+) error {
+	cluster.deletes++
+	return cluster.Client.Delete(ctx, object, options...)
+}

--- a/internal/eval/grader.go
+++ b/internal/eval/grader.go
@@ -1,11 +1,5 @@
 package eval
 
-import (
-	"encoding/json"
-	"fmt"
-	"strings"
-)
-
 func GradeRecord(record *Record, graders []Grader) {
 	record.Grades = make([]Grade, 0, len(graders))
 	for _, grader := range graders {
@@ -14,111 +8,11 @@ func GradeRecord(record *Record, graders []Grader) {
 }
 
 func grade(record *Record, grader Grader) Grade {
-	result := Grade{Type: grader.Type}
-	if err := validateGrader(grader); err != nil {
-		result.Message = fmt.Sprintf("invalid grader: %v", err)
-		return result
+	spec, err := graderSpecFor(grader.Type)
+	if err != nil {
+		return Grade{Type: grader.Type, Message: err.Error()}
 	}
-	switch grader.Type {
-	case GraderTerminalPhase:
-		result.Expected = grader.Phase
-		result.Observed = record.TerminalPhase
-		result.Pass = record.TerminalPhase == grader.Phase
-	case GraderStatusResult:
-		result.Observed = record.StatusResult
-		switch {
-		case grader.StatusResult.Exact != nil:
-			result.Expected = map[string]string{"exact": *grader.StatusResult.Exact}
-			result.Pass = record.StatusResult == *grader.StatusResult.Exact
-		case grader.StatusResult.Contains != nil:
-			result.Expected = map[string]string{"contains": *grader.StatusResult.Contains}
-			result.Pass = strings.Contains(record.StatusResult, *grader.StatusResult.Contains)
-		case grader.StatusResult.NotContains != nil:
-			result.Expected = map[string]string{"notContains": *grader.StatusResult.NotContains}
-			result.Pass = !strings.Contains(record.StatusResult, *grader.StatusResult.NotContains)
-		}
-	case GraderStructuredOutput:
-		expectation := grader.StructuredOutput
-		present := record.StatusOutput != nil
-		valid := present && json.Valid(record.StatusOutput.Value)
-		mediaType := ""
-		if present {
-			mediaType = record.StatusOutput.MediaType
-		}
-		result.Expected = expectation
-		result.Observed = map[string]any{"present": present, "valid": valid, "mediaType": mediaType}
-		result.Pass = true
-		if expectation.Present != nil {
-			result.Pass = result.Pass && present == *expectation.Present
-		}
-		if expectation.Valid != nil {
-			result.Pass = result.Pass && valid == *expectation.Valid
-		}
-		if expectation.MediaType != "" {
-			result.Pass = result.Pass && mediaType == expectation.MediaType
-		}
-	case GraderUsageFields:
-		observed := usagePresence(record)
-		result.Expected = grader.UsageFields
-		result.Observed = observed
-		result.Pass = true
-		for _, field := range grader.UsageFields {
-			result.Pass = result.Pass && observed[field]
-		}
-	case GraderEnvelopeError:
-		result.Expected = grader.ErrorCode
-		if record.Envelope != nil && record.Envelope.Error != nil {
-			result.Observed = record.Envelope.Error.Code
-			result.Pass = record.Envelope.Error.Code == grader.ErrorCode
-		}
-	case GraderEnvelopeOutcome:
-		result.Expected = grader.Outcome
-		if record.Envelope != nil {
-			result.Observed = record.Envelope.Outcome
-			result.Pass = record.Envelope.Outcome == grader.Outcome
-		}
-	case GraderExecutionModel:
-		result.Expected = grader.Model
-		if record.Envelope != nil && record.Envelope.Execution != nil {
-			result.Observed = record.Envelope.Execution.Model
-			result.Pass = record.Envelope.Execution.Model == grader.Model
-		}
-	case GraderEnvelopeTurns:
-		result.Expected = *grader.Turns
-		if record.Envelope != nil && record.Envelope.Execution != nil &&
-			record.Envelope.Execution.Turns != nil {
-			result.Observed = *record.Envelope.Execution.Turns
-			result.Pass = *record.Envelope.Execution.Turns == *grader.Turns
-		}
-	case GraderEnvelopeTools:
-		result.Expected = *grader.ToolCalls
-		if record.Envelope != nil && record.Envelope.Execution != nil &&
-			record.Envelope.Execution.ToolCalls != nil {
-			result.Observed = *record.Envelope.Execution.ToolCalls
-			result.Pass = *record.Envelope.Execution.ToolCalls == *grader.ToolCalls
-		}
-	case GraderEventCount:
-		result.Expected = grader.Event.Count
-		result.Observed = record.Events.Counts[grader.Event.Type]
-		result.Pass = record.Events.Counts[grader.Event.Type] == grader.Event.Count
-	case GraderToolEvents:
-		matches := matchingTools(record.Events.Tools, *grader.Tool)
-		result.Expected = grader.Tool
-		result.Observed = matches
-		result.Pass = len(matches) == grader.Tool.Count
-	case GraderDuration:
-		result.Expected = grader.MaxDuration.Milliseconds()
-		result.Observed = record.DurationMillis
-		result.Pass = record.DurationMillis <= grader.MaxDuration.Milliseconds()
-	case GraderPodExitCode:
-		result.Expected = *grader.ExitCode
-		if record.PodExitCode != nil {
-			result.Observed = *record.PodExitCode
-			result.Pass = *record.PodExitCode == *grader.ExitCode
-		}
-	default:
-		result.Message = fmt.Sprintf("unsupported grader type %q", grader.Type)
-	}
+	result := spec.grade(record, grader)
 	if !result.Pass && result.Message == "" {
 		result.Message = "observed value did not match expectation"
 	}

--- a/internal/eval/grader_specs.go
+++ b/internal/eval/grader_specs.go
@@ -145,14 +145,14 @@ func validateStructuredOutputGrader(grader Grader) error {
 	if grader.StructuredOutput == nil {
 		return errors.New("structuredOutput expectation is required")
 	}
+	mediaType := grader.StructuredOutput.MediaType
+	if mediaType != "" && strings.TrimSpace(mediaType) == "" {
+		return errors.New("structuredOutput.mediaType must not be blank")
+	}
 	if grader.StructuredOutput.Present == nil &&
 		grader.StructuredOutput.Valid == nil &&
-		strings.TrimSpace(grader.StructuredOutput.MediaType) == "" {
+		mediaType == "" {
 		return errors.New("structuredOutput requires present, valid, or mediaType")
-	}
-	if grader.StructuredOutput.MediaType != "" &&
-		strings.TrimSpace(grader.StructuredOutput.MediaType) == "" {
-		return errors.New("structuredOutput.mediaType must not be blank")
 	}
 	return nil
 }

--- a/internal/eval/grader_specs.go
+++ b/internal/eval/grader_specs.go
@@ -1,0 +1,466 @@
+package eval
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
+)
+
+type graderSpec struct {
+	validate     func(Grader) error
+	requirements func(Grader, *artifactRequirements)
+	grade        func(*Record, Grader) Grade
+}
+
+var graderSpecs = map[GraderType]graderSpec{
+	GraderTerminalPhase: {
+		validate:     validateTerminalPhaseGrader,
+		requirements: noArtifactRequirements,
+		grade:        gradeTerminalPhase,
+	},
+	GraderStatusResult: {
+		validate:     validateStatusResultGrader,
+		requirements: requireStatusResult,
+		grade:        gradeStatusResult,
+	},
+	GraderStructuredOutput: {
+		validate:     validateStructuredOutputGrader,
+		requirements: requireStatusOutput,
+		grade:        gradeStructuredOutput,
+	},
+	GraderUsageFields: {
+		validate:     validateUsageFieldsGrader,
+		requirements: requireStatusUsage,
+		grade:        gradeUsageFields,
+	},
+	GraderEnvelopeError: {
+		validate:     validateEnvelopeErrorGrader,
+		requirements: requireEnvelopeError,
+		grade:        gradeEnvelopeError,
+	},
+	GraderEnvelopeOutcome: {
+		validate:     validateEnvelopeOutcomeGrader,
+		requirements: requireEnvelopeOutcome,
+		grade:        gradeEnvelopeOutcome,
+	},
+	GraderExecutionModel: {
+		validate:     validateExecutionModelGrader,
+		requirements: requireEnvelopeModel,
+		grade:        gradeExecutionModel,
+	},
+	GraderEnvelopeTurns: {
+		validate:     validateEnvelopeTurnsGrader,
+		requirements: requireEnvelopeTurns,
+		grade:        gradeEnvelopeTurns,
+	},
+	GraderEnvelopeTools: {
+		validate:     validateEnvelopeToolsGrader,
+		requirements: requireEnvelopeTools,
+		grade:        gradeEnvelopeTools,
+	},
+	GraderEventCount: {
+		validate:     validateEventCountGrader,
+		requirements: requireEventCount,
+		grade:        gradeEventCount,
+	},
+	GraderToolEvents: {
+		validate:     validateToolEventsGrader,
+		requirements: requireToolEvents,
+		grade:        gradeToolEvents,
+	},
+	GraderDuration: {
+		validate:     validateDurationGrader,
+		requirements: noArtifactRequirements,
+		grade:        gradeDuration,
+	},
+	GraderPodExitCode: {
+		validate:     validatePodExitCodeGrader,
+		requirements: requirePodExitCode,
+		grade:        gradePodExitCode,
+	},
+}
+
+func graderSpecFor(graderType GraderType) (graderSpec, error) {
+	spec, ok := graderSpecs[graderType]
+	if !ok {
+		return graderSpec{}, fmt.Errorf("unsupported grader type %q", graderType)
+	}
+	if spec.validate == nil || spec.requirements == nil || spec.grade == nil {
+		return graderSpec{}, fmt.Errorf("grader type %q has an incomplete dispatch spec", graderType)
+	}
+	return spec, nil
+}
+
+func validateGrader(grader Grader) error {
+	spec, err := graderSpecFor(grader.Type)
+	if err != nil {
+		return err
+	}
+	return spec.validate(grader)
+}
+
+func validateTerminalPhaseGrader(grader Grader) error {
+	switch grader.Phase {
+	case kontextv1alpha1.AgentRunPhaseSucceeded,
+		kontextv1alpha1.AgentRunPhaseFailed,
+		kontextv1alpha1.AgentRunPhaseBudgetExceeded:
+		return nil
+	default:
+		return fmt.Errorf("invalid terminal phase %q", grader.Phase)
+	}
+}
+
+func validateStatusResultGrader(grader Grader) error {
+	if grader.StatusResult == nil {
+		return errors.New("statusResult expectation is required")
+	}
+	count := 0
+	if grader.StatusResult.Exact != nil {
+		count++
+	}
+	if grader.StatusResult.Contains != nil {
+		count++
+	}
+	if grader.StatusResult.NotContains != nil {
+		count++
+	}
+	if count != 1 {
+		return errors.New("statusResult requires exactly one of exact, contains, or notContains")
+	}
+	if grader.StatusResult.Contains != nil && *grader.StatusResult.Contains == "" {
+		return errors.New("statusResult.contains must not be empty")
+	}
+	if grader.StatusResult.NotContains != nil && *grader.StatusResult.NotContains == "" {
+		return errors.New("statusResult.notContains must not be empty")
+	}
+	return nil
+}
+
+func validateStructuredOutputGrader(grader Grader) error {
+	if grader.StructuredOutput == nil {
+		return errors.New("structuredOutput expectation is required")
+	}
+	if grader.StructuredOutput.Present == nil &&
+		grader.StructuredOutput.Valid == nil &&
+		strings.TrimSpace(grader.StructuredOutput.MediaType) == "" {
+		return errors.New("structuredOutput requires present, valid, or mediaType")
+	}
+	if grader.StructuredOutput.MediaType != "" &&
+		strings.TrimSpace(grader.StructuredOutput.MediaType) == "" {
+		return errors.New("structuredOutput.mediaType must not be blank")
+	}
+	return nil
+}
+
+func validateUsageFieldsGrader(grader Grader) error {
+	if len(grader.UsageFields) == 0 {
+		return errors.New("usageFields must not be empty")
+	}
+	seenFields := make(map[string]struct{}, len(grader.UsageFields))
+	for _, field := range grader.UsageFields {
+		switch field {
+		case "tokens", "inputTokens", "outputTokens", "dollars":
+		default:
+			return fmt.Errorf("invalid usage field %q", field)
+		}
+		if _, exists := seenFields[field]; exists {
+			return fmt.Errorf("duplicate usage field %q", field)
+		}
+		seenFields[field] = struct{}{}
+	}
+	return nil
+}
+
+func validateEnvelopeErrorGrader(grader Grader) error {
+	if strings.TrimSpace(grader.ErrorCode) == "" {
+		return errors.New("errorCode is required")
+	}
+	return nil
+}
+
+func validateEnvelopeOutcomeGrader(grader Grader) error {
+	switch grader.Outcome {
+	case resultv1alpha1.OutcomeSucceeded, resultv1alpha1.OutcomeFailed:
+		return nil
+	default:
+		return fmt.Errorf("invalid envelope outcome %q", grader.Outcome)
+	}
+}
+
+func validateExecutionModelGrader(grader Grader) error {
+	if strings.TrimSpace(grader.Model) == "" {
+		return errors.New("model is required")
+	}
+	return nil
+}
+
+func validateEnvelopeTurnsGrader(grader Grader) error {
+	if grader.Turns == nil || *grader.Turns < 0 {
+		return errors.New("turns must be a non-negative integer")
+	}
+	return nil
+}
+
+func validateEnvelopeToolsGrader(grader Grader) error {
+	if grader.ToolCalls == nil || *grader.ToolCalls < 0 {
+		return errors.New("toolCalls must be a non-negative integer")
+	}
+	return nil
+}
+
+func validateEventCountGrader(grader Grader) error {
+	if grader.Event == nil || grader.Event.Count < 0 {
+		return errors.New("event with non-negative count is required")
+	}
+	switch grader.Event.Type {
+	case eventv1alpha1.TypeLifecycle, eventv1alpha1.TypeOutput, eventv1alpha1.TypeUsage,
+		eventv1alpha1.TypeTool, eventv1alpha1.TypeError:
+		return nil
+	default:
+		return fmt.Errorf("invalid event type %q", grader.Event.Type)
+	}
+}
+
+func validateToolEventsGrader(grader Grader) error {
+	if grader.Tool == nil {
+		return errors.New("tool expectation is required")
+	}
+	if strings.TrimSpace(grader.Tool.Name) == "" {
+		return errors.New("tool.name is required")
+	}
+	if grader.Tool.Count < 0 {
+		return errors.New("tool.count must be non-negative")
+	}
+	if grader.Tool.ErrorCode != "" && strings.TrimSpace(grader.Tool.ErrorCode) == "" {
+		return errors.New("tool.errorCode must not be blank")
+	}
+	return nil
+}
+
+func validateDurationGrader(grader Grader) error {
+	if grader.MaxDuration.Duration <= 0 {
+		return errors.New("maxDuration must be greater than zero")
+	}
+	return nil
+}
+
+func validatePodExitCodeGrader(grader Grader) error {
+	if grader.ExitCode == nil {
+		return errors.New("exitCode is required")
+	}
+	return nil
+}
+
+func noArtifactRequirements(Grader, *artifactRequirements) {}
+
+func requireStatusResult(_ Grader, requirements *artifactRequirements) {
+	requirements.statusResult = true
+}
+
+func requireStatusOutput(_ Grader, requirements *artifactRequirements) {
+	requirements.statusOutput = true
+}
+
+func requireStatusUsage(_ Grader, requirements *artifactRequirements) {
+	requirements.statusUsage = true
+}
+
+func requireEnvelopeError(_ Grader, requirements *artifactRequirements) {
+	requireEnvelope(requirements, projectEnvelopeError)
+}
+
+func requireEnvelopeOutcome(_ Grader, requirements *artifactRequirements) {
+	requireEnvelope(requirements, projectEnvelopeOutcome)
+}
+
+func requireEnvelopeModel(_ Grader, requirements *artifactRequirements) {
+	requireEnvelope(requirements, projectEnvelopeModel)
+}
+
+func requireEnvelopeTurns(_ Grader, requirements *artifactRequirements) {
+	requireEnvelope(requirements, projectEnvelopeTurns)
+}
+
+func requireEnvelopeTools(_ Grader, requirements *artifactRequirements) {
+	requireEnvelope(requirements, projectEnvelopeTools)
+}
+
+func requireEnvelope(requirements *artifactRequirements, projector envelopeProjector) {
+	requirements.pod = true
+	requirements.envelope = true
+	requirements.envelopeProjectors = append(requirements.envelopeProjectors, projector)
+}
+
+func requireEventCount(grader Grader, requirements *artifactRequirements) {
+	requirements.pod = true
+	requirements.logs = true
+	requirements.eventTypes[grader.Event.Type] = struct{}{}
+}
+
+func requireToolEvents(_ Grader, requirements *artifactRequirements) {
+	requirements.pod = true
+	requirements.logs = true
+	requirements.eventTypes[eventv1alpha1.TypeTool] = struct{}{}
+	requirements.eventDetailTypes[eventv1alpha1.TypeTool] = struct{}{}
+}
+
+func requirePodExitCode(_ Grader, requirements *artifactRequirements) {
+	requirements.pod = true
+	requirements.exitCode = true
+}
+
+func gradeTerminalPhase(record *Record, grader Grader) Grade {
+	return Grade{
+		Type:     grader.Type,
+		Expected: grader.Phase,
+		Observed: record.TerminalPhase,
+		Pass:     record.TerminalPhase == grader.Phase,
+	}
+}
+
+func gradeStatusResult(record *Record, grader Grader) Grade {
+	result := Grade{Type: grader.Type, Observed: record.StatusResult}
+	switch {
+	case grader.StatusResult.Exact != nil:
+		result.Expected = map[string]string{"exact": *grader.StatusResult.Exact}
+		result.Pass = record.StatusResult == *grader.StatusResult.Exact
+	case grader.StatusResult.Contains != nil:
+		result.Expected = map[string]string{"contains": *grader.StatusResult.Contains}
+		result.Pass = strings.Contains(record.StatusResult, *grader.StatusResult.Contains)
+	case grader.StatusResult.NotContains != nil:
+		result.Expected = map[string]string{"notContains": *grader.StatusResult.NotContains}
+		result.Pass = !strings.Contains(record.StatusResult, *grader.StatusResult.NotContains)
+	}
+	return result
+}
+
+func gradeStructuredOutput(record *Record, grader Grader) Grade {
+	expectation := grader.StructuredOutput
+	present := record.StatusOutput != nil
+	valid := present && json.Valid(record.StatusOutput.Value)
+	mediaType := ""
+	if present {
+		mediaType = record.StatusOutput.MediaType
+	}
+	pass := true
+	if expectation.Present != nil {
+		pass = pass && present == *expectation.Present
+	}
+	if expectation.Valid != nil {
+		pass = pass && valid == *expectation.Valid
+	}
+	if expectation.MediaType != "" {
+		pass = pass && mediaType == expectation.MediaType
+	}
+	return Grade{
+		Type:     grader.Type,
+		Expected: expectation,
+		Observed: map[string]any{"present": present, "valid": valid, "mediaType": mediaType},
+		Pass:     pass,
+	}
+}
+
+func gradeUsageFields(record *Record, grader Grader) Grade {
+	observed := usagePresence(record)
+	pass := true
+	for _, field := range grader.UsageFields {
+		pass = pass && observed[field]
+	}
+	return Grade{
+		Type:     grader.Type,
+		Expected: grader.UsageFields,
+		Observed: observed,
+		Pass:     pass,
+	}
+}
+
+func gradeEnvelopeError(record *Record, grader Grader) Grade {
+	result := Grade{Type: grader.Type, Expected: grader.ErrorCode}
+	if record.Envelope != nil && record.Envelope.Error != nil {
+		result.Observed = record.Envelope.Error.Code
+		result.Pass = record.Envelope.Error.Code == grader.ErrorCode
+	}
+	return result
+}
+
+func gradeEnvelopeOutcome(record *Record, grader Grader) Grade {
+	result := Grade{Type: grader.Type, Expected: grader.Outcome}
+	if record.Envelope != nil {
+		result.Observed = record.Envelope.Outcome
+		result.Pass = record.Envelope.Outcome == grader.Outcome
+	}
+	return result
+}
+
+func gradeExecutionModel(record *Record, grader Grader) Grade {
+	result := Grade{Type: grader.Type, Expected: grader.Model}
+	if record.Envelope != nil && record.Envelope.Execution != nil {
+		result.Observed = record.Envelope.Execution.Model
+		result.Pass = record.Envelope.Execution.Model == grader.Model
+	}
+	return result
+}
+
+func gradeEnvelopeTurns(record *Record, grader Grader) Grade {
+	result := Grade{Type: grader.Type, Expected: *grader.Turns}
+	if record.Envelope != nil && record.Envelope.Execution != nil &&
+		record.Envelope.Execution.Turns != nil {
+		result.Observed = *record.Envelope.Execution.Turns
+		result.Pass = *record.Envelope.Execution.Turns == *grader.Turns
+	}
+	return result
+}
+
+func gradeEnvelopeTools(record *Record, grader Grader) Grade {
+	result := Grade{Type: grader.Type, Expected: *grader.ToolCalls}
+	if record.Envelope != nil && record.Envelope.Execution != nil &&
+		record.Envelope.Execution.ToolCalls != nil {
+		result.Observed = *record.Envelope.Execution.ToolCalls
+		result.Pass = *record.Envelope.Execution.ToolCalls == *grader.ToolCalls
+	}
+	return result
+}
+
+func gradeEventCount(record *Record, grader Grader) Grade {
+	observed := record.Events.Counts[grader.Event.Type]
+	return Grade{
+		Type:     grader.Type,
+		Expected: grader.Event.Count,
+		Observed: observed,
+		Pass:     observed == grader.Event.Count,
+	}
+}
+
+func gradeToolEvents(record *Record, grader Grader) Grade {
+	matches := matchingTools(record.Events.Tools, *grader.Tool)
+	return Grade{
+		Type:     grader.Type,
+		Expected: grader.Tool,
+		Observed: matches,
+		Pass:     len(matches) == grader.Tool.Count,
+	}
+}
+
+func gradeDuration(record *Record, grader Grader) Grade {
+	expected := grader.MaxDuration.Milliseconds()
+	return Grade{
+		Type:     grader.Type,
+		Expected: expected,
+		Observed: record.DurationMillis,
+		Pass:     record.DurationMillis <= expected,
+	}
+}
+
+func gradePodExitCode(record *Record, grader Grader) Grade {
+	result := Grade{Type: grader.Type, Expected: *grader.ExitCode}
+	if record.PodExitCode != nil {
+		result.Observed = *record.PodExitCode
+		result.Pass = *record.PodExitCode == *grader.ExitCode
+	}
+	return result
+}

--- a/internal/eval/observe.go
+++ b/internal/eval/observe.go
@@ -17,6 +17,16 @@ const (
 	MaxEventLineBytes = 64 << 10
 )
 
+var (
+	eventAPIVersionFieldMarker          = []byte(`"apiVersion"`)
+	currentEventAPIVersionMarker        = []byte(`"` + eventv1alpha1.APIVersion + `"`)
+	escapedCurrentEventAPIVersionMarker = bytes.ReplaceAll(
+		currentEventAPIVersionMarker,
+		[]byte("/"),
+		[]byte(`\/`),
+	)
+)
+
 type parsedLogs struct {
 	Events EventSummary
 	Errors []string
@@ -76,7 +86,7 @@ func ParseLogs(
 		line := append([]byte(nil), scanner.Bytes()...)
 		event, err := eventv1alpha1.Parse(line)
 		if err != nil {
-			if bytes.Contains(line, []byte(eventv1alpha1.APIVersion)) {
+			if hasCurrentEventAPIVersionMarker(line) {
 				parsed.Errors = append(parsed.Errors, fmt.Sprintf("parse required runtime event: %v", err))
 			}
 			continue
@@ -109,6 +119,29 @@ func ParseLogs(
 		parsed.Errors = append(parsed.Errors, fmt.Sprintf("scan runtime logs: %v", err))
 	}
 	return parsed
+}
+
+// hasCurrentEventAPIVersionMarker intentionally ignores event type. A line
+// claiming the current protocol version must satisfy the strict top-level
+// envelope and use a known current-version type, even when no grader requests
+// that type. JSON may encode slashes in the version string as either "/" or
+// "\/", so both exact quoted values are recognized after an apiVersion key
+// without normalizing or reparsing the malformed frame.
+func hasCurrentEventAPIVersionMarker(line []byte) bool {
+	fieldIndex := bytes.Index(line, eventAPIVersionFieldMarker)
+	if fieldIndex < 0 {
+		return false
+	}
+	valueRegion := bytes.TrimLeft(
+		line[fieldIndex+len(eventAPIVersionFieldMarker):],
+		" \t\r\n",
+	)
+	if len(valueRegion) == 0 || valueRegion[0] != ':' {
+		return false
+	}
+	valueRegion = bytes.TrimLeft(valueRegion[1:], " \t\r\n")
+	return bytes.HasPrefix(valueRegion, currentEventAPIVersionMarker) ||
+		bytes.HasPrefix(valueRegion, escapedCurrentEventAPIVersionMarker)
 }
 
 func parseEventData(event eventv1alpha1.Event) (any, error) {

--- a/internal/eval/observe.go
+++ b/internal/eval/observe.go
@@ -22,6 +22,33 @@ type parsedLogs struct {
 	Errors []string
 }
 
+type lifecycleEventData struct {
+	Phase string `json:"phase"`
+}
+
+type toolEventData struct {
+	Name      string `json:"name"`
+	Count     *int32 `json:"count"`
+	IsError   *bool  `json:"isError"`
+	ErrorCode string `json:"errorCode"`
+	Truncated *bool  `json:"truncated"`
+}
+
+type errorEventData struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type outputEventData struct {
+	MediaType string          `json:"mediaType"`
+	Value     json.RawMessage `json:"value"`
+}
+
+type usageEventData struct {
+	Turn  *int32                     `json:"turn"`
+	Usage map[string]json.RawMessage `json:"usage"`
+}
+
 func ParseLogs(
 	logs []byte,
 	truncated bool,
@@ -49,7 +76,7 @@ func ParseLogs(
 		line := append([]byte(nil), scanner.Bytes()...)
 		event, err := eventv1alpha1.Parse(line)
 		if err != nil {
-			if malformedRelevantEvent(line, relevantTypes) {
+			if bytes.Contains(line, []byte(eventv1alpha1.APIVersion)) {
 				parsed.Errors = append(parsed.Errors, fmt.Sprintf("parse required runtime event: %v", err))
 			}
 			continue
@@ -57,7 +84,8 @@ func ParseLogs(
 		if _, relevant := relevantTypes[event.Type]; !relevant {
 			continue
 		}
-		if err := validateEventData(event); err != nil {
+		data, err := parseEventData(event)
+		if err != nil {
 			parsed.Errors = append(
 				parsed.Errors,
 				fmt.Sprintf("parse required %s event data: %v", event.Type, err),
@@ -74,7 +102,7 @@ func ParseLogs(
 			continue
 		}
 		if _, detailsRequired := detailTypes[event.Type]; detailsRequired {
-			summarizeEvent(&parsed.Events, event)
+			summarizeEvent(&parsed.Events, event, data)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -83,184 +111,111 @@ func ParseLogs(
 	return parsed
 }
 
-func malformedRelevantEvent(line []byte, relevantTypes map[eventv1alpha1.Type]struct{}) bool {
-	var header struct {
-		APIVersion string             `json:"apiVersion"`
-		Type       eventv1alpha1.Type `json:"type"`
-	}
-	if err := json.Unmarshal(line, &header); err == nil {
-		_, relevant := relevantTypes[header.Type]
-		return relevant && strings.HasPrefix(header.APIVersion, "kontext.dev/event/")
-	}
-	normalized := normalizeMalformedFrame(line)
-	versionMarker := []byte(`"apiVersion":"` + eventv1alpha1.APIVersion + `"`)
-	if !bytes.Contains(normalized, versionMarker) {
-		return false
-	}
-	for eventType := range relevantTypes {
-		marker := []byte(`"type":"` + string(eventType) + `"`)
-		if bytes.Contains(normalized, marker) {
-			return true
-		}
-	}
-	return len(relevantTypes) > 0 && bytes.Contains(normalized, []byte(`"type"`))
-}
-
-func normalizeMalformedFrame(line []byte) []byte {
-	normalized := make([]byte, 0, len(line))
-	for _, value := range line {
-		switch value {
-		case ' ', '\t', '\n', '\r', '\f', '\v':
-			continue
-		default:
-			normalized = append(normalized, value)
-		}
-	}
-	return bytes.ReplaceAll(normalized, []byte(`\/`), []byte(`/`))
-}
-
-func validateEventData(event eventv1alpha1.Event) error {
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(event.Data, &fields); err != nil {
-		return fmt.Errorf("data must be an object: %w", err)
-	}
-	if fields == nil {
-		return fmt.Errorf("data must be an object")
+func parseEventData(event eventv1alpha1.Event) (any, error) {
+	trimmed := bytes.TrimSpace(event.Data)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, fmt.Errorf("data must be an object")
 	}
 	switch event.Type {
 	case eventv1alpha1.TypeLifecycle:
-		if _, err := requiredString(fields, "phase"); err != nil {
-			return err
+		var data lifecycleEventData
+		if err := json.Unmarshal(event.Data, &data); err != nil {
+			return nil, fmt.Errorf("decode lifecycle data: %w", err)
 		}
+		if strings.TrimSpace(data.Phase) == "" {
+			return nil, fmt.Errorf("phase is required and must not be empty")
+		}
+		return data, nil
 	case eventv1alpha1.TypeTool:
-		if _, err := requiredString(fields, "name"); err != nil {
-			return err
+		var data toolEventData
+		if err := json.Unmarshal(event.Data, &data); err != nil {
+			return nil, fmt.Errorf("decode tool data: %w", err)
 		}
-		count, err := requiredInt32(fields, "count")
-		if err != nil {
-			return err
+		if strings.TrimSpace(data.Name) == "" {
+			return nil, fmt.Errorf("name is required and must not be empty")
 		}
-		if count < 1 {
-			return fmt.Errorf("count must be at least 1")
+		if data.Count == nil {
+			return nil, fmt.Errorf("count is required")
 		}
-		if _, err := requiredBool(fields, "isError"); err != nil {
-			return err
+		if *data.Count < 1 {
+			return nil, fmt.Errorf("count must be at least 1")
 		}
-		if _, err := requiredBool(fields, "truncated"); err != nil {
-			return err
+		if data.IsError == nil {
+			return nil, fmt.Errorf("isError is required")
 		}
-		if value, exists := fields["errorCode"]; exists {
-			var errorCode string
-			if err := json.Unmarshal(value, &errorCode); err != nil {
-				return fmt.Errorf("errorCode must be a string")
-			}
+		if data.Truncated == nil {
+			return nil, fmt.Errorf("truncated is required")
 		}
+		return data, nil
 	case eventv1alpha1.TypeError:
-		if _, err := requiredString(fields, "code"); err != nil {
-			return err
+		var data errorEventData
+		if err := json.Unmarshal(event.Data, &data); err != nil {
+			return nil, fmt.Errorf("decode error data: %w", err)
 		}
-		if _, err := requiredString(fields, "message"); err != nil {
-			return err
+		if strings.TrimSpace(data.Code) == "" {
+			return nil, fmt.Errorf("code is required and must not be empty")
 		}
+		if strings.TrimSpace(data.Message) == "" {
+			return nil, fmt.Errorf("message is required and must not be empty")
+		}
+		return data, nil
 	case eventv1alpha1.TypeOutput:
-		if _, err := requiredString(fields, "mediaType"); err != nil {
-			return err
+		var data outputEventData
+		if err := json.Unmarshal(event.Data, &data); err != nil {
+			return nil, fmt.Errorf("decode output data: %w", err)
 		}
-		if _, exists := fields["value"]; !exists {
-			return fmt.Errorf("value is required")
+		if strings.TrimSpace(data.MediaType) == "" {
+			return nil, fmt.Errorf("mediaType is required and must not be empty")
 		}
+		if data.Value == nil {
+			return nil, fmt.Errorf("value is required")
+		}
+		return data, nil
 	case eventv1alpha1.TypeUsage:
-		turn, err := requiredInt32(fields, "turn")
-		if err != nil {
-			return err
+		var data usageEventData
+		if err := json.Unmarshal(event.Data, &data); err != nil {
+			return nil, fmt.Errorf("decode usage data: %w", err)
 		}
-		if turn < 1 {
-			return fmt.Errorf("turn must be at least 1")
+		if data.Turn == nil {
+			return nil, fmt.Errorf("turn is required")
 		}
-		var usage map[string]json.RawMessage
-		if err := json.Unmarshal(fields["usage"], &usage); err != nil || usage == nil {
-			return fmt.Errorf("usage must be an object")
+		if *data.Turn < 1 {
+			return nil, fmt.Errorf("turn must be at least 1")
 		}
+		if data.Usage == nil {
+			return nil, fmt.Errorf("usage is required and must be an object")
+		}
+		return data, nil
+	default:
+		return nil, fmt.Errorf("unsupported event type %q", event.Type)
 	}
-	return nil
 }
 
-func summarizeEvent(summary *EventSummary, event eventv1alpha1.Event) {
-	var fields map[string]json.RawMessage
-	_ = json.Unmarshal(event.Data, &fields)
+func summarizeEvent(summary *EventSummary, event eventv1alpha1.Event, parsedData any) {
 	metadata := EventMetadata{Timestamp: event.Timestamp, Type: event.Type}
-	switch event.Type {
-	case eventv1alpha1.TypeLifecycle:
-		metadata.Phase, _ = requiredString(fields, "phase")
-		if metadata.Phase != "" {
-			summary.Lifecycle = append(summary.Lifecycle, metadata.Phase)
-		}
-	case eventv1alpha1.TypeTool:
+	switch data := parsedData.(type) {
+	case lifecycleEventData:
+		metadata.Phase = data.Phase
+		summary.Lifecycle = append(summary.Lifecycle, data.Phase)
+	case toolEventData:
 		tool := ToolEvent{
-			ErrorCode: optionalString(fields, "errorCode"),
+			Name:      data.Name,
+			Count:     *data.Count,
+			IsError:   *data.IsError,
+			ErrorCode: data.ErrorCode,
+			Truncated: *data.Truncated,
 		}
-		tool.Name, _ = requiredString(fields, "name")
-		tool.Count, _ = requiredInt32(fields, "count")
-		tool.IsError, _ = requiredBool(fields, "isError")
-		tool.Truncated, _ = requiredBool(fields, "truncated")
 		summary.Tools = append(summary.Tools, tool)
 		metadata.Name = tool.Name
 		metadata.IsError = tool.IsError
 		metadata.ErrorCode = tool.ErrorCode
 		metadata.Truncated = tool.Truncated
-	case eventv1alpha1.TypeError:
-		metadata.ErrorCode, _ = requiredString(fields, "code")
-		if metadata.ErrorCode != "" {
-			summary.Errors = append(summary.Errors, metadata.ErrorCode)
-		}
-	case eventv1alpha1.TypeOutput, eventv1alpha1.TypeUsage:
+	case errorEventData:
+		metadata.ErrorCode = data.Code
+		summary.Errors = append(summary.Errors, data.Code)
+	case outputEventData, usageEventData:
 	}
 	summary.Metadata = append(summary.Metadata, metadata)
-}
-
-func requiredString(fields map[string]json.RawMessage, name string) (string, error) {
-	value, exists := fields[name]
-	if !exists {
-		return "", fmt.Errorf("%s is required", name)
-	}
-	var decoded string
-	if err := json.Unmarshal(value, &decoded); err != nil {
-		return "", fmt.Errorf("%s must be a string", name)
-	}
-	if strings.TrimSpace(decoded) == "" {
-		return "", fmt.Errorf("%s must not be empty", name)
-	}
-	return decoded, nil
-}
-
-func requiredInt32(fields map[string]json.RawMessage, name string) (int32, error) {
-	value, exists := fields[name]
-	if !exists {
-		return 0, fmt.Errorf("%s is required", name)
-	}
-	var decoded int32
-	if err := json.Unmarshal(value, &decoded); err != nil {
-		return 0, fmt.Errorf("%s must be an integer", name)
-	}
-	return decoded, nil
-}
-
-func requiredBool(fields map[string]json.RawMessage, name string) (bool, error) {
-	value, exists := fields[name]
-	if !exists {
-		return false, fmt.Errorf("%s is required", name)
-	}
-	var decoded bool
-	if err := json.Unmarshal(value, &decoded); err != nil {
-		return false, fmt.Errorf("%s must be a boolean", name)
-	}
-	return decoded, nil
-}
-
-func optionalString(fields map[string]json.RawMessage, name string) string {
-	var decoded string
-	_ = json.Unmarshal(fields[name], &decoded)
-	return decoded
 }
 
 func boundedMessage(value string) string {

--- a/internal/eval/observe_grader_test.go
+++ b/internal/eval/observe_grader_test.go
@@ -62,9 +62,8 @@ func TestParseLogsFailsRelevantMalformedAndIncompleteEvents(t *testing.T) {
 	}
 }
 
-func TestMalformedRelevantEventFallbackHandlesWhitespaceAndEscapedSlashes(t *testing.T) {
-	line := "{\t\"apiVersion\"\t:\t\"kontext.dev\\/event\\/v1alpha1\",\t" +
-		"\"type\"\t:\t\"tool\",\t\"data\":"
+func TestMalformedEventWithAPIVersionMarkerFailsCollection(t *testing.T) {
+	line := `{"apiVersion": "kontext.dev/event/v1alpha1","type":"tool","data":`
 	parsed := ParseLogs(
 		[]byte(line+"\n"),
 		false,
@@ -73,6 +72,73 @@ func TestMalformedRelevantEventFallbackHandlesWhitespaceAndEscapedSlashes(t *tes
 	)
 	if len(parsed.Errors) == 0 {
 		t.Fatalf("malformed escaped event frame was ignored: %#v", parsed)
+	}
+}
+
+func TestParseLogsValidatesAndSummarizesTypedEventData(t *testing.T) {
+	lines := []string{
+		`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"lifecycle","data":{"phase":"started","extension":true}}`,
+		`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:01Z","type":"output","data":{"mediaType":"application/json","value":{"ok":true}}}`,
+		`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:02Z","type":"usage","data":{"turn":1,"usage":{"tokens":3}}}`,
+		`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:03Z","type":"tool","data":{"name":"shell","count":1,"isError":false,"truncated":false}}`,
+		`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:04Z","type":"error","data":{"code":"denied","message":"no"}}`,
+	}
+	relevant := map[eventv1alpha1.Type]struct{}{
+		eventv1alpha1.TypeLifecycle: {},
+		eventv1alpha1.TypeOutput:    {},
+		eventv1alpha1.TypeUsage:     {},
+		eventv1alpha1.TypeTool:      {},
+		eventv1alpha1.TypeError:     {},
+	}
+	parsed := ParseLogs(
+		[]byte(strings.Join(lines, "\n")+"\n"),
+		false,
+		relevant,
+		relevant,
+	)
+	if len(parsed.Errors) != 0 {
+		t.Fatalf("typed event data was rejected: %v", parsed.Errors)
+	}
+	for eventType := range relevant {
+		if parsed.Events.Counts[eventType] != 1 {
+			t.Fatalf("%s count = %d, want 1", eventType, parsed.Events.Counts[eventType])
+		}
+	}
+	if len(parsed.Events.Metadata) != len(lines) ||
+		len(parsed.Events.Lifecycle) != 1 ||
+		len(parsed.Events.Tools) != 1 ||
+		len(parsed.Events.Errors) != 1 {
+		t.Fatalf("typed summaries were incomplete: %#v", parsed.Events)
+	}
+}
+
+func TestParseLogsRejectsMalformedTypedAndTopLevelEvents(t *testing.T) {
+	tests := map[string]string{
+		"strict top-level envelope": `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"tool","extra":true,"data":{"name":"shell","count":1,"isError":false,"truncated":false}}`,
+		"lifecycle data":            `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"lifecycle","data":{"phase":""}}`,
+		"output data":               `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"output","data":{"mediaType":"text/plain"}}`,
+		"usage data":                `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"usage","data":{"turn":0,"usage":{}}}`,
+		"tool data":                 `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"tool","data":{"name":"shell","count":1,"truncated":false}}`,
+		"error data":                `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"error","data":{"code":"denied"}}`,
+	}
+	for name, line := range tests {
+		t.Run(name, func(t *testing.T) {
+			parsed := ParseLogs(
+				[]byte(line+"\n"),
+				false,
+				map[eventv1alpha1.Type]struct{}{
+					eventv1alpha1.TypeLifecycle: {},
+					eventv1alpha1.TypeOutput:    {},
+					eventv1alpha1.TypeUsage:     {},
+					eventv1alpha1.TypeTool:      {},
+					eventv1alpha1.TypeError:     {},
+				},
+				nil,
+			)
+			if len(parsed.Errors) != 1 {
+				t.Fatalf("malformed event did not fail clearly: %#v", parsed)
+			}
+		})
 	}
 }
 
@@ -147,6 +213,97 @@ func TestGradeRecordCoversDeterministicGradersAndOptionalMetrics(t *testing.T) {
 	}
 }
 
+func TestGraderDispatchSpecsCoverEveryGraderType(t *testing.T) {
+	exact := "result"
+	present := true
+	turns := int32(1)
+	toolCalls := int32(1)
+	exitCode := int32(0)
+	graders := []Grader{
+		{Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded},
+		{Type: GraderStatusResult, StatusResult: &StringMatch{Exact: &exact}},
+		{Type: GraderStructuredOutput, StructuredOutput: &StructuredOutputExpectation{Present: &present}},
+		{Type: GraderUsageFields, UsageFields: []string{"tokens"}},
+		{Type: GraderEnvelopeError, ErrorCode: "denied"},
+		{Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeSucceeded},
+		{Type: GraderExecutionModel, Model: "model"},
+		{Type: GraderEnvelopeTurns, Turns: &turns},
+		{Type: GraderEnvelopeTools, ToolCalls: &toolCalls},
+		{Type: GraderEventCount, Event: &EventCountExpectation{
+			Type: eventv1alpha1.TypeLifecycle, Count: 1,
+		}},
+		{Type: GraderToolEvents, Tool: &ToolExpectation{Name: "shell", Count: 1}},
+		{Type: GraderDuration, MaxDuration: Duration{Duration: time.Second}},
+		{Type: GraderPodExitCode, ExitCode: &exitCode},
+	}
+	if len(graderSpecs) != len(graders) {
+		t.Fatalf("grader dispatch has %d specs, want %d", len(graderSpecs), len(graders))
+	}
+	for _, grader := range graders {
+		t.Run(string(grader.Type), func(t *testing.T) {
+			spec, err := graderSpecFor(grader.Type)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := spec.validate(grader); err != nil {
+				t.Fatalf("valid grader was rejected: %v", err)
+			}
+			requirements, err := requirementsForGraders([]Grader{grader})
+			if err != nil {
+				t.Fatalf("requirements dispatch failed: %v", err)
+			}
+			switch grader.Type {
+			case GraderTerminalPhase, GraderDuration:
+				if requirements.pod || requirements.logs || requirements.envelope ||
+					requirements.statusResult || requirements.statusOutput || requirements.statusUsage {
+					t.Fatalf("status-only grader requested artifacts: %#v", requirements)
+				}
+			case GraderStatusResult:
+				if !requirements.statusResult {
+					t.Fatal("status result was not requested")
+				}
+			case GraderStructuredOutput:
+				if !requirements.statusOutput {
+					t.Fatal("status output was not requested")
+				}
+			case GraderUsageFields:
+				if !requirements.statusUsage {
+					t.Fatal("status usage was not requested")
+				}
+			case GraderEnvelopeError, GraderEnvelopeOutcome, GraderExecutionModel,
+				GraderEnvelopeTurns, GraderEnvelopeTools:
+				if !requirements.pod || !requirements.envelope ||
+					len(requirements.envelopeProjectors) != 1 {
+					t.Fatalf("envelope artifacts were incomplete: %#v", requirements)
+				}
+			case GraderEventCount:
+				if !requirements.pod || !requirements.logs ||
+					len(requirements.eventTypes) != 1 {
+					t.Fatalf("event artifacts were incomplete: %#v", requirements)
+				}
+			case GraderToolEvents:
+				if !requirements.pod || !requirements.logs ||
+					len(requirements.eventDetailTypes) != 1 {
+					t.Fatalf("tool event artifacts were incomplete: %#v", requirements)
+				}
+			case GraderPodExitCode:
+				if !requirements.pod || !requirements.exitCode {
+					t.Fatalf("Pod exit artifacts were incomplete: %#v", requirements)
+				}
+			default:
+				t.Fatalf("test is missing grader type %q", grader.Type)
+			}
+			_ = spec.grade(&Record{
+				Events: EventSummary{Counts: map[eventv1alpha1.Type]int{}},
+			}, grader)
+		})
+	}
+	if _, err := requirementsForGraders([]Grader{{Type: GraderType("future")}}); err == nil ||
+		!strings.Contains(err.Error(), "unsupported grader type") {
+		t.Fatalf("unsupported requirements dispatch did not fail clearly: %v", err)
+	}
+}
+
 func TestStatusResultMatchModes(t *testing.T) {
 	contains := "needle"
 	notContains := "secret"
@@ -160,12 +317,12 @@ func TestStatusResultMatchModes(t *testing.T) {
 	}
 }
 
-func TestGradeRecordRejectsUnvalidatedGraders(t *testing.T) {
+func TestGradeRecordRejectsUnsupportedGraderType(t *testing.T) {
 	record := Record{}
-	GradeRecord(&record, []Grader{{Type: GraderEnvelopeTurns}})
+	GradeRecord(&record, []Grader{{Type: GraderType("future")}})
 	if len(record.Grades) != 1 ||
 		record.Grades[0].Pass ||
-		!strings.Contains(record.Grades[0].Message, "invalid grader") {
-		t.Fatalf("unvalidated grader was not rejected safely: %#v", record.Grades)
+		!strings.Contains(record.Grades[0].Message, "unsupported grader type") {
+		t.Fatalf("unsupported grader was not rejected clearly: %#v", record.Grades)
 	}
 }

--- a/internal/eval/observe_grader_test.go
+++ b/internal/eval/observe_grader_test.go
@@ -62,16 +62,57 @@ func TestParseLogsFailsRelevantMalformedAndIncompleteEvents(t *testing.T) {
 	}
 }
 
-func TestMalformedEventWithAPIVersionMarkerFailsCollection(t *testing.T) {
-	line := `{"apiVersion": "kontext.dev/event/v1alpha1","type":"tool","data":`
+func TestMalformedCurrentVersionEventMarkersFailCollection(t *testing.T) {
+	tests := map[string]string{
+		"literal slashes": `{"apiVersion": "kontext.dev/event/v1alpha1","type":"tool","data":`,
+		"escaped slashes": `{"apiVersion":"kontext.dev\/event\/v1alpha1","type":"tool","data":`,
+	}
+	for name, line := range tests {
+		t.Run(name, func(t *testing.T) {
+			parsed := ParseLogs(
+				[]byte(line+"\n"),
+				false,
+				map[eventv1alpha1.Type]struct{}{eventv1alpha1.TypeLifecycle: {}},
+				nil,
+			)
+			if len(parsed.Errors) != 1 ||
+				!strings.Contains(parsed.Errors[0], "parse required runtime event") {
+				t.Fatalf("malformed current-version frame was ignored: %#v", parsed)
+			}
+		})
+	}
+}
+
+func TestUnknownCurrentVersionEventTypeFailsCollection(t *testing.T) {
+	currentUnknown := `{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"telemetry","data":{}}`
 	parsed := ParseLogs(
-		[]byte(line+"\n"),
+		[]byte(currentUnknown+"\n"),
 		false,
-		map[eventv1alpha1.Type]struct{}{eventv1alpha1.TypeTool: {}},
+		map[eventv1alpha1.Type]struct{}{eventv1alpha1.TypeLifecycle: {}},
 		nil,
 	)
-	if len(parsed.Errors) == 0 {
-		t.Fatalf("malformed escaped event frame was ignored: %#v", parsed)
+	if len(parsed.Errors) != 1 ||
+		!strings.Contains(parsed.Errors[0], `unsupported event type "telemetry"`) {
+		t.Fatalf("unknown current-version type did not fail collection: %#v", parsed)
+	}
+
+	for _, version := range []string{"kontext.dev/event/v1alpha2", "kontext.dev/event/v1alpha10"} {
+		futureUnknown := strings.Replace(currentUnknown, eventv1alpha1.APIVersion, version, 1)
+		futureUnknown = strings.Replace(
+			futureUnknown,
+			`"data":{}`,
+			`"data":{"mentionedVersion":"`+eventv1alpha1.APIVersion+`"}`,
+			1,
+		)
+		parsed = ParseLogs(
+			[]byte(futureUnknown+"\n"),
+			false,
+			map[eventv1alpha1.Type]struct{}{eventv1alpha1.TypeLifecycle: {}},
+			nil,
+		)
+		if len(parsed.Errors) != 0 {
+			t.Fatalf("%s line affected current-version collection: %#v", version, parsed)
+		}
 	}
 }
 

--- a/internal/eval/output_judge_test.go
+++ b/internal/eval/output_judge_test.go
@@ -83,6 +83,23 @@ func TestCommandJudgeBoundsAndResponseValidation(t *testing.T) {
 	}
 }
 
+func TestJudgeResultSerializesFalsePassAndZeroScore(t *testing.T) {
+	encoded, err := json.Marshal(JudgeResult{
+		Configured: true,
+		Pass:       false,
+		Score:      0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(encoded, []byte(`"pass":false`)) {
+		t.Fatalf("false judge pass was omitted: %s", encoded)
+	}
+	if bytes.Contains(encoded, []byte(`"score"`)) {
+		t.Fatalf("zero optional score should remain omitted: %s", encoded)
+	}
+}
+
 func TestLimitedWriterReportsOutputLimit(t *testing.T) {
 	var output bytes.Buffer
 	writer := &limitedWriter{Writer: &output, Remaining: 3}

--- a/internal/eval/runner.go
+++ b/internal/eval/runner.go
@@ -16,7 +16,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	clientretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
@@ -107,13 +109,7 @@ type Runner struct {
 }
 
 func (runner Runner) RunSuite(ctx context.Context, suite EvalSuite) []Record {
-	if runner.Options.InvocationID == "" {
-		now := runner.Options.Now
-		if now == nil {
-			now = time.Now
-		}
-		runner.Options.InvocationID = invocationID(now())
-	}
+	runner.Options = normalizeRunnerOptions(runner.Options, suite.Spec.Defaults)
 	records := make([]Record, 0, len(suite.Spec.Cases))
 	for _, item := range suite.Spec.Cases {
 		records = append(records, runner.runCase(ctx, suite, item))
@@ -121,19 +117,26 @@ func (runner Runner) RunSuite(ctx context.Context, suite EvalSuite) []Record {
 	return records
 }
 
+func normalizeRunnerOptions(options RunnerOptions, defaults SuiteDefaults) RunnerOptions {
+	if options.Now == nil {
+		options.Now = time.Now
+	}
+	if options.InvocationID == "" {
+		options.InvocationID = invocationID(options.Now())
+	}
+	if options.Namespace == "" {
+		options.Namespace = defaults.Namespace
+	}
+	if options.PollInterval <= 0 {
+		options.PollInterval = 500 * time.Millisecond
+	}
+	return options
+}
+
 func (runner Runner) runCase(ctx context.Context, suite EvalSuite, item Case) Record {
 	now := runner.Options.Now
-	if now == nil {
-		now = time.Now
-	}
 	invocation := runner.Options.InvocationID
-	if invocation == "" {
-		invocation = invocationID(now())
-	}
 	namespace := runner.Options.Namespace
-	if namespace == "" {
-		namespace = suite.Spec.Defaults.Namespace
-	}
 	name := NameForCase(suite.Metadata.Name, item.ID, invocation)
 	record := Record{
 		APIVersion:  APIVersion,
@@ -150,13 +153,27 @@ func (runner Runner) runCase(ctx context.Context, suite EvalSuite, item Case) Re
 		labelEvalCase:   labelValue(item.ID),
 		labelInvocation: labelValue(invocation),
 	}
+	requirements, requirementsErr := requirementsForGraders(item.Graders)
+	if requirementsErr != nil {
+		record.CollectionErrors = append(record.CollectionErrors, requirementsErr.Error())
+		return runner.finishRecord(
+			ctx,
+			&record,
+			item,
+			requirements,
+			nil,
+			nil,
+			false,
+			now,
+		)
+	}
 	run := newAgentRun(name, namespace, item.AgentRun, ownershipLabels)
 	caseCtx, cancel := context.WithTimeout(ctx, item.Timeout.Duration)
 	defer cancel()
 	created := false
 	if err := runner.Client.Create(caseCtx, run); err != nil {
 		record.CollectionErrors = append(record.CollectionErrors, fmt.Sprintf("create AgentRun: %v", err))
-		if !runner.Options.KeepRuns && ambiguousCreateError(err) {
+		if !runner.Options.KeepRuns && classifyKubernetesError(err).ambiguousWrite {
 			record.CollectionErrors = append(
 				record.CollectionErrors,
 				runner.cleanupAmbiguousCreate(caseCtx, types.NamespacedName{
@@ -170,7 +187,7 @@ func (runner Runner) runCase(ctx context.Context, suite EvalSuite, item Case) Re
 				"AgentRun name collision was left untouched",
 			)
 		}
-		return runner.finishRecord(caseCtx, &record, item, nil, nil, created, now)
+		return runner.finishRecord(caseCtx, &record, item, requirements, nil, nil, created, now)
 	}
 	created = true
 
@@ -186,7 +203,6 @@ func (runner Runner) runCase(ctx context.Context, suite EvalSuite, item Case) Re
 	}
 	record.TerminalPhase = terminalRun.Status.Phase
 	record.Run.PodName = terminalRun.Status.PodName
-	requirements := requirementsForGraders(item.Graders)
 	if requirements.statusResult {
 		record.StatusResult = terminalRun.Status.Result
 	}
@@ -202,37 +218,33 @@ func (runner Runner) runCase(ctx context.Context, suite EvalSuite, item Case) Re
 
 	var pod *corev1.Pod
 	if !requirements.pod {
-		return runner.finishRecord(caseCtx, &record, item, terminalRun, nil, created, now)
+		return runner.finishRecord(caseCtx, &record, item, requirements, terminalRun, nil, created, now)
 	}
 	if terminalRun.Status.PodName == "" {
-		if requirements.pod {
-			record.CollectionErrors = append(record.CollectionErrors, "required runtime Pod name was not recorded")
-		}
+		record.CollectionErrors = append(record.CollectionErrors, "required runtime Pod name was not recorded")
 	} else {
 		pod = &corev1.Pod{}
 		if err := runner.getWithRetry(caseCtx, types.NamespacedName{
 			Namespace: namespace,
 			Name:      terminalRun.Status.PodName,
 		}, pod); err != nil {
-			if requirements.pod {
-				record.CollectionErrors = append(record.CollectionErrors, fmt.Sprintf("get required runtime Pod: %v", err))
-			}
+			record.CollectionErrors = append(record.CollectionErrors, fmt.Sprintf("get required runtime Pod: %v", err))
 			pod = nil
 		}
 	}
-	return runner.finishRecord(caseCtx, &record, item, terminalRun, pod, created, now)
+	return runner.finishRecord(caseCtx, &record, item, requirements, terminalRun, pod, created, now)
 }
 
 func (runner Runner) finishRecord(
 	ctx context.Context,
 	record *Record,
 	item Case,
+	requirements artifactRequirements,
 	run *kontextv1alpha1.AgentRun,
 	pod *corev1.Pod,
 	created bool,
 	now func() time.Time,
 ) Record {
-	requirements := requirementsForGraders(item.Graders)
 	if requirements.exitCode {
 		record.PodExitCode = podExitCode(pod)
 		if pod != nil && record.PodExitCode == nil {
@@ -317,72 +329,34 @@ func (runner Runner) finishRecord(
 	return *record
 }
 
+type envelopeProjector func(resultv1alpha1.Envelope, *EnvelopeObservation)
+
 type artifactRequirements struct {
-	pod              bool
-	logs             bool
-	envelope         bool
-	exitCode         bool
-	statusResult     bool
-	statusOutput     bool
-	statusUsage      bool
-	eventTypes       map[eventv1alpha1.Type]struct{}
-	eventDetailTypes map[eventv1alpha1.Type]struct{}
-	envelopeOutcome  bool
-	envelopeError    bool
-	envelopeModel    bool
-	envelopeTurns    bool
-	envelopeTools    bool
+	pod                bool
+	logs               bool
+	envelope           bool
+	exitCode           bool
+	statusResult       bool
+	statusOutput       bool
+	statusUsage        bool
+	eventTypes         map[eventv1alpha1.Type]struct{}
+	eventDetailTypes   map[eventv1alpha1.Type]struct{}
+	envelopeProjectors []envelopeProjector
 }
 
-func requirementsForGraders(graders []Grader) artifactRequirements {
+func requirementsForGraders(graders []Grader) (artifactRequirements, error) {
 	requirements := artifactRequirements{
 		eventTypes:       make(map[eventv1alpha1.Type]struct{}),
 		eventDetailTypes: make(map[eventv1alpha1.Type]struct{}),
 	}
 	for _, grader := range graders {
-		switch grader.Type {
-		case GraderEnvelopeError:
-			requirements.envelope = true
-			requirements.envelopeError = true
-			requirements.pod = true
-		case GraderEnvelopeOutcome:
-			requirements.envelope = true
-			requirements.envelopeOutcome = true
-			requirements.pod = true
-		case GraderExecutionModel:
-			requirements.envelope = true
-			requirements.envelopeModel = true
-			requirements.pod = true
-		case GraderEnvelopeTurns:
-			requirements.envelope = true
-			requirements.envelopeTurns = true
-			requirements.pod = true
-		case GraderEnvelopeTools:
-			requirements.envelope = true
-			requirements.envelopeTools = true
-			requirements.pod = true
-		case GraderEventCount:
-			requirements.logs = true
-			requirements.pod = true
-			requirements.eventTypes[grader.Event.Type] = struct{}{}
-		case GraderToolEvents:
-			requirements.logs = true
-			requirements.pod = true
-			requirements.eventTypes[eventv1alpha1.TypeTool] = struct{}{}
-			requirements.eventDetailTypes[eventv1alpha1.TypeTool] = struct{}{}
-		case GraderPodExitCode:
-			requirements.pod = true
-			requirements.exitCode = true
-		case GraderStatusResult:
-			requirements.statusResult = true
-		case GraderStructuredOutput:
-			requirements.statusOutput = true
-		case GraderUsageFields:
-			requirements.statusUsage = true
-		case GraderTerminalPhase, GraderDuration:
+		spec, err := graderSpecFor(grader.Type)
+		if err != nil {
+			return artifactRequirements{}, fmt.Errorf("resolve grader requirements: %w", err)
 		}
+		spec.requirements(grader, &requirements)
 	}
-	return requirements
+	return requirements, nil
 }
 
 func projectEnvelope(
@@ -390,28 +364,48 @@ func projectEnvelope(
 	requirements artifactRequirements,
 ) *EnvelopeObservation {
 	observation := &EnvelopeObservation{}
-	if requirements.envelopeOutcome {
-		observation.Outcome = envelope.Outcome
-	}
-	if requirements.envelopeError && envelope.Error != nil {
-		observation.Error = &EnvelopeErrorObservation{Code: boundedString(envelope.Error.Code, 4096)}
-	}
-	if requirements.envelopeModel || requirements.envelopeTurns || requirements.envelopeTools {
-		execution := &EnvelopeExecutionObservation{}
-		if envelope.Execution != nil {
-			if requirements.envelopeModel {
-				execution.Model = boundedString(envelope.Execution.Model, 4096)
-			}
-			if requirements.envelopeTurns {
-				execution.Turns = cloneInt32(envelope.Execution.Turns)
-			}
-			if requirements.envelopeTools {
-				execution.ToolCalls = cloneInt32(envelope.Execution.ToolCalls)
-			}
-		}
-		observation.Execution = execution
+	for _, projector := range requirements.envelopeProjectors {
+		projector(envelope, observation)
 	}
 	return observation
+}
+
+func projectEnvelopeOutcome(envelope resultv1alpha1.Envelope, observation *EnvelopeObservation) {
+	observation.Outcome = envelope.Outcome
+}
+
+func projectEnvelopeError(envelope resultv1alpha1.Envelope, observation *EnvelopeObservation) {
+	if envelope.Error != nil {
+		observation.Error = &EnvelopeErrorObservation{Code: boundedString(envelope.Error.Code, 4096)}
+	}
+}
+
+func projectEnvelopeModel(envelope resultv1alpha1.Envelope, observation *EnvelopeObservation) {
+	execution := ensureEnvelopeExecution(observation)
+	if envelope.Execution != nil {
+		execution.Model = boundedString(envelope.Execution.Model, 4096)
+	}
+}
+
+func projectEnvelopeTurns(envelope resultv1alpha1.Envelope, observation *EnvelopeObservation) {
+	execution := ensureEnvelopeExecution(observation)
+	if envelope.Execution != nil {
+		execution.Turns = cloneInt32(envelope.Execution.Turns)
+	}
+}
+
+func projectEnvelopeTools(envelope resultv1alpha1.Envelope, observation *EnvelopeObservation) {
+	execution := ensureEnvelopeExecution(observation)
+	if envelope.Execution != nil {
+		execution.ToolCalls = cloneInt32(envelope.Execution.ToolCalls)
+	}
+}
+
+func ensureEnvelopeExecution(observation *EnvelopeObservation) *EnvelopeExecutionObservation {
+	if observation.Execution == nil {
+		observation.Execution = &EnvelopeExecutionObservation{}
+	}
+	return observation.Execution
 }
 
 func cloneInt32(value *int32) *int32 {
@@ -431,15 +425,43 @@ func containsCollectionError(errors []string, fragment string) bool {
 	return false
 }
 
-func ambiguousCreateError(err error) bool {
-	return !apierrors.IsAlreadyExists(err) &&
-		!apierrors.IsBadRequest(err) &&
-		!apierrors.IsInvalid(err) &&
-		!apierrors.IsForbidden(err) &&
-		!apierrors.IsUnauthorized(err) &&
-		!apierrors.IsMethodNotSupported(err) &&
-		!apierrors.IsNotAcceptable(err) &&
-		!apierrors.IsUnsupportedMediaType(err)
+type kubernetesErrorClassification struct {
+	retryableRead  bool
+	ambiguousWrite bool
+}
+
+func classifyKubernetesError(err error) kubernetesErrorClassification {
+	if apierrors.IsAlreadyExists(err) ||
+		apierrors.IsBadRequest(err) ||
+		apierrors.IsInvalid(err) ||
+		apierrors.IsForbidden(err) ||
+		apierrors.IsUnauthorized(err) ||
+		apierrors.IsMethodNotSupported(err) ||
+		apierrors.IsNotAcceptable(err) ||
+		apierrors.IsUnsupportedMediaType(err) {
+		return kubernetesErrorClassification{}
+	}
+	if apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.ETIMEDOUT) {
+		return kubernetesErrorClassification{retryableRead: true, ambiguousWrite: true}
+	}
+	var urlError *url.Error
+	if errors.As(err, &urlError) {
+		return kubernetesErrorClassification{retryableRead: true, ambiguousWrite: true}
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) {
+		return kubernetesErrorClassification{retryableRead: true, ambiguousWrite: true}
+	}
+	return kubernetesErrorClassification{ambiguousWrite: true}
 }
 
 func (runner Runner) cleanupAmbiguousCreate(
@@ -449,34 +471,49 @@ func (runner Runner) cleanupAmbiguousCreate(
 ) []string {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), 300*time.Millisecond)
 	defer cancel()
-	backoff := 25 * time.Millisecond
 	var lastErr error
-	for {
+	deleteAttempted := false
+	err := clientretry.OnError(wait.Backoff{
+		Duration: 25 * time.Millisecond,
+		Factor:   2,
+		Steps:    8,
+		Cap:      200 * time.Millisecond,
+	}, func(err error) bool {
+		return ctx.Err() == nil &&
+			(apierrors.IsNotFound(err) || classifyKubernetesError(err).retryableRead)
+	}, func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		observed := &kontextv1alpha1.AgentRun{}
 		err := runner.Client.Get(ctx, key, observed)
+		if apierrors.IsNotFound(err) && deleteAttempted {
+			return nil
+		}
 		if err == nil {
 			if !hasExactEvaluatorOwnership(observed.Labels, expectedLabels) {
-				return []string{"ambiguous AgentRun exists without exact evaluator ownership; left untouched"}
+				return errors.New("ambiguous AgentRun exists without exact evaluator ownership; left untouched")
 			}
+			deleteAttempted = true
 			if err := runner.Client.Delete(ctx, observed); err != nil && !apierrors.IsNotFound(err) {
-				return []string{fmt.Sprintf("cleanup ambiguous AgentRun: %v", err)}
+				return fmt.Errorf("cleanup ambiguous AgentRun: %w", err)
 			}
 			return nil
 		}
 		lastErr = err
-		if !apierrors.IsNotFound(err) && !transientGetError(err) {
-			return []string{fmt.Sprintf("probe ambiguous AgentRun: %v", err)}
-		}
-		if err := waitBackoff(ctx, backoff); err != nil {
-			return []string{fmt.Sprintf("probe ambiguous AgentRun after create error: %v (last read: %v)", err, lastErr)}
-		}
-		if backoff < 200*time.Millisecond {
-			backoff *= 2
-			if backoff > 200*time.Millisecond {
-				backoff = 200 * time.Millisecond
-			}
-		}
+		return err
+	})
+	if err == nil {
+		return nil
 	}
+	if ctx.Err() != nil {
+		return []string{fmt.Sprintf(
+			"probe ambiguous AgentRun after create error: %v (last read: %v)",
+			ctx.Err(),
+			lastErr,
+		)}
+	}
+	return []string{err.Error()}
 }
 
 func hasExactEvaluatorOwnership(actual, expected map[string]string) bool {
@@ -563,62 +600,19 @@ func (runner Runner) getWithRetry(
 	key types.NamespacedName,
 	object client.Object,
 ) error {
-	backoff := 25 * time.Millisecond
-	for {
-		err := runner.Client.Get(ctx, key, object)
-		if err == nil || !transientGetError(err) {
+	return clientretry.OnError(wait.Backoff{
+		Duration: 25 * time.Millisecond,
+		Factor:   2,
+		Steps:    10_000,
+		Cap:      500 * time.Millisecond,
+	}, func(err error) bool {
+		return ctx.Err() == nil && classifyKubernetesError(err).retryableRead
+	}, func() error {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := waitBackoff(ctx, backoff); err != nil {
-			return err
-		}
-		if backoff < 500*time.Millisecond {
-			backoff *= 2
-			if backoff > 500*time.Millisecond {
-				backoff = 500 * time.Millisecond
-			}
-		}
-	}
-}
-
-func transientGetError(err error) bool {
-	if apierrors.IsForbidden(err) ||
-		apierrors.IsUnauthorized(err) ||
-		apierrors.IsInvalid(err) ||
-		apierrors.IsBadRequest(err) {
-		return false
-	}
-	if apierrors.IsTimeout(err) ||
-		apierrors.IsServerTimeout(err) ||
-		apierrors.IsTooManyRequests(err) ||
-		apierrors.IsServiceUnavailable(err) ||
-		apierrors.IsInternalError(err) {
-		return true
-	}
-	if errors.Is(err, io.ErrUnexpectedEOF) ||
-		errors.Is(err, syscall.ECONNRESET) ||
-		errors.Is(err, syscall.ECONNREFUSED) ||
-		errors.Is(err, syscall.ECONNABORTED) ||
-		errors.Is(err, syscall.ETIMEDOUT) {
-		return true
-	}
-	var urlError *url.Error
-	if errors.As(err, &urlError) {
-		return true
-	}
-	var networkError net.Error
-	return errors.As(err, &networkError)
-}
-
-func waitBackoff(ctx context.Context, duration time.Duration) error {
-	timer := time.NewTimer(duration)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
+		return runner.Client.Get(ctx, key, object)
+	})
 }
 
 func (runner Runner) waitForTerminal(
@@ -626,9 +620,6 @@ func (runner Runner) waitForTerminal(
 	key types.NamespacedName,
 ) (*kontextv1alpha1.AgentRun, error) {
 	interval := runner.Options.PollInterval
-	if interval <= 0 {
-		interval = 500 * time.Millisecond
-	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	var latest *kontextv1alpha1.AgentRun

--- a/internal/eval/runner_retry_test.go
+++ b/internal/eval/runner_retry_test.go
@@ -1,0 +1,207 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"syscall"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
+)
+
+func TestRunnerRetriesTransientAgentRunAndPodGets(t *testing.T) {
+	terminal := &terminalClient{Client: newFakeEvalClient(t)}
+	cluster := &sequencedGetClient{
+		Client: terminal,
+		agentErrors: []error{
+			&url.Error{Op: "GET", URL: "https://cluster", Err: io.ErrUnexpectedEOF},
+			syscall.ECONNRESET,
+			apierrors.NewServiceUnavailable("try again"),
+		},
+		podErrors: []error{apierrors.NewTooManyRequests("slow down", 0)},
+	}
+	timeout := Duration{Duration: time.Second}
+	suite := EvalSuite{
+		Metadata: Metadata{Name: "retry"},
+		Spec: SuiteSpec{
+			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
+			Cases: []Case{{
+				ID: "transient", Timeout: &timeout,
+				AgentRun: kontextv1alpha1.AgentRunSpec{
+					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+				},
+				Graders: []Grader{{
+					Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeSucceeded,
+				}},
+			}},
+		},
+	}
+	records := (Runner{
+		Client: cluster,
+		Options: RunnerOptions{
+			PollInterval: time.Millisecond,
+			InvocationID: "retry",
+		},
+	}).RunSuite(context.Background(), suite)
+	if len(records) != 1 || !records[0].Pass {
+		t.Fatalf("transient reads did not recover: %#v", records)
+	}
+	if cluster.agentGets < 4 || cluster.podGets < 2 || terminal.deletes != 1 {
+		t.Fatalf(
+			"transient reads were not retried before cleanup: agent=%d pod=%d deletes=%d",
+			cluster.agentGets,
+			cluster.podGets,
+			terminal.deletes,
+		)
+	}
+}
+
+func TestRunnerFailsPermanentGetImmediately(t *testing.T) {
+	terminal := &terminalClient{Client: newFakeEvalClient(t)}
+	cluster := &sequencedGetClient{
+		Client:      terminal,
+		agentErrors: []error{apierrors.NewBadRequest("invalid read")},
+	}
+	timeout := Duration{Duration: time.Second}
+	suite := EvalSuite{
+		Metadata: Metadata{Name: "permanent"},
+		Spec: SuiteSpec{
+			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
+			Cases: []Case{{
+				ID: "permanent", Timeout: &timeout,
+				AgentRun: kontextv1alpha1.AgentRunSpec{
+					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+				},
+				Graders: []Grader{{
+					Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+				}},
+			}},
+		},
+	}
+	records := (Runner{
+		Client: cluster,
+		Options: RunnerOptions{
+			PollInterval: time.Millisecond,
+			InvocationID: "permanent",
+		},
+	}).RunSuite(context.Background(), suite)
+	if len(records) != 1 || records[0].Pass || cluster.agentGets != 1 {
+		t.Fatalf("permanent read was not failed immediately: records=%#v gets=%d", records, cluster.agentGets)
+	}
+}
+
+func TestKubernetesErrorClassification(t *testing.T) {
+	resource := schema.GroupResource{Group: "kontext.dev", Resource: "agentruns"}
+	for name, err := range map[string]error{
+		"timeout":             apierrors.NewTimeoutError("timeout", 1),
+		"server timeout":      apierrors.NewServerTimeout(resource, "get", 1),
+		"too many requests":   apierrors.NewTooManyRequests("limited", 1),
+		"service unavailable": apierrors.NewServiceUnavailable("down"),
+		"internal":            apierrors.NewInternalError(errors.New("temporary")),
+		"url timeout": &url.Error{
+			Op: "GET", URL: "https://cluster", Err: io.ErrUnexpectedEOF,
+		},
+		"connection reset":   syscall.ECONNRESET,
+		"connection refused": syscall.ECONNREFUSED,
+	} {
+		t.Run(name, func(t *testing.T) {
+			classification := classifyKubernetesError(err)
+			if !classification.retryableRead || !classification.ambiguousWrite {
+				t.Fatalf("error was not classified transient: %v", err)
+			}
+		})
+	}
+	if classification := classifyKubernetesError(apierrors.NewBadRequest("permanent")); classification.retryableRead ||
+		classification.ambiguousWrite {
+		t.Fatal("permanent error was classified transient")
+	}
+	if classification := classifyKubernetesError(apierrors.NewUnauthorized("permanent")); classification.retryableRead ||
+		classification.ambiguousWrite {
+		t.Fatal("unauthorized error was classified transient")
+	}
+	unknown := classifyKubernetesError(errors.New("write result unknown"))
+	if unknown.retryableRead || !unknown.ambiguousWrite {
+		t.Fatalf("unknown error classification was unsafe: %#v", unknown)
+	}
+}
+
+func TestCaseTimeoutCoversCreateWaitPodLogsAndJudge(t *testing.T) {
+	timeout := 40 * time.Millisecond
+	tests := map[string]func(*testing.T) (client.Client, LogFetcher, Judge, []Grader){
+		"create": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			return &blockingCreateClient{Client: newFakeEvalClient(t)}, nil, nil, []Grader{{
+				Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+			}}
+		},
+		"wait": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			return newFakeEvalClient(t), nil, nil, []Grader{{
+				Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+			}}
+		},
+		"pod": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			terminal := &terminalClient{Client: newFakeEvalClient(t)}
+			return &blockingPodGetClient{Client: terminal}, nil, nil, []Grader{{
+				Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeSucceeded,
+			}}
+		},
+		"logs": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			return &terminalClient{Client: newFakeEvalClient(t)}, blockingLogs{}, nil, []Grader{{
+				Type: GraderEventCount,
+				Event: &EventCountExpectation{
+					Type: eventv1alpha1.TypeTool, Count: 0,
+				},
+			}}
+		},
+		"judge": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
+			return &terminalClient{Client: newFakeEvalClient(t)}, nil, blockingJudge{}, []Grader{{
+				Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
+			}}
+		},
+	}
+	for name, setup := range tests {
+		t.Run(name, func(t *testing.T) {
+			cluster, logs, judge, graders := setup(t)
+			duration := Duration{Duration: timeout}
+			suite := EvalSuite{
+				Metadata: Metadata{Name: "timeout"},
+				Spec: SuiteSpec{
+					Defaults: SuiteDefaults{Namespace: "evals", Timeout: &duration},
+					Cases: []Case{{
+						ID: "case", Timeout: &duration,
+						AgentRun: kontextv1alpha1.AgentRunSpec{
+							Goal: "goal", Model: "model",
+							Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
+						},
+						Graders: graders,
+					}},
+				},
+			}
+			startedAt := time.Now()
+			records := (Runner{
+				Client: cluster,
+				Logs:   logs,
+				Options: RunnerOptions{
+					PollInterval: time.Millisecond,
+					InvocationID: name,
+					Judge:        judge,
+				},
+			}).RunSuite(context.Background(), suite)
+			if elapsed := time.Since(startedAt); elapsed > time.Second {
+				t.Fatalf("case timeout did not bound %s stage: %s", name, elapsed)
+			}
+			if len(records) != 1 || records[0].Pass ||
+				!containsCollectionError(records[0].CollectionErrors, context.DeadlineExceeded.Error()) {
+				t.Fatalf("%s stage did not fail on case timeout: %#v", name, records)
+			}
+		})
+	}
+}

--- a/internal/eval/runner_test.go
+++ b/internal/eval/runner_test.go
@@ -6,18 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"net/url"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
@@ -306,10 +302,12 @@ func TestEnvelopeGradersUseTerminationMessageWithoutLogs(t *testing.T) {
 		{Type: GraderEnvelopeTurns, Turns: &turns},
 		{Type: GraderEnvelopeTools, ToolCalls: &tools},
 	}}
+	requirements := mustArtifactRequirements(t, item.Graders)
 	finished := (Runner{Logs: logs}).finishRecord(
 		context.Background(),
 		&record,
 		item,
+		requirements,
 		nil,
 		pod,
 		false,
@@ -348,10 +346,12 @@ func TestEventGradersFailTransportAndTruncationErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			record := Record{StartedAt: time.Unix(0, 0)}
 			judge := &orderingJudge{t: t}
+			requirements := mustArtifactRequirements(t, item.Graders)
 			finished := (Runner{Logs: logs, Options: RunnerOptions{Judge: judge}}).finishRecord(
 				context.Background(),
 				&record,
 				item,
+				requirements,
 				nil,
 				pod,
 				false,
@@ -388,10 +388,12 @@ func TestCleanupUsesFreshContextAfterCancellation(t *testing.T) {
 	item := Case{Graders: []Grader{{
 		Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
 	}}}
+	requirements := mustArtifactRequirements(t, item.Graders)
 	finished := (Runner{Client: cluster}).finishRecord(
 		ctx,
 		&record,
 		item,
+		requirements,
 		run,
 		nil,
 		true,
@@ -457,195 +459,6 @@ func TestKubernetesLogFetcherSetsServerBoundsAndReportsIncompleteTail(t *testing
 	}
 }
 
-func TestRunnerRetriesTransientAgentRunAndPodGets(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = kontextv1alpha1.AddToScheme(scheme)
-	base := fake.NewClientBuilder().WithScheme(scheme).Build()
-	terminal := &terminalClient{Client: base}
-	cluster := &sequencedGetClient{
-		Client: terminal,
-		agentErrors: []error{
-			&url.Error{Op: "GET", URL: "https://cluster", Err: io.ErrUnexpectedEOF},
-			syscall.ECONNRESET,
-			apierrors.NewServiceUnavailable("try again"),
-		},
-		podErrors: []error{apierrors.NewTooManyRequests("slow down", 0)},
-	}
-	timeout := Duration{Duration: time.Second}
-	suite := EvalSuite{
-		Metadata: Metadata{Name: "retry"},
-		Spec: SuiteSpec{
-			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
-			Cases: []Case{{
-				ID: "transient", Timeout: &timeout,
-				AgentRun: kontextv1alpha1.AgentRunSpec{
-					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
-				},
-				Graders: []Grader{{
-					Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeSucceeded,
-				}},
-			}},
-		},
-	}
-	records := (Runner{
-		Client: cluster,
-		Options: RunnerOptions{
-			PollInterval: time.Millisecond,
-			InvocationID: "retry",
-		},
-	}).RunSuite(context.Background(), suite)
-	if len(records) != 1 || !records[0].Pass {
-		t.Fatalf("transient reads did not recover: %#v", records)
-	}
-	if cluster.agentGets < 4 || cluster.podGets < 2 || terminal.deletes != 1 {
-		t.Fatalf(
-			"transient reads were not retried before cleanup: agent=%d pod=%d deletes=%d",
-			cluster.agentGets,
-			cluster.podGets,
-			terminal.deletes,
-		)
-	}
-}
-
-func TestRunnerFailsPermanentGetImmediately(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = kontextv1alpha1.AddToScheme(scheme)
-	base := fake.NewClientBuilder().WithScheme(scheme).Build()
-	terminal := &terminalClient{Client: base}
-	cluster := &sequencedGetClient{
-		Client:      terminal,
-		agentErrors: []error{apierrors.NewBadRequest("invalid read")},
-	}
-	timeout := Duration{Duration: time.Second}
-	suite := EvalSuite{
-		Metadata: Metadata{Name: "permanent"},
-		Spec: SuiteSpec{
-			Defaults: SuiteDefaults{Namespace: "evals", Timeout: &timeout},
-			Cases: []Case{{
-				ID: "permanent", Timeout: &timeout,
-				AgentRun: kontextv1alpha1.AgentRunSpec{
-					Goal: "goal", Model: "model", Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
-				},
-				Graders: []Grader{{
-					Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
-				}},
-			}},
-		},
-	}
-	records := (Runner{
-		Client: cluster,
-		Options: RunnerOptions{
-			PollInterval: time.Millisecond,
-			InvocationID: "permanent",
-		},
-	}).RunSuite(context.Background(), suite)
-	if len(records) != 1 || records[0].Pass || cluster.agentGets != 1 {
-		t.Fatalf("permanent read was not failed immediately: records=%#v gets=%d", records, cluster.agentGets)
-	}
-}
-
-func TestTransientGetErrorClassification(t *testing.T) {
-	resource := schema.GroupResource{Group: "kontext.dev", Resource: "agentruns"}
-	for name, err := range map[string]error{
-		"timeout":             apierrors.NewTimeoutError("timeout", 1),
-		"server timeout":      apierrors.NewServerTimeout(resource, "get", 1),
-		"too many requests":   apierrors.NewTooManyRequests("limited", 1),
-		"service unavailable": apierrors.NewServiceUnavailable("down"),
-		"internal":            apierrors.NewInternalError(errors.New("temporary")),
-		"url timeout": &url.Error{
-			Op: "GET", URL: "https://cluster", Err: io.ErrUnexpectedEOF,
-		},
-		"connection reset":   syscall.ECONNRESET,
-		"connection refused": syscall.ECONNREFUSED,
-	} {
-		t.Run(name, func(t *testing.T) {
-			if !transientGetError(err) {
-				t.Fatalf("error was not classified transient: %v", err)
-			}
-		})
-	}
-	if transientGetError(apierrors.NewBadRequest("permanent")) {
-		t.Fatal("permanent error was classified transient")
-	}
-	if transientGetError(apierrors.NewUnauthorized("permanent")) {
-		t.Fatal("unauthorized error was classified transient")
-	}
-}
-
-func TestCaseTimeoutCoversCreateWaitPodLogsAndJudge(t *testing.T) {
-	timeout := 40 * time.Millisecond
-	tests := map[string]func(*testing.T) (client.Client, LogFetcher, Judge, []Grader){
-		"create": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
-			return &blockingCreateClient{Client: newFakeEvalClient(t)}, nil, nil, []Grader{{
-				Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
-			}}
-		},
-		"wait": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
-			return newFakeEvalClient(t), nil, nil, []Grader{{
-				Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
-			}}
-		},
-		"pod": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
-			terminal := &terminalClient{Client: newFakeEvalClient(t)}
-			return &blockingPodGetClient{Client: terminal}, nil, nil, []Grader{{
-				Type: GraderEnvelopeOutcome, Outcome: resultv1alpha1.OutcomeSucceeded,
-			}}
-		},
-		"logs": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
-			return &terminalClient{Client: newFakeEvalClient(t)}, blockingLogs{}, nil, []Grader{{
-				Type: GraderEventCount,
-				Event: &EventCountExpectation{
-					Type: eventv1alpha1.TypeTool, Count: 0,
-				},
-			}}
-		},
-		"judge": func(t *testing.T) (client.Client, LogFetcher, Judge, []Grader) {
-			return &terminalClient{Client: newFakeEvalClient(t)}, nil, blockingJudge{}, []Grader{{
-				Type: GraderTerminalPhase, Phase: kontextv1alpha1.AgentRunPhaseSucceeded,
-			}}
-		},
-	}
-	for name, setup := range tests {
-		t.Run(name, func(t *testing.T) {
-			cluster, logs, judge, graders := setup(t)
-			duration := Duration{Duration: timeout}
-			suite := EvalSuite{
-				Metadata: Metadata{Name: "timeout"},
-				Spec: SuiteSpec{
-					Defaults: SuiteDefaults{Namespace: "evals", Timeout: &duration},
-					Cases: []Case{{
-						ID: "case", Timeout: &duration,
-						AgentRun: kontextv1alpha1.AgentRunSpec{
-							Goal: "goal", Model: "model",
-							Runtime: kontextv1alpha1.RuntimeSpec{Image: "runtime"},
-						},
-						Graders: graders,
-					}},
-				},
-			}
-			startedAt := time.Now()
-			records := (Runner{
-				Client: cluster,
-				Logs:   logs,
-				Options: RunnerOptions{
-					PollInterval: time.Millisecond,
-					InvocationID: name,
-					Judge:        judge,
-				},
-			}).RunSuite(context.Background(), suite)
-			if elapsed := time.Since(startedAt); elapsed > time.Second {
-				t.Fatalf("case timeout did not bound %s stage: %s", name, elapsed)
-			}
-			if len(records) != 1 || records[0].Pass ||
-				!containsCollectionError(records[0].CollectionErrors, context.DeadlineExceeded.Error()) {
-				t.Fatalf("%s stage did not fail on case timeout: %#v", name, records)
-			}
-		})
-	}
-}
-
 func TestFinishRecordAllowsStatusOnlyResultWithoutPodArtifacts(t *testing.T) {
 	timeout := Duration{Duration: time.Second}
 	item := Case{
@@ -661,11 +474,13 @@ func TestFinishRecordAllowsStatusOnlyResultWithoutPodArtifacts(t *testing.T) {
 		TerminalPhase: kontextv1alpha1.AgentRunPhaseBudgetExceeded,
 	}
 	now := func() time.Time { return time.Unix(1, 0) }
+	requirements := mustArtifactRequirements(t, item.Graders)
 
 	finished := (Runner{}).finishRecord(
 		context.Background(),
 		&record,
 		item,
+		requirements,
 		nil,
 		nil,
 		false,
@@ -695,7 +510,7 @@ func TestFinishRecordFailsWhenGraderRequiredArtifactIsMissing(t *testing.T) {
 	}
 	for name, grader := range cases {
 		t.Run(name, func(t *testing.T) {
-			requirements := requirementsForGraders([]Grader{grader})
+			requirements := mustArtifactRequirements(t, []Grader{grader})
 			if !requirements.pod {
 				t.Fatal("artifact grader did not require a Pod")
 			}
@@ -712,6 +527,7 @@ func TestFinishRecordFailsWhenGraderRequiredArtifactIsMissing(t *testing.T) {
 				context.Background(),
 				&record,
 				item,
+				requirements,
 				nil,
 				nil,
 				false,
@@ -722,324 +538,4 @@ func TestFinishRecordFailsWhenGraderRequiredArtifactIsMissing(t *testing.T) {
 			}
 		})
 	}
-}
-
-type terminalClient struct {
-	client.Client
-	deletes int
-	podGets int
-	phase   kontextv1alpha1.AgentRunPhase
-	message string
-}
-
-func (cluster *terminalClient) Create(ctx context.Context, object client.Object, options ...client.CreateOption) error {
-	if err := cluster.Client.Create(ctx, object, options...); err != nil {
-		return err
-	}
-	run, ok := object.(*kontextv1alpha1.AgentRun)
-	if !ok {
-		return nil
-	}
-	exitCode := int32(0)
-	pod := &corev1.Pod{}
-	pod.Namespace = run.Namespace
-	pod.Name = "pod-" + run.Name
-	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
-		Name: "runtime",
-		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
-			ExitCode: exitCode,
-		}},
-	}}
-	return cluster.Client.Create(ctx, pod)
-}
-
-func (cluster *terminalClient) Get(ctx context.Context, key types.NamespacedName, object client.Object, options ...client.GetOption) error {
-	if err := cluster.Client.Get(ctx, key, object, options...); err != nil {
-		return err
-	}
-	if run, ok := object.(*kontextv1alpha1.AgentRun); ok {
-		phase := cluster.phase
-		if phase == "" {
-			phase = kontextv1alpha1.AgentRunPhaseSucceeded
-		}
-		run.Status.Phase = phase
-		run.Status.Message = cluster.message
-		if run.Status.Message == "" {
-			run.Status.Message = "successful status message"
-		}
-		run.Status.PodName = "pod-" + run.Name
-		run.Status.Result = "sensitive model output"
-		value := int64(7)
-		run.Status.Usage = &kontextv1alpha1.UsageStatus{Tokens: &value}
-		run.Status.Output = &kontextv1alpha1.OutputStatus{
-			MediaType: "text/plain",
-			Value:     runtime.RawExtension{Raw: []byte(`"sensitive model output"`)},
-		}
-	}
-	if pod, ok := object.(*corev1.Pod); ok {
-		cluster.podGets++
-		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
-			Name: "runtime",
-			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
-				ExitCode: 0,
-				Message:  successfulEnvelopeMessage(),
-			}},
-		}}
-	}
-	return nil
-}
-
-func (cluster *terminalClient) Delete(ctx context.Context, object client.Object, options ...client.DeleteOption) error {
-	cluster.deletes++
-	return cluster.Client.Delete(ctx, object, options...)
-}
-
-type createFailClient struct {
-	client.Client
-	deletes int
-}
-
-func (cluster *createFailClient) Create(context.Context, client.Object, ...client.CreateOption) error {
-	return apierrors.NewForbidden(
-		schema.GroupResource{Group: "kontext.dev", Resource: "agentruns"},
-		"case",
-		errors.New("forbidden"),
-	)
-}
-
-func (cluster *createFailClient) Delete(context.Context, client.Object, ...client.DeleteOption) error {
-	cluster.deletes++
-	return nil
-}
-
-type staticLogs struct {
-	data      []byte
-	err       error
-	truncated bool
-	calls     int
-}
-
-func (logs *staticLogs) Fetch(context.Context, string, string, string) (LogCollection, error) {
-	logs.calls++
-	return LogCollection{
-		Data:      append([]byte(nil), logs.data...),
-		Truncated: logs.truncated,
-	}, logs.err
-}
-
-type orderingJudge struct {
-	t      *testing.T
-	called bool
-}
-
-func (judge *orderingJudge) Evaluate(_ context.Context, observation JudgeObservation) (JudgeResult, error) {
-	judge.called = true
-	if len(observation.Grades) == 0 {
-		judge.t.Fatal("judge ran before deterministic graders")
-	}
-	return JudgeResult{Configured: true, Pass: true, Score: 1, Rationale: "ok"}, nil
-}
-
-func successfulLogs(t *testing.T) []byte {
-	t.Helper()
-	var logs bytes.Buffer
-	logs.WriteString(`{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-19T00:00:00Z","type":"lifecycle","data":{"phase":"started"}}` + "\n")
-	return logs.Bytes()
-}
-
-func successfulEnvelopeMessage() string {
-	output, _ := json.Marshal("private output")
-	extension, _ := json.Marshal("secret-extension")
-	turns := int32(2)
-	tools := int32(1)
-	envelope := resultv1alpha1.Envelope{
-		APIVersion: resultv1alpha1.APIVersion,
-		Outcome:    resultv1alpha1.OutcomeSucceeded,
-		Output: &resultv1alpha1.Output{
-			MediaType: "text/plain",
-			Value:     output,
-		},
-		Execution: &resultv1alpha1.Execution{
-			Provider:  "private-provider",
-			Model:     "model",
-			RequestID: "request-secret",
-			Turns:     &turns,
-			ToolCalls: &tools,
-		},
-		Artifacts: []resultv1alpha1.Artifact{{
-			Name: "artifact-secret", URI: "memory://artifact",
-		}},
-		Extensions: map[string]json.RawMessage{
-			"example.com/private": extension,
-		},
-	}
-	encoded, err := json.Marshal(envelope)
-	if err != nil {
-		panic(err)
-	}
-	return string(encoded)
-}
-
-func int32Pointer(value int32) *int32 {
-	return &value
-}
-
-type cleanupContextClient struct {
-	client.Client
-	deletes          int
-	deleteContextErr error
-	hadDeadline      bool
-}
-
-func (cluster *cleanupContextClient) Delete(
-	ctx context.Context,
-	object client.Object,
-	options ...client.DeleteOption,
-) error {
-	cluster.deletes++
-	cluster.deleteContextErr = ctx.Err()
-	_, cluster.hadDeadline = ctx.Deadline()
-	return cluster.Client.Delete(ctx, object, options...)
-}
-
-type sequencedGetClient struct {
-	client.Client
-	agentErrors []error
-	podErrors   []error
-	agentGets   int
-	podGets     int
-}
-
-func (cluster *sequencedGetClient) Get(
-	ctx context.Context,
-	key types.NamespacedName,
-	object client.Object,
-	options ...client.GetOption,
-) error {
-	switch object.(type) {
-	case *kontextv1alpha1.AgentRun:
-		cluster.agentGets++
-		if len(cluster.agentErrors) > 0 {
-			err := cluster.agentErrors[0]
-			cluster.agentErrors = cluster.agentErrors[1:]
-			return err
-		}
-	case *corev1.Pod:
-		cluster.podGets++
-		if len(cluster.podErrors) > 0 {
-			err := cluster.podErrors[0]
-			cluster.podErrors = cluster.podErrors[1:]
-			return err
-		}
-	}
-	return cluster.Client.Get(ctx, key, object, options...)
-}
-
-func newFakeEvalClient(t *testing.T) client.Client {
-	t.Helper()
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := kontextv1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	return fake.NewClientBuilder().WithScheme(scheme).Build()
-}
-
-type blockingCreateClient struct {
-	client.Client
-}
-
-func (cluster *blockingCreateClient) Create(
-	ctx context.Context,
-	_ client.Object,
-	_ ...client.CreateOption,
-) error {
-	<-ctx.Done()
-	return ctx.Err()
-}
-
-type blockingPodGetClient struct {
-	client.Client
-}
-
-func (cluster *blockingPodGetClient) Get(
-	ctx context.Context,
-	key types.NamespacedName,
-	object client.Object,
-	options ...client.GetOption,
-) error {
-	if _, ok := object.(*corev1.Pod); ok {
-		<-ctx.Done()
-		return ctx.Err()
-	}
-	return cluster.Client.Get(ctx, key, object, options...)
-}
-
-type blockingLogs struct{}
-
-func (blockingLogs) Fetch(
-	ctx context.Context,
-	_, _, _ string,
-) (LogCollection, error) {
-	<-ctx.Done()
-	return LogCollection{}, ctx.Err()
-}
-
-type blockingJudge struct{}
-
-func (blockingJudge) Evaluate(
-	ctx context.Context,
-	_ JudgeObservation,
-) (JudgeResult, error) {
-	<-ctx.Done()
-	return JudgeResult{}, ctx.Err()
-}
-
-type ambiguousCreateClient struct {
-	client.Client
-	unowned            bool
-	probeNotFoundCount int
-	deletes            int
-}
-
-func (cluster *ambiguousCreateClient) Create(
-	ctx context.Context,
-	object client.Object,
-	_ ...client.CreateOption,
-) error {
-	run := object.(*kontextv1alpha1.AgentRun).DeepCopy()
-	if cluster.unowned {
-		run.Labels = map[string]string{"owner": "user"}
-	}
-	if err := cluster.Client.Create(ctx, run); err != nil {
-		return err
-	}
-	return apierrors.NewTimeoutError("create response lost", 0)
-}
-
-func (cluster *ambiguousCreateClient) Get(
-	ctx context.Context,
-	key types.NamespacedName,
-	object client.Object,
-	options ...client.GetOption,
-) error {
-	if _, ok := object.(*kontextv1alpha1.AgentRun); ok && cluster.probeNotFoundCount > 0 {
-		cluster.probeNotFoundCount--
-		return apierrors.NewNotFound(
-			schema.GroupResource{Group: "kontext.dev", Resource: "agentruns"},
-			key.Name,
-		)
-	}
-	return cluster.Client.Get(ctx, key, object, options...)
-}
-
-func (cluster *ambiguousCreateClient) Delete(
-	ctx context.Context,
-	object client.Object,
-	options ...client.DeleteOption,
-) error {
-	cluster.deletes++
-	return cluster.Client.Delete(ctx, object, options...)
 }

--- a/internal/eval/suite.go
+++ b/internal/eval/suite.go
@@ -13,10 +13,6 @@ import (
 	"time"
 
 	"sigs.k8s.io/yaml"
-
-	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
-	eventv1alpha1 "github.com/MFS-code/Kontext/pkg/event/v1alpha1"
-	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
 
 const defaultTimeout = 5 * time.Minute
@@ -116,127 +112,6 @@ func prepareSuite(suite *EvalSuite, runtimeImageOverride string) error {
 				return fmt.Errorf("case %q grader %d: %w", item.ID, graderIndex, err)
 			}
 		}
-	}
-	return nil
-}
-
-func validateGrader(grader Grader) error {
-	switch grader.Type {
-	case GraderTerminalPhase:
-		switch grader.Phase {
-		case kontextv1alpha1.AgentRunPhaseSucceeded,
-			kontextv1alpha1.AgentRunPhaseFailed,
-			kontextv1alpha1.AgentRunPhaseBudgetExceeded:
-		default:
-			return fmt.Errorf("invalid terminal phase %q", grader.Phase)
-		}
-	case GraderStatusResult:
-		if grader.StatusResult == nil {
-			return errors.New("statusResult expectation is required")
-		}
-		count := 0
-		if grader.StatusResult.Exact != nil {
-			count++
-		}
-		if grader.StatusResult.Contains != nil {
-			count++
-		}
-		if grader.StatusResult.NotContains != nil {
-			count++
-		}
-		if count != 1 {
-			return errors.New("statusResult requires exactly one of exact, contains, or notContains")
-		}
-		if grader.StatusResult.Contains != nil && *grader.StatusResult.Contains == "" {
-			return errors.New("statusResult.contains must not be empty")
-		}
-		if grader.StatusResult.NotContains != nil && *grader.StatusResult.NotContains == "" {
-			return errors.New("statusResult.notContains must not be empty")
-		}
-	case GraderStructuredOutput:
-		if grader.StructuredOutput == nil {
-			return errors.New("structuredOutput expectation is required")
-		}
-		if grader.StructuredOutput.Present == nil &&
-			grader.StructuredOutput.Valid == nil &&
-			strings.TrimSpace(grader.StructuredOutput.MediaType) == "" {
-			return errors.New("structuredOutput requires present, valid, or mediaType")
-		}
-		if grader.StructuredOutput.MediaType != "" &&
-			strings.TrimSpace(grader.StructuredOutput.MediaType) == "" {
-			return errors.New("structuredOutput.mediaType must not be blank")
-		}
-	case GraderUsageFields:
-		if len(grader.UsageFields) == 0 {
-			return errors.New("usageFields must not be empty")
-		}
-		seenFields := make(map[string]struct{}, len(grader.UsageFields))
-		for _, field := range grader.UsageFields {
-			switch field {
-			case "tokens", "inputTokens", "outputTokens", "dollars":
-			default:
-				return fmt.Errorf("invalid usage field %q", field)
-			}
-			if _, exists := seenFields[field]; exists {
-				return fmt.Errorf("duplicate usage field %q", field)
-			}
-			seenFields[field] = struct{}{}
-		}
-	case GraderEnvelopeError:
-		if strings.TrimSpace(grader.ErrorCode) == "" {
-			return errors.New("errorCode is required")
-		}
-	case GraderEnvelopeOutcome:
-		switch grader.Outcome {
-		case resultv1alpha1.OutcomeSucceeded, resultv1alpha1.OutcomeFailed:
-		default:
-			return fmt.Errorf("invalid envelope outcome %q", grader.Outcome)
-		}
-	case GraderExecutionModel:
-		if strings.TrimSpace(grader.Model) == "" {
-			return errors.New("model is required")
-		}
-	case GraderEnvelopeTurns:
-		if grader.Turns == nil || *grader.Turns < 0 {
-			return errors.New("turns must be a non-negative integer")
-		}
-	case GraderEnvelopeTools:
-		if grader.ToolCalls == nil || *grader.ToolCalls < 0 {
-			return errors.New("toolCalls must be a non-negative integer")
-		}
-	case GraderEventCount:
-		if grader.Event == nil || grader.Event.Count < 0 {
-			return errors.New("event with non-negative count is required")
-		}
-		switch grader.Event.Type {
-		case eventv1alpha1.TypeLifecycle, eventv1alpha1.TypeOutput, eventv1alpha1.TypeUsage,
-			eventv1alpha1.TypeTool, eventv1alpha1.TypeError:
-		default:
-			return fmt.Errorf("invalid event type %q", grader.Event.Type)
-		}
-	case GraderToolEvents:
-		if grader.Tool == nil {
-			return errors.New("tool expectation is required")
-		}
-		if strings.TrimSpace(grader.Tool.Name) == "" {
-			return errors.New("tool.name is required")
-		}
-		if grader.Tool.Count < 0 {
-			return errors.New("tool.count must be non-negative")
-		}
-		if grader.Tool.ErrorCode != "" && strings.TrimSpace(grader.Tool.ErrorCode) == "" {
-			return errors.New("tool.errorCode must not be blank")
-		}
-	case GraderDuration:
-		if grader.MaxDuration.Duration <= 0 {
-			return errors.New("maxDuration must be greater than zero")
-		}
-	case GraderPodExitCode:
-		if grader.ExitCode == nil {
-			return errors.New("exitCode is required")
-		}
-	default:
-		return fmt.Errorf("unsupported grader type %q", grader.Type)
 	}
 	return nil
 }

--- a/internal/eval/suite_test.go
+++ b/internal/eval/suite_test.go
@@ -184,6 +184,57 @@ func TestValidateGraderRejectsVacuousExpectations(t *testing.T) {
 	}
 }
 
+func TestValidateStructuredOutputGraderBranches(t *testing.T) {
+	present := true
+	valid := true
+	tests := map[string]struct {
+		expectation *StructuredOutputExpectation
+		wantError   string
+	}{
+		"missing expectation": {
+			wantError: "structuredOutput expectation is required",
+		},
+		"empty expectation": {
+			expectation: &StructuredOutputExpectation{},
+			wantError:   "structuredOutput requires present, valid, or mediaType",
+		},
+		"blank media type only": {
+			expectation: &StructuredOutputExpectation{MediaType: " \t "},
+			wantError:   "structuredOutput.mediaType must not be blank",
+		},
+		"blank media type with present": {
+			expectation: &StructuredOutputExpectation{Present: &present, MediaType: " \t "},
+			wantError:   "structuredOutput.mediaType must not be blank",
+		},
+		"present only": {
+			expectation: &StructuredOutputExpectation{Present: &present},
+		},
+		"valid only": {
+			expectation: &StructuredOutputExpectation{Valid: &valid},
+		},
+		"media type only": {
+			expectation: &StructuredOutputExpectation{MediaType: "application/json"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateStructuredOutputGrader(Grader{
+				Type:             GraderStructuredOutput,
+				StructuredOutput: test.expectation,
+			})
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("valid expectation was rejected: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("validation error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+}
+
 func TestNameForCaseIsStableDNSSafeAndBounded(t *testing.T) {
 	first := NameForCase("Suite_Name", "CASE with spaces", strings.Repeat("x", 100))
 	second := NameForCase("Suite_Name", "CASE with spaces", strings.Repeat("x", 100))

--- a/internal/eval/types.go
+++ b/internal/eval/types.go
@@ -178,7 +178,7 @@ type Grade struct {
 
 type JudgeResult struct {
 	Configured bool    `json:"configured"`
-	Pass       bool    `json:"pass,omitempty"`
+	Pass       bool    `json:"pass"`
 	Score      float64 `json:"score,omitempty"`
 	Rationale  string  `json:"rationale,omitempty"`
 	Error      string  `json:"error,omitempty"`


### PR DESCRIPTION
## Summary
- centralize validation, artifact requirements, envelope projection, and grading in one spec per grader type
- parse typed event payloads once while preserving strict event envelopes and actionable malformed-frame errors
- normalize runner behavior, consolidate retry classification, preserve cleanup safety, and split runner tests

## Tests
- `gofmt -w internal/eval`
- `make verify`
- `make test`
- `go test ./internal/eval/... -count=1`

Closes #62