### PR TITLE
Publish release-ready docs with syntax highlighting

### DIFF
--- a/EVALS.md
+++ b/EVALS.md
@@ -100,7 +100,7 @@ Missing or incomplete required artifacts fail the case.
 kind cluster, validates the records, checks controller timeout cleanup, and
 separately proves the no-wallclock Service example remains Running and
 recasts. See [`docs/evals.md`](docs/evals.md) for comparison guidance,
-privacy boundaries, and the protected pre-alpha provider acceptance step.
+privacy boundaries, and protected provider acceptance for releases.
 
 ## Optional judge
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Kubernetes-native control plane for running, governing, and observing AI agent
 
 The thesis: **agents are workloads.** An agent should not live in a screen session or behind a bespoke orchestration service. It should be a resource your cluster understands — created with `kubectl apply`, observed with `kubectl logs -f`, governed by RBAC, budgets, and owner references, and restarted by a controller when it dies.
 
-Public surfaces (after DNS is wired):
+Public sites:
 
 - Marketing site: [kontext.run](https://kontext.run)
 - Docs: [docs.kontext.run](https://docs.kontext.run)
@@ -25,8 +25,8 @@ Kontext adds two custom resources under `kontext.dev/v1alpha1`, deliberately mir
 | Kontext | Kubernetes analogue | Behavior |
 |---|---|---|
 | `Agent` (mode `Service`) | `Deployment` | Always-on. The controller keeps one live `AgentRun` and re-casts it with backoff when it exits. |
-| `Agent` (mode `Task`) | reusable template | A definition that mints an `AgentRun` per invocation. *(Schema present; controller support planned.)* |
-| `Agent` (mode `Scheduled`) | `CronJob` | Mints runs on a cron schedule. *(Schema present; controller support not yet planned.)* |
+| `Agent` (mode `Task`) | reusable template | Schema available; the controller reports `UnsupportedMode`. Create a standalone `AgentRun` for one-shot work. |
+| `Agent` (mode `Scheduled`) | `CronJob` | Schema available; the controller reports `UnsupportedMode` and does not schedule runs. |
 | `AgentRun` | `Job` / `Pod` | One bounded execution. Owns exactly one Pod, holds the immutable spec snapshot, the final `.status.result`, and usage. |
 
 An `AgentRun` can also be created standalone, without any owning `Agent` — useful for ad-hoc dispatch and demos.
@@ -42,9 +42,8 @@ backward-compatible text projection. The full versioned contract is in
 ## Install a tagged release
 
 An existing Kubernetes cluster needs only kubectl and permission to create
-CRDs, cluster-scoped RBAC, a Namespace, and a Deployment. The install URL
-requires a matching [GitHub release](https://github.com/MFS-code/Kontext/releases);
-until the first alpha tag is published, use [Quickstart on kind](#quickstart-on-kind).
+CRDs, cluster-scoped RBAC, a Namespace, and a Deployment. Install the published
+`v0.1.0-alpha.1` release directly from GitHub:
 
 ```bash
 VERSION=v0.1.0-alpha.1
@@ -265,11 +264,12 @@ scripts/                   kind install + e2e
 
 ## Status
 
-`v1alpha1` is alpha on purpose: the API shape is allowed to evolve. `Service` mode and standalone `AgentRun`s are implemented and covered by envtest and kind e2e; `Task` and `Scheduled` modes exist in the schema but are not reconciled yet.
-
-No public alpha tag has been published yet. The release workflow publishes and
-verifies versioned images and installation artifacts when a version tag is
-pushed from `main`.
+The current public release is `v0.1.0-alpha.1`. Its GitHub release contains
+the digest-pinned install manifest and versioned multi-architecture images.
+`v1alpha1` is alpha on purpose: the API shape is allowed to evolve. `Service`
+mode and standalone `AgentRun`s are implemented and covered by envtest and
+kind e2e; `Task` and `Scheduled` modes exist in the schema but are not
+reconciled.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,11 +5,9 @@ and should not be treated as a hardened multi-tenant sandbox.
 
 ## Supported versions
 
-Before the first public release, `main` is development code and no version is
-supported for production use. After publication, security fixes target the
-latest alpha release. Older alpha releases may not receive patches.
-
-The support policy will become stricter when the API leaves alpha.
+Security fixes target the latest published alpha release, currently
+`v0.1.0-alpha.1`. The `main` branch is development code, not a supported
+distribution. Older alpha releases may not receive patches.
 
 ## Reporting a vulnerability
 
@@ -29,8 +27,8 @@ Include the affected version or commit, prerequisites, reproduction steps,
 impact, and any suggested mitigation. Remove live credentials and unrelated
 private data.
 
-There is no guaranteed response time during alpha. Reports will be reviewed
-privately before disclosure or remediation details are published.
+There is no guaranteed response time during alpha. The project reviews reports
+privately before publishing disclosure or remediation details.
 
 ## Security boundaries
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -4,9 +4,11 @@ description: Agent, AgentRun, and runtime-image contract for kontext.dev/v1alpha
 sidebarTitle: API spec
 ---
 
-# Kontext API Spec (DRAFT — v1alpha1)
+# Kontext API specification (`v1alpha1`)
 
-> Status: draft for review. This contract keeps Kontext a **general** agent runtime. Features that require application-specific vocabulary or behavior belong in the consumer's runtime image, not the control plane.
+> This is the published `v1alpha1` API and runtime-image contract. Kontext
+> remains a general agent runtime. Application-specific vocabulary and behavior
+> belong in the consumer's runtime image, not the control plane.
 
 Kontext exposes two custom resources and one runtime-image contract.
 
@@ -24,8 +26,8 @@ API group/version: `kontext.dev/v1alpha1` (alpha on purpose — the shape is all
 | Kontext                  | Core Kubernetes analogue | Behavior                                                                               |
 | ------------------------ | ------------------------ | -------------------------------------------------------------------------------------- |
 | `Agent` mode `Service`   | `Deployment`             | Always-on. Controller keeps one live `AgentRun`; re-casts on exit/failure.             |
-| `Agent` mode `Task`      | reusable template        | Does not run on its own. Each invocation mints an `AgentRun`.                          |
-| `Agent` mode `Scheduled` | `CronJob`                | Mints an `AgentRun` on a cron schedule. *(Reserved; build later.)*                     |
+| `Agent` mode `Task`      | reusable template        | Reserved in the schema. The controller reports `UnsupportedMode`; create a standalone `AgentRun` for one-shot work. |
+| `Agent` mode `Scheduled` | `CronJob`                | Reserved in the schema. The controller reports `UnsupportedMode` and does not schedule runs. |
 | `AgentRun`               | `Pod` / `Job`            | The single execution unit. Owns one Pod. Holds `status.result`, usage, immutable spec. |
 
 
@@ -415,14 +417,4 @@ security boundary.
 ## Anti-overfit firewall (read before adding a field)
 
 Kontext's vocabulary is fixed: `Agent`, `AgentRun`, runtime image, mode, budget, secret, tools, status, result. It must not gain domain-specific fields or workflow semantics for any one consumer. Consumers encode their semantics inside runtime images and orchestrate by creating generic `Agent`/`AgentRun` objects.
-
----
-
-## Open questions (resolve as real examples appear)
-
-1. Does `Service` mode ever need >1 concurrent `AgentRun` (replicas), or is single-run-per-Agent enough for the MVP?
-2. Where do tool *permissions* get enforced — admission/CEL on the CRD, or trusted to the runtime image at first?
-3. Is `BudgetExceeded` a distinct phase or a `Failed` with a reason condition?
-4. Do we need a `goalTemplate` + parameters object now, or defer templating until a concrete consumer needs it?
-5. Standalone `AgentRun` UX: encouraged primitive, or always create via an `Agent`?
 

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -2,7 +2,8 @@
 
 Self-hosted documentation app (ViaBOM-style). Renders repository Markdown from
 `docs/*.md` and `SPEC.md`, with navigation from root `docs-nav.json`. Visual
-language matches [`website/`](../website/).
+language matches [`website/`](../website/). The production site is live at
+[docs.kontext.run](https://docs.kontext.run).
 
 `npm run sync` copies those sources into `docs-site/content/` (gitignored) before
 dev/build. On Vercel the full repo is available, so sync works with Root
@@ -31,15 +32,11 @@ mise exec node@22 -- npm run preview
 | Node | 22.x |
 | Domain | `docs.kontext.run` |
 
-DNS at Namecheap (or your registrar):
+Production DNS:
 
 ```text
 A    docs    76.76.21.21
 ```
-
-(Or the CNAME target shown in the Vercel domain panel.)
-
-Production alias today: https://kontext-docs-red.vercel.app
 
 ## LLM / raw Markdown
 

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kontext-docs",
       "version": "0.1.0",
       "dependencies": {
+        "highlight.js": "^11.11.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
@@ -53,6 +54,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1251,6 +1253,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1341,6 +1344,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -1682,6 +1686,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-url-attributes": {
@@ -2725,6 +2738,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2776,6 +2790,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2785,6 +2800,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3255,6 +3271,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -14,6 +14,7 @@
     "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
+    "highlight.js": "^11.11.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/docs-site/src/components/Markdown.tsx
+++ b/docs-site/src/components/Markdown.tsx
@@ -51,7 +51,7 @@ const components: Components = {
       </a>
     );
   },
-  code({ className, children, ...props }) {
+  code({ className, children, node: _node, ...props }) {
     const text = String(children).replace(/\n$/, "");
     const isBlock = Boolean(className) || text.includes("\n");
     if (!isBlock) {

--- a/docs-site/src/components/Markdown.tsx
+++ b/docs-site/src/components/Markdown.tsx
@@ -1,7 +1,15 @@
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import json from "highlight.js/lib/languages/json";
+import yaml from "highlight.js/lib/languages/yaml";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Link } from "react-router-dom";
 import type { Components } from "react-markdown";
+
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("yaml", yaml);
 
 type MarkdownProps = {
   source: string;
@@ -9,6 +17,23 @@ type MarkdownProps = {
 
 function isInternalPath(href: string): boolean {
   return href.startsWith("/") && !href.startsWith("//");
+}
+
+function highlightLanguage(className: string | undefined): string | undefined {
+  const language = className?.match(/^language-(\S+)$/)?.[1];
+  switch (language) {
+    case "bash":
+    case "sh":
+    case "shell":
+      return "bash";
+    case "json":
+      return "json";
+    case "yaml":
+    case "yml":
+      return "yaml";
+    default:
+      return undefined;
+  }
 }
 
 const components: Components = {
@@ -34,6 +59,17 @@ const components: Components = {
         <code className="inline-code" {...props}>
           {children}
         </code>
+      );
+    }
+    const language = highlightLanguage(className);
+    if (language) {
+      const highlighted = hljs.highlight(text, { language }).value;
+      return (
+        <code
+          className={`${className ?? ""} hljs`.trim()}
+          dangerouslySetInnerHTML={{ __html: highlighted }}
+          {...props}
+        />
       );
     }
     return (

--- a/docs-site/src/styles.css
+++ b/docs-site/src/styles.css
@@ -7,6 +7,10 @@
   --sidebar: #f7f6f2;
   --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   --sans: ui-sans-serif, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  --tok-prompt: #2f6f55;
+  --tok-cmd: #2a5580;
+  --tok-key: #5a4d78;
+  --tok-str: #8a5a3c;
 }
 
 * {
@@ -272,6 +276,42 @@ a {
   font-size: inherit;
   background: none;
   padding: 0;
+}
+
+.markdown .hljs-attr,
+.markdown .hljs-attribute,
+.markdown .hljs-property {
+  color: var(--tok-key);
+}
+
+.markdown .hljs-string,
+.markdown .hljs-regexp {
+  color: var(--tok-str);
+}
+
+.markdown .hljs-built_in,
+.markdown .hljs-keyword,
+.markdown .hljs-name,
+.markdown .hljs-section,
+.markdown .hljs-selector-tag,
+.markdown .hljs-title {
+  color: var(--tok-cmd);
+  font-weight: 600;
+}
+
+.markdown .hljs-bullet,
+.markdown .hljs-literal,
+.markdown .hljs-meta,
+.markdown .hljs-number,
+.markdown .hljs-symbol,
+.markdown .hljs-template-variable,
+.markdown .hljs-variable {
+  color: var(--tok-prompt);
+}
+
+.markdown .hljs-comment,
+.markdown .hljs-quote {
+  color: var(--muted);
 }
 
 .inline-code,

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -85,14 +85,15 @@ successful `scripts/eval-kind.sh` removes the marker after writing and
 validating JSONL/summary output; an earlier failure leaves the marker visible
 in the always-uploaded artifact.
 
-## Protected pre-alpha acceptance
+## Protected release acceptance
 
-Before an alpha release, a maintainer must dispatch `.github/workflows/provider-acceptance.yml`
-against the protected `provider-acceptance` environment for each maintained
-transport being released. Select a small supported model, review endpoint and
-pricing, approve the environment, and require the workflow to pass. Download
-the `provider-acceptance-<run>-<attempt>` artifact and retain
-`acceptance.json` with the release evidence.
+For each release, a maintainer dispatches
+`.github/workflows/provider-acceptance.yml` against the protected
+`provider-acceptance` environment for every maintained transport in that
+release. Select a small supported model, review endpoint and pricing, approve
+the environment, and require the workflow to pass. Download the
+`provider-acceptance-<run>-<attempt>` artifact and retain `acceptance.json`
+with the release evidence.
 
 A local render or keyless run is not an authenticated provider acceptance.
 Without the protected credentials, record that the dispatch remains pending;

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,8 @@ when it dies.
 | Kontext | Kubernetes analogue | Behavior |
 |---|---|---|
 | `Agent` (mode `Service`) | `Deployment` | Always-on. The controller keeps one live `AgentRun` and re-casts it when it exits. |
-| `Agent` (mode `Task`) | reusable template | Schema present; controller support is planned. |
-| `Agent` (mode `Scheduled`) | `CronJob` | Schema present; not reconciled yet. |
+| `Agent` (mode `Task`) | reusable template | Schema available; the controller reports `UnsupportedMode`. Use a standalone `AgentRun` for one-shot work. |
+| `Agent` (mode `Scheduled`) | `CronJob` | Schema available; the controller reports `UnsupportedMode` and does not schedule runs. |
 | `AgentRun` | `Job` / `Pod` | One bounded execution. Owns exactly one Pod and holds `.status.result`. |
 
 You can also create a standalone `AgentRun` without an owning `Agent` — useful

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -40,7 +40,7 @@ Token and dollar budgets are not enforcement controls. Runtimes may report
 those measurements, and Kontext records them in status. Only wallclock is
 authoritatively enforced by the controller.
 
-Kontext does not yet publish a formal Kubernetes version compatibility range.
+Kontext does not publish a formal Kubernetes version compatibility range.
 CI uses Kubernetes 1.32 envtest binaries and disposable kind clusters. Other
 distributions and versions may work, but the alpha does not certify them.
 
@@ -197,7 +197,7 @@ kubectl delete -f <release-install-url> \
 
 The complete path deletes both CRDs and all `Agent` and `AgentRun` resources
 stored under them. Back up those resources first. Read
-[release and image versioning](releases.md) for the exact install URL and alpha
+[release and image versioning](/docs/releases) for the exact install URL and alpha
 upgrade procedure.
 
 ## Troubleshooting
@@ -305,6 +305,7 @@ upgrade procedure. Downgrades are not supported.
 
 Kontext has no availability or response-time SLA during alpha.
 
-For non-sensitive help, read [SUPPORT.md](../SUPPORT.md) and open a GitHub
-issue. Report security problems through the private process in
-[SECURITY.md](../SECURITY.md).
+For non-sensitive help, read
+[SUPPORT.md](https://github.com/MFS-code/Kontext/blob/main/SUPPORT.md) and open
+a GitHub issue. Report security problems through the private process in
+[SECURITY.md](https://github.com/MFS-code/Kontext/blob/main/SECURITY.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,13 +11,6 @@ echo `AgentRun`. You need kubectl and permission to create CRDs, cluster-scoped
 RBAC, a Namespace, and a Deployment. You do not need Docker, kind, or a
 repository clone.
 
-<Note>
-  The install URL only works after a matching GitHub release exists. Check
-  [Releases](https://github.com/MFS-code/Kontext/releases) before running the
-  commands below. Until the first alpha tag is published, use the kind-based
-  developer path in the repository README.
-</Note>
-
 ## Install
 
 ```bash

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,7 +6,8 @@ sidebarTitle: Releases
 
 # Release and image versioning
 
-Kontext releases use SemVer-compatible git tags:
+The current public release is `v0.1.0-alpha.1`. Kontext releases use
+SemVer-compatible git tags:
 
 ```text
 vMAJOR.MINOR.PATCH
@@ -14,8 +15,7 @@ vMAJOR.MINOR.PATCH-PRERELEASE
 ```
 
 Build metadata suffixes (`+...`) are not supported because they are not valid
-OCI tag characters. The first public alpha can therefore use a tag such as
-`v0.1.0-alpha.1`.
+OCI tag characters.
 
 ## Published images
 
@@ -80,7 +80,7 @@ Apply the new release manifest over the existing installation and wait for the
 controller rollout:
 
 ```bash
-NEW_VERSION=v0.1.0-alpha.2
+NEW_VERSION="<target-release-tag>"
 kubectl apply -f \
   "https://github.com/MFS-code/Kontext/releases/download/${NEW_VERSION}/install.yaml"
 kubectl rollout status deployment/controller-manager \
@@ -131,7 +131,7 @@ Release CI verifies both the retention procedure and complete removal.
 The git tag, GitHub release, and image tags identify one version of the Kontext
 distribution. They do not change the Kubernetes API group/version: current
 releases serve `kontext.dev/v1alpha1`, and maintained runtimes emit the
-versioned event and result contracts documented in [`SPEC.md`](../SPEC.md).
+versioned event and result contracts documented in the [API specification](/SPEC).
 
 `v1alpha1` is intentionally unstable. A new Kontext alpha release may make
 breaking CRD, runtime-contract, or status-shape changes while retaining the

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -17,10 +17,11 @@ model, budgets, and related fields.
 - **Service** — always-on. The controller keeps one live child `AgentRun` and
   re-casts it with backoff after exit or failure. In-memory conversation is not
   restored across recasts.
-- **Task** — reusable template intended to mint an `AgentRun` per invocation.
-  Schema is present; controller support is planned.
-- **Scheduled** — reserved for cron-style minting. Schema is present; not
-  reconciled yet.
+- **Task** — reserved reusable template. The schema is available, but the
+  controller reports `UnsupportedMode`. Create a standalone `AgentRun` for
+  one-shot work.
+- **Scheduled** — reserved for cron-style minting. The schema is available,
+  but the controller reports `UnsupportedMode` and does not schedule runs.
 
 ## AgentRun
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -42,7 +42,9 @@ keep full events and diagnostics outside Kubernetes status. The Pod termination
 message and its `AgentRun.status` projection are authoritative for terminal
 output; raw logs are only the event/diagnostic stream.
 
-See `deploy/examples/v1alpha1/README.md` for one manifest for each path.
+See the
+[v1alpha1 example manifests](https://github.com/MFS-code/Kontext/tree/main/deploy/examples/v1alpha1)
+for one manifest for each path.
 
 ## Context and tools
 

--- a/docs/service-workload.md
+++ b/docs/service-workload.md
@@ -11,9 +11,8 @@ available. The controller owns one live `AgentRun` for the `Agent` and mints a
 replacement when that run exits.
 
 <Note>
-  Use a published release image tag or digest. The example below uses the first
-  planned alpha tag; confirm it exists on
-  [Releases](https://github.com/MFS-code/Kontext/releases) before applying.
+  The example uses the published `v0.1.0-alpha.1` echo image. Pin a release tag
+  or digest in your own manifests.
 </Note>
 
 ## Apply a Service Agent

--- a/runtimes/reference/README.md
+++ b/runtimes/reference/README.md
@@ -457,11 +457,11 @@ measured usage, turns, tool calls, and pass/fail only. It excludes API keys,
 Secret values, raw logs, and model output. The workflow uploads this record on
 success or failure with short retention.
 
-Before an alpha release, dispatch the workflow for each maintained transport
-being released, approve the protected environment, require a passing run, and
+For each release, dispatch the workflow for every maintained transport being
+published, approve the protected environment, require a passing run, and
 retain the `provider-acceptance-<run>-<attempt>` artifact with the release
 evidence. Without those protected credentials, no local or keyless run counts
-as authenticated acceptance. Immutable versioned image publication is a
+as authenticated acceptance. Immutable versioned image publication remains a
 separate release step.
 
 ## Dependency inventory

--- a/website/README.md
+++ b/website/README.md
@@ -1,29 +1,18 @@
 # Website and docs deployment
 
-Marketing site: static files in this directory → **Vercel** → `kontext.run`  
-Documentation: [`docs-site/`](../docs-site/) (renders `docs/*.md` + `SPEC.md`) →
-**Vercel** → `docs.kontext.run`
+Both public sites are live on Vercel:
 
-Publish the marketing site only after `v0.1.0-alpha.1` (or the current alpha tag)
-exists as a GitHub release with `install.yaml`. The page already warns that a
-published release is required.
+- [kontext.run](https://kontext.run) serves the static marketing site from
+  this directory.
+- [docs.kontext.run](https://docs.kontext.run) serves [`docs-site/`](../docs-site/),
+  which renders `docs/*.md` and `SPEC.md`.
 
-## Vercel marketing (`kontext.run`)
+## Production configuration
 
-1. Import the `MFS-code/Kontext` repository in the Vercel dashboard.
-2. Set **Root Directory** to `website`.
-3. Framework preset: **Other** (no build command). Output is the `website/`
-   folder as-is. `vercel.json` lives next to `index.html`.
-4. Assign the production domain `kontext.run` (and `www` redirect if you want it).
-
-## Vercel docs (`docs.kontext.run`)
-
-1. Create a second Vercel project from the same repository (or use the existing
-   team).
-2. Root Directory: `docs-site`
-3. Build command: `npm run build` · Output: `dist` · Node 20 or 22
-4. Assign `docs.kontext.run`
-5. DNS: CNAME `docs` → the Vercel DNS target shown for that project
+| Site | Root directory | Build | Output |
+|---|---|---|---|
+| `kontext.run` | `website` | none | static files in `website/` |
+| `docs.kontext.run` | `docs-site` | `npm run build` on Node 22 | `dist` |
 
 Local:
 
@@ -36,7 +25,7 @@ mise exec node@22 -- npm run dev
 Navigation still comes from root [`docs-nav.json`](../docs-nav.json). Markdown stays the
 source of truth under `docs/` and `SPEC.md`.
 
-## DNS checklist
+## Production routing
 
 | Host | Target | Purpose |
 |---|---|---|


### PR DESCRIPTION
## Summary
- present `v0.1.0-alpha.1`, the public sites, and the API contract as released and operational
- replace stale planned-mode wording with current `UnsupportedMode` behavior and fix hosted-doc links
- highlight Bash, YAML, and JSON examples with the landing-page color palette

## Test plan
- [x] `cd docs-site && npm test`
- [x] `cd docs-site && npm run typecheck`
- [x] `cd docs-site && npm run build`
- [x] verify the quickstart page in local Chrome