### PR TITLE
Unify reference runtime execution policy

### DIFF
--- a/runtimes/reference/internal/engine/engine.go
+++ b/runtimes/reference/internal/engine/engine.go
@@ -27,15 +27,14 @@ type Resolver func(config.Config) (provider.Provider, error)
 type ToolExecutor interface {
 	Definitions() []runtimeapi.ToolDefinition
 	Execute(context.Context, runtimeapi.ToolCall) (runtimeapi.ToolResult, error)
+	Close(context.Context) error
 }
 
-type ToolResolver func(config.Config) (ToolExecutor, error)
 type ContextToolResolver func(context.Context, config.Config) (ToolExecutor, error)
 
 type Runner struct {
 	Emitter             Emitter
 	Resolve             Resolver
-	ResolveTools        ToolResolver
 	ResolveToolsContext ContextToolResolver
 	Now                 func() time.Time
 }
@@ -45,38 +44,46 @@ type Result struct {
 	ExitCode int
 }
 
+type execution struct {
+	emitter      Emitter
+	config       config.Config
+	provider     provider.Provider
+	toolExecutor ToolExecutor
+	state        *loopState
+	limits       limitsPolicy
+}
+
 func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Result {
 	resolve := runner.Resolve
 	if resolve == nil {
 		resolve = provider.Resolve
 	}
-	resolveTools := runner.ResolveToolsContext
-	if resolveTools == nil && runner.ResolveTools != nil {
-		resolveTools = func(_ context.Context, runtimeConfig config.Config) (ToolExecutor, error) {
-			return runner.ResolveTools(runtimeConfig)
-		}
-	}
-	if resolveTools == nil {
-		resolveTools = func(ctx context.Context, runtimeConfig config.Config) (ToolExecutor, error) {
-			return tools.NewWithContext(ctx, tools.Config{
-				Allowed: runtimeConfig.Tools,
-				MCP:     runtimeConfig.MCP,
-			})
-		}
-	}
 	now := runner.Now
 	if now == nil {
 		now = time.Now
 	}
-	state := newLoopState(runtimeConfig.Goal, now)
+	execution := &execution{
+		emitter: runner.Emitter,
+		config:  runtimeConfig,
+		state:   newLoopState(runtimeConfig.Goal, now),
+		limits:  newLimitsPolicy(runtimeConfig),
+	}
 
-	runner.emit(events.TypeLifecycle, map[string]any{
+	execution.emit(events.TypeLifecycle, map[string]any{
 		"phase":     "started",
 		"runName":   runtimeConfig.RunName,
 		"agentName": runtimeConfig.AgentName,
 		"provider":  runtimeConfig.Provider,
 		"model":     runtimeConfig.Model,
 	})
+	if runner.ResolveToolsContext == nil {
+		return execution.fail(
+			"invalid_tool_configuration",
+			"tool resolver is required",
+			nil,
+			"",
+		)
+	}
 	selectedProvider, err := resolve(runtimeConfig)
 	if err != nil {
 		code := "unsupported_provider"
@@ -87,24 +94,38 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 				code = "invalid_provider_configuration"
 			}
 		}
-		return state.failure(runner, runtimeConfig, code, err.Error(), nil, "")
+		return execution.fail(code, err.Error(), nil, "")
 	}
-	toolExecutor, err := resolveTools(ctx, runtimeConfig)
+	execution.provider = selectedProvider
+	toolExecutor, err := runner.ResolveToolsContext(ctx, runtimeConfig)
 	if err != nil {
 		code := "invalid_tool_configuration"
 		var toolError *tools.Error
 		if errors.As(err, &toolError) && toolError.Code != "" {
 			code = toolError.Code
 		}
-		return state.failure(runner, runtimeConfig, code, err.Error(), nil, "")
+		return execution.fail(code, err.Error(), nil, "")
 	}
-	definitions := toolExecutor.Definitions()
+	if toolExecutor == nil {
+		return execution.fail(
+			"invalid_tool_configuration",
+			"tool resolver returned a nil tool executor",
+			nil,
+			"",
+		)
+	}
+	execution.toolExecutor = toolExecutor
+	return execution.run(ctx)
+}
+
+func (execution *execution) run(ctx context.Context) Result {
+	definitions := execution.toolExecutor.Definitions()
 	if len(definitions) > 0 {
 		names := make([]string, 0, len(definitions))
 		for _, definition := range definitions {
 			names = append(names, definition.Name)
 		}
-		runner.emit(events.TypeLifecycle, map[string]any{
+		execution.emit(events.TypeLifecycle, map[string]any{
 			"phase": "tools_available",
 			"count": len(definitions),
 			"names": names,
@@ -112,51 +133,24 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 	}
 
 	for {
-		outcome := runner.providerTurn(
-			ctx,
-			runtimeConfig,
-			selectedProvider,
-			definitions,
-			state,
-		)
+		outcome := execution.providerTurn(ctx, definitions)
 		switch outcome.kind {
 		case turnOutcomePaused:
 			continue
 		case turnOutcomeFinal:
-			result := runner.cleanupToolExecutor(
-				toolExecutor,
-				outcome.result,
-				state,
-				runtimeConfig,
-			)
+			result := execution.cleanupToolExecutor(outcome.result)
 			if result.Envelope.Output != nil {
-				runner.emit(events.TypeOutput, map[string]any{
+				execution.emit(events.TypeOutput, map[string]any{
 					"mediaType": resultv1alpha1.DefaultMediaType,
 					"value":     runtimeapi.MessageText(outcome.response.Message),
 				})
 			}
 			return result
 		case turnOutcomeFailed:
-			return runner.cleanupToolExecutor(
-				toolExecutor,
-				outcome.result,
-				state,
-				runtimeConfig,
-			)
+			return execution.cleanupToolExecutor(outcome.result)
 		case turnOutcomeToolBatch:
-			if result := runner.executeToolBatch(
-				ctx,
-				runtimeConfig,
-				toolExecutor,
-				state,
-				outcome,
-			); result != nil {
-				return runner.cleanupToolExecutor(
-					toolExecutor,
-					*result,
-					state,
-					runtimeConfig,
-				)
+			if result := execution.executeToolBatch(ctx, outcome); result != nil {
+				return execution.cleanupToolExecutor(*result)
 			}
 		default:
 			panic(fmt.Sprintf("unsupported turn outcome %d", outcome.kind))
@@ -164,36 +158,18 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 	}
 }
 
-func (runner Runner) cleanupToolExecutor(
-	executor ToolExecutor,
-	result Result,
-	state *loopState,
-	runtimeConfig config.Config,
-) Result {
-	closer, ok := executor.(interface {
-		Close(context.Context) error
-	})
-	if !ok {
-		return result
-	}
+func (execution *execution) cleanupToolExecutor(result Result) Result {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := closer.Close(cleanupCtx); err != nil {
+	if err := execution.toolExecutor.Close(cleanupCtx); err != nil {
 		const code = "tool_cleanup_failed"
 		message := tooloutput.TruncateUTF8(fmt.Sprintf("tool cleanup failed: %v", err), 4<<10)
 		if result.ExitCode == 0 {
-			failure := state.failure(
-				runner,
-				runtimeConfig,
-				code,
-				message,
-				nil,
-				state.lastRequestID,
-			)
+			failure := execution.fail(code, message, nil, execution.state.lastRequestID)
 			failure.Envelope.Output = result.Envelope.Output
 			return failure
 		}
-		runner.emitError(code, message, nil)
+		execution.emitError(code, message, nil)
 	}
 	return result
 }
@@ -218,31 +194,136 @@ func terminalStopFailure(reason runtimeapi.StopReason) (string, string) {
 	}
 }
 
-func limitReached(limit *int64, value int64) bool {
-	return limit != nil && value >= *limit
+type limitViolation struct {
+	code    string
+	message string
 }
 
-func batchExceedsLimit(limit *int64, consumed int64, requested int64) bool {
-	if limit == nil {
-		return false
+type limitsPolicy struct {
+	tokenBudget             *int64
+	maxTurns                *int64
+	maxToolCalls            *int64
+	maxToolResultBytes      *int64
+	maxTotalToolOutputBytes *int64
+}
+
+func newLimitsPolicy(runtimeConfig config.Config) limitsPolicy {
+	return limitsPolicy{
+		tokenBudget:             runtimeConfig.TokenBudget,
+		maxTurns:                runtimeConfig.MaxTurns,
+		maxToolCalls:            runtimeConfig.MaxToolCalls,
+		maxToolResultBytes:      runtimeConfig.MaxToolResultBytes,
+		maxTotalToolOutputBytes: runtimeConfig.MaxTotalToolOutputBytes,
 	}
-	remaining := *limit - consumed
-	return remaining < 0 || requested > remaining
 }
 
-func remainingTokenBudget(limit *int64, consumed int64) *int64 {
-	if limit == nil {
+func (limits limitsPolicy) checkBeforeProviderTurn(state *loopState) *limitViolation {
+	if limits.reached(limits.maxTurns, int64(state.turns)) {
+		return &limitViolation{
+			code:    "turn_limit_exceeded",
+			message: "maximum provider turns reached before final output",
+		}
+	}
+	return nil
+}
+
+func (limits limitsPolicy) checkAfterResponse(state *loopState) *limitViolation {
+	// Provider usage is checked after a response and may equal the budget. A
+	// follow-up tool batch requires remaining budget, so its preflight uses >=.
+	if limits.tokenBudget != nil && state.consumedTokens > *limits.tokenBudget {
+		return &limitViolation{
+			code:    "token_limit_exceeded",
+			message: "measured provider usage exceeded the run token budget",
+		}
+	}
+	return nil
+}
+
+func (limits limitsPolicy) checkBeforeToolBatch(
+	state *loopState,
+	requestedCalls int64,
+) *limitViolation {
+	if limits.reached(limits.tokenBudget, state.consumedTokens) {
+		return &limitViolation{
+			code:    "token_limit_exceeded",
+			message: "run token budget was exhausted before tool results could be returned",
+		}
+	}
+	if limits.reached(limits.maxTurns, int64(state.turns)) {
+		return &limitViolation{
+			code:    "turn_limit_exceeded",
+			message: "maximum provider turns reached before tool results could be returned",
+		}
+	}
+	if limits.batchExceeds(limits.maxToolCalls, int64(state.toolCalls), requestedCalls) {
+		return &limitViolation{
+			code:    "tool_call_limit_exceeded",
+			message: "maximum tool calls reached before final output",
+		}
+	}
+	return limits.checkBeforeToolCall(state)
+}
+
+func (limits limitsPolicy) checkBeforeToolCall(state *loopState) *limitViolation {
+	if limits.reached(limits.maxTotalToolOutputBytes, state.totalToolOutputBytes) {
+		return &limitViolation{
+			code:    "tool_output_limit_exceeded",
+			message: "total tool-output limit reached before final output",
+		}
+	}
+	return nil
+}
+
+func (limits limitsPolicy) remainingTokenBudget(consumed int64) *int64 {
+	if limits.tokenBudget == nil {
 		return nil
 	}
-	remaining := *limit - consumed
+	remaining := *limits.tokenBudget - consumed
 	if remaining < 1 {
 		remaining = 1
 	}
 	return &remaining
 }
 
-func tokenBudgetExceeded(limit *int64, consumed int64) bool {
-	return limit != nil && consumed > *limit
+func (limits limitsPolicy) applyToolOutput(
+	result runtimeapi.ToolResult,
+	totalBytes *int64,
+) runtimeapi.ToolResult {
+	maxBytes := int64(len(result.Content))
+	if limits.maxToolResultBytes != nil && *limits.maxToolResultBytes < maxBytes {
+		maxBytes = *limits.maxToolResultBytes
+	}
+	if limits.maxTotalToolOutputBytes != nil {
+		remaining := *limits.maxTotalToolOutputBytes - *totalBytes
+		if remaining < maxBytes {
+			maxBytes = remaining
+		}
+	}
+	if maxBytes < 0 {
+		maxBytes = 0
+	}
+	if content, truncated := tooloutput.Bound(result.Content, maxBytes); truncated {
+		result.Content = content
+		result.Truncated = true
+	}
+	*totalBytes += int64(len(result.Content))
+	return result
+}
+
+func (limits limitsPolicy) reached(limit *int64, value int64) bool {
+	return limit != nil && value >= *limit
+}
+
+func (limits limitsPolicy) batchExceeds(
+	limit *int64,
+	consumed int64,
+	requested int64,
+) bool {
+	if limit == nil {
+		return false
+	}
+	remaining := *limit - consumed
+	return remaining < 0 || requested > remaining
 }
 
 func measuredTokens(usage runtimeapi.Usage) int64 {
@@ -289,71 +370,47 @@ func saturatingAdd(left int64, right int64) int64 {
 	return left + right
 }
 
-func applyToolOutputLimits(
-	result runtimeapi.ToolResult,
-	runtimeConfig config.Config,
-	totalBytes *int64,
-) runtimeapi.ToolResult {
-	maxBytes := int64(len(result.Content))
-	if runtimeConfig.MaxToolResultBytes != nil &&
-		*runtimeConfig.MaxToolResultBytes < maxBytes {
-		maxBytes = *runtimeConfig.MaxToolResultBytes
-	}
-	if runtimeConfig.MaxTotalToolOutputBytes != nil {
-		remaining := *runtimeConfig.MaxTotalToolOutputBytes - *totalBytes
-		if remaining < maxBytes {
-			maxBytes = remaining
-		}
-	}
-	if maxBytes < 0 {
-		maxBytes = 0
-	}
-	if content, truncated := tooloutput.Bound(result.Content, maxBytes); truncated {
-		result.Content = content
-		result.Truncated = true
-	}
-	*totalBytes += int64(len(result.Content))
-	return result
-}
-
-func (runner Runner) limitFailure(
+func (execution *execution) fail(
 	code string,
 	message string,
-	usage runtimeapi.Usage,
-	metadata Metadata,
+	retryable *bool,
+	requestID string,
 ) Result {
-	retryable := false
-	runner.emitError(code, message, &retryable)
-	result := failed(code, message, &retryable, metadata)
-	result.Envelope.Usage = envelopeUsage(usage)
+	execution.emitError(code, message, retryable)
+	result := Result{
+		Envelope: failureEnvelope(
+			code,
+			message,
+			retryable,
+			execution.state.metadata(execution.config, requestID),
+		),
+		ExitCode: 1,
+	}
+	result.Envelope.Usage = envelopeUsage(execution.state.usage)
 	return result
 }
 
-func (runner Runner) emit(eventType events.Type, data any) {
-	if runner.Emitter == nil {
-		return
-	}
-	runner.Emitter.Emit(eventType, data)
+func (execution *execution) failLimit(
+	violation *limitViolation,
+	requestID string,
+) Result {
+	retryable := false
+	return execution.fail(violation.code, violation.message, &retryable, requestID)
 }
 
-func (runner Runner) emitError(code string, message string, retryable *bool) {
-	runner.emit(events.TypeError, map[string]any{
+func (execution *execution) emit(eventType events.Type, data any) {
+	if execution.emitter == nil {
+		return
+	}
+	execution.emitter.Emit(eventType, data)
+}
+
+func (execution *execution) emitError(code string, message string, retryable *bool) {
+	execution.emit(events.TypeError, map[string]any{
 		"code":      code,
 		"message":   message,
 		"retryable": retryable,
 	})
-}
-
-func failed(
-	code string,
-	message string,
-	retryable *bool,
-	metadata Metadata,
-) Result {
-	return Result{
-		Envelope: Failure(code, message, retryable, metadata),
-		ExitCode: 1,
-	}
 }
 
 func normalizeError(

--- a/runtimes/reference/internal/engine/engine.go
+++ b/runtimes/reference/internal/engine/engine.go
@@ -98,13 +98,14 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 	}
 	execution.provider = selectedProvider
 	toolExecutor, err := runner.ResolveToolsContext(ctx, runtimeConfig)
+	execution.toolExecutor = toolExecutor
 	if err != nil {
 		code := "invalid_tool_configuration"
 		var toolError *tools.Error
 		if errors.As(err, &toolError) && toolError.Code != "" {
 			code = toolError.Code
 		}
-		return execution.fail(code, err.Error(), nil, "")
+		return execution.finish(execution.fail(code, err.Error(), nil, ""))
 	}
 	if toolExecutor == nil {
 		return execution.fail(
@@ -114,7 +115,6 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 			"",
 		)
 	}
-	execution.toolExecutor = toolExecutor
 	return execution.run(ctx)
 }
 
@@ -138,7 +138,7 @@ func (execution *execution) run(ctx context.Context) Result {
 		case turnOutcomePaused:
 			continue
 		case turnOutcomeFinal:
-			result := execution.cleanupToolExecutor(outcome.result)
+			result := execution.finish(outcome.result)
 			if result.Envelope.Output != nil {
 				execution.emit(events.TypeOutput, map[string]any{
 					"mediaType": resultv1alpha1.DefaultMediaType,
@@ -147,15 +147,22 @@ func (execution *execution) run(ctx context.Context) Result {
 			}
 			return result
 		case turnOutcomeFailed:
-			return execution.cleanupToolExecutor(outcome.result)
+			return execution.finish(outcome.result)
 		case turnOutcomeToolBatch:
 			if result := execution.executeToolBatch(ctx, outcome); result != nil {
-				return execution.cleanupToolExecutor(*result)
+				return execution.finish(*result)
 			}
 		default:
 			panic(fmt.Sprintf("unsupported turn outcome %d", outcome.kind))
 		}
 	}
+}
+
+func (execution *execution) finish(result Result) Result {
+	if execution.toolExecutor == nil {
+		return result
+	}
+	return execution.cleanupToolExecutor(result)
 }
 
 func (execution *execution) cleanupToolExecutor(result Result) Result {

--- a/runtimes/reference/internal/engine/engine_test.go
+++ b/runtimes/reference/internal/engine/engine_test.go
@@ -60,6 +60,117 @@ func TestRunnerRequiresContextAwareToolResolver(t *testing.T) {
 	}
 }
 
+func TestRunnerClosesEveryResolvedExecutorExactlyOnce(t *testing.T) {
+	tests := []struct {
+		name           string
+		returnExecutor bool
+		resolverError  error
+		wantExitCode   int
+		wantCloseCalls int
+	}{
+		{
+			name:           "executor and error",
+			returnExecutor: true,
+			resolverError:  errors.New("resolve failed"),
+			wantExitCode:   1,
+			wantCloseCalls: 1,
+		},
+		{
+			name:           "nil and error",
+			resolverError:  errors.New("resolve failed"),
+			wantExitCode:   1,
+			wantCloseCalls: 0,
+		},
+		{
+			name:           "successful executor",
+			returnExecutor: true,
+			wantExitCode:   0,
+			wantCloseCalls: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			executor := &closingToolExecutor{
+				close: func(context.Context) error { return nil },
+			}
+			runner := engine.Runner{
+				Emitter: &recordingEmitter{},
+				ResolveToolsContext: func(
+					context.Context,
+					config.Config,
+				) (engine.ToolExecutor, error) {
+					if !test.returnExecutor {
+						return nil, test.resolverError
+					}
+					return executor, test.resolverError
+				},
+			}
+
+			result := runner.Run(context.Background(), baseConfig())
+			if result.ExitCode != test.wantExitCode {
+				t.Fatalf("exit code=%d, want %d; result=%#v", result.ExitCode, test.wantExitCode, result)
+			}
+			if executor.closeCalls != test.wantCloseCalls {
+				t.Fatalf("close calls=%d, want %d", executor.closeCalls, test.wantCloseCalls)
+			}
+			if test.resolverError != nil &&
+				(result.Envelope.Error == nil ||
+					result.Envelope.Error.Code != "invalid_tool_configuration" ||
+					result.Envelope.Error.Message != test.resolverError.Error()) {
+				t.Fatalf("resolver error was not preserved: %#v", result.Envelope.Error)
+			}
+		})
+	}
+}
+
+func TestRunnerReportsCleanupAfterResolverFailure(t *testing.T) {
+	emitter := &dataRecordingEmitter{}
+	executor := &closingToolExecutor{
+		close: func(context.Context) error {
+			return errors.New("close failed")
+		},
+	}
+	runner := engine.Runner{
+		Emitter: emitter,
+		ResolveToolsContext: func(
+			context.Context,
+			config.Config,
+		) (engine.ToolExecutor, error) {
+			return executor, errors.New("resolve failed")
+		},
+	}
+
+	result := runner.Run(context.Background(), baseConfig())
+	if result.Envelope.Error == nil ||
+		result.Envelope.Error.Code != "invalid_tool_configuration" ||
+		result.Envelope.Error.Message != "resolve failed" {
+		t.Fatalf("cleanup replaced resolver failure: %#v", result.Envelope.Error)
+	}
+	if executor.closeCalls != 1 {
+		t.Fatalf("close calls=%d, want 1", executor.closeCalls)
+	}
+
+	var errorCodes []string
+	for _, event := range emitter.events {
+		switch event.eventType {
+		case events.TypeError:
+			data, ok := event.data.(map[string]any)
+			if !ok {
+				t.Fatalf("unexpected error event data %#v", event.data)
+			}
+			code, _ := data["code"].(string)
+			errorCodes = append(errorCodes, code)
+		case events.TypeOutput:
+			t.Fatal("resolver failure emitted terminal output")
+		}
+	}
+	if len(errorCodes) != 2 ||
+		errorCodes[0] != "invalid_tool_configuration" ||
+		errorCodes[1] != "tool_cleanup_failed" {
+		t.Fatalf("unexpected error event ordering %#v", errorCodes)
+	}
+}
+
 func TestRunnerNormalizesProviderFailures(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/runtimes/reference/internal/engine/engine_test.go
+++ b/runtimes/reference/internal/engine/engine_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestRunnerCompletesFakeConversation(t *testing.T) {
 	emitter := &recordingEmitter{}
-	runner := engine.Runner{Emitter: emitter}
+	runner := runnerWithoutTools(emitter)
 	result := runner.Run(context.Background(), baseConfig())
 
 	if result.ExitCode != 0 || result.Envelope.Outcome != resultv1alpha1.OutcomeSucceeded {
@@ -44,6 +44,22 @@ func TestRunnerCompletesFakeConversation(t *testing.T) {
 	}
 }
 
+func TestRunnerRequiresContextAwareToolResolver(t *testing.T) {
+	emitter := &recordingEmitter{}
+	result := (engine.Runner{Emitter: emitter}).Run(context.Background(), baseConfig())
+
+	if result.ExitCode == 0 || result.Envelope.Error == nil {
+		t.Fatalf("expected resolver configuration failure, got %#v", result)
+	}
+	if result.Envelope.Error.Code != "invalid_tool_configuration" ||
+		result.Envelope.Error.Message != "tool resolver is required" {
+		t.Fatalf("unexpected resolver failure %#v", result.Envelope.Error)
+	}
+	if got := emitter.count(events.TypeError); got != 1 {
+		t.Fatalf("expected one terminal error event, got %d", got)
+	}
+}
+
 func TestRunnerNormalizesProviderFailures(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -57,7 +73,7 @@ func TestRunnerNormalizesProviderFailures(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			runtimeConfig := baseConfig()
 			runtimeConfig.FakeScenario = test.scenario
-			result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+			result := runnerWithoutTools(&recordingEmitter{}).Run(
 				context.Background(),
 				runtimeConfig,
 			)
@@ -112,7 +128,7 @@ func TestRunnerDoesNotTreatIncompleteStopReasonsAsSuccess(t *testing.T) {
 func TestRunnerRejectsUnsupportedProvider(t *testing.T) {
 	runtimeConfig := baseConfig()
 	runtimeConfig.Provider = "unknown"
-	result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+	result := runnerWithoutTools(&recordingEmitter{}).Run(
 		context.Background(),
 		runtimeConfig,
 	)
@@ -124,7 +140,7 @@ func TestRunnerRejectsUnsupportedProvider(t *testing.T) {
 func TestRunnerDistinguishesInvalidProviderConfiguration(t *testing.T) {
 	runtimeConfig := baseConfig()
 	runtimeConfig.FakeScenario = "unknown"
-	result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+	result := runnerWithoutTools(&recordingEmitter{}).Run(
 		context.Background(),
 		runtimeConfig,
 	)
@@ -139,7 +155,7 @@ func TestRunnerReportsMissingProviderCredentials(t *testing.T) {
 		t.Run(providerName, func(t *testing.T) {
 			runtimeConfig := baseConfig()
 			runtimeConfig.Provider = providerName
-			result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+			result := runnerWithoutTools(&recordingEmitter{}).Run(
 				context.Background(),
 				runtimeConfig,
 			)
@@ -199,7 +215,7 @@ func TestRunnerExecutesToolCallsAndReturnsResultsToProvider(t *testing.T) {
 		Resolve: func(config.Config) (provider.Provider, error) {
 			return selectedProvider, nil
 		},
-		ResolveTools: func(config.Config) (engine.ToolExecutor, error) {
+		ResolveToolsContext: func(context.Context, config.Config) (engine.ToolExecutor, error) {
 			return executor, nil
 		},
 	}
@@ -288,6 +304,31 @@ func TestRunnerCleanupFailureDoesNotReplaceExistingFailure(t *testing.T) {
 	}
 	if executor.closeCalls != 1 {
 		t.Fatalf("expected one cleanup call, got %d", executor.closeCalls)
+	}
+}
+
+func TestRunnerClosesToolsBeforeEmittingFinalOutput(t *testing.T) {
+	closed := false
+	executor := &closingToolExecutor{
+		staticToolExecutor: *lookupExecutor(runtimeapi.ToolResult{}),
+		close: func(context.Context) error {
+			closed = true
+			return nil
+		},
+	}
+	runner := runnerWithTools(
+		&scriptedProvider{responses: []runtimeapi.CompletionResponse{finalResponse("done")}},
+		executor,
+	)
+	runner.Emitter = emitterFunc(func(eventType events.Type, _ any) {
+		if eventType == events.TypeOutput && !closed {
+			t.Fatal("final output emitted before tool cleanup")
+		}
+	})
+
+	result := runner.Run(context.Background(), baseConfig())
+	if result.ExitCode != 0 || !closed {
+		t.Fatalf("cleanup ordering failed: result=%#v closed=%t", result, closed)
 	}
 }
 
@@ -441,6 +482,52 @@ func TestRunnerEnforcesTurnAndToolCallLimits(t *testing.T) {
 		}
 		if len(executor.calls) != 1 {
 			t.Fatalf("oversized second batch changed call count to %d", len(executor.calls))
+		}
+	})
+}
+
+func TestRunnerPreservesTokenBudgetBoundarySemantics(t *testing.T) {
+	const budget = int64(10)
+
+	t.Run("terminal response may equal budget", func(t *testing.T) {
+		response := finalResponse("done")
+		response.Usage.TotalTokens = int64Pointer(budget)
+		result := runnerWithTools(
+			&scriptedProvider{responses: []runtimeapi.CompletionResponse{response}},
+			lookupExecutor(runtimeapi.ToolResult{}),
+		).Run(context.Background(), configWithTokenBudget(budget))
+		if result.ExitCode != 0 {
+			t.Fatalf("exact-budget terminal response failed: %#v", result.Envelope.Error)
+		}
+	})
+
+	t.Run("tool follow-up requires remaining budget", func(t *testing.T) {
+		response := toolCallResponse("call-1")
+		response.Usage.TotalTokens = int64Pointer(budget)
+		executor := lookupExecutor(runtimeapi.ToolResult{Content: "ok"})
+		result := runnerWithTools(
+			&scriptedProvider{responses: []runtimeapi.CompletionResponse{response}},
+			executor,
+		).Run(context.Background(), configWithTokenBudget(budget))
+		if result.Envelope.Error == nil ||
+			result.Envelope.Error.Code != "token_limit_exceeded" {
+			t.Fatalf("unexpected exact-budget tool result %#v", result.Envelope.Error)
+		}
+		if len(executor.calls) != 0 {
+			t.Fatalf("tool executed without remaining token budget")
+		}
+	})
+
+	t.Run("response over budget fails", func(t *testing.T) {
+		response := finalResponse("done")
+		response.Usage.TotalTokens = int64Pointer(budget + 1)
+		result := runnerWithTools(
+			&scriptedProvider{responses: []runtimeapi.CompletionResponse{response}},
+			lookupExecutor(runtimeapi.ToolResult{}),
+		).Run(context.Background(), configWithTokenBudget(budget))
+		if result.Envelope.Error == nil ||
+			result.Envelope.Error.Code != "token_limit_exceeded" {
+			t.Fatalf("unexpected over-budget result %#v", result.Envelope.Error)
 		}
 	})
 }
@@ -626,6 +713,36 @@ func TestRunnerBoundsToolOutputAndReturnsToolErrors(t *testing.T) {
 			t.Fatalf("tool error was not returned: %#v", results)
 		}
 	})
+
+	t.Run("cumulative output is checked between calls", func(t *testing.T) {
+		response := toolCallResponse("call-1")
+		response.Message.Content = append(
+			response.Message.Content,
+			runtimeapi.ContentBlock{
+				Type: runtimeapi.ContentTypeToolCall,
+				ToolCall: &runtimeapi.ToolCall{
+					ID:        "call-2",
+					Name:      "lookup",
+					Arguments: json.RawMessage(`{}`),
+				},
+			},
+		)
+		executor := lookupExecutor(runtimeapi.ToolResult{Content: "ok"})
+		runtimeConfig := baseConfig()
+		totalOutput := int64(2)
+		runtimeConfig.MaxTotalToolOutputBytes = &totalOutput
+		result := runnerWithTools(
+			&scriptedProvider{responses: []runtimeapi.CompletionResponse{response}},
+			executor,
+		).Run(context.Background(), runtimeConfig)
+		if result.Envelope.Error == nil ||
+			result.Envelope.Error.Code != "tool_output_limit_exceeded" {
+			t.Fatalf("unexpected cumulative output result %#v", result.Envelope.Error)
+		}
+		if len(executor.calls) != 1 {
+			t.Fatalf("expected one call before output exhaustion, got %d", len(executor.calls))
+		}
+	})
 }
 
 func TestRunnerSaturatesCumulativeUsageWithoutOverflow(t *testing.T) {
@@ -692,7 +809,7 @@ func TestRunnerHasNoImplicitWallclockDeadline(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(ctx, runtimeConfig)
+	result := runnerWithoutTools(&recordingEmitter{}).Run(ctx, runtimeConfig)
 	if result.ExitCode != 0 {
 		t.Fatalf("delay should succeed without configured wallclock: %#v", result.Envelope.Error)
 	}
@@ -707,7 +824,7 @@ func TestRunnerLeavesWallclockAuthorityWithController(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(ctx, runtimeConfig)
+	result := runnerWithoutTools(&recordingEmitter{}).Run(ctx, runtimeConfig)
 	if result.ExitCode != 0 {
 		t.Fatalf("runtime must not race controller wallclock enforcement: %#v", result.Envelope.Error)
 	}
@@ -721,7 +838,7 @@ func TestRunnerHandlesParentDeadlineAndCancellation(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
 
-		result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(
+		result := runnerWithoutTools(&recordingEmitter{}).Run(
 			ctx,
 			runtimeConfig,
 		)
@@ -737,7 +854,7 @@ func TestRunnerHandlesParentDeadlineAndCancellation(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		result := (engine.Runner{Emitter: &recordingEmitter{}}).Run(ctx, runtimeConfig)
+		result := runnerWithoutTools(&recordingEmitter{}).Run(ctx, runtimeConfig)
 		if result.Envelope.Error == nil || result.Envelope.Error.Code != "cancelled" {
 			t.Fatalf("unexpected cancellation result %#v", result.Envelope.Error)
 		}
@@ -755,6 +872,16 @@ func baseConfig() config.Config {
 	}
 }
 
+func configWithTokenBudget(budget int64) config.Config {
+	runtimeConfig := baseConfig()
+	runtimeConfig.TokenBudget = &budget
+	return runtimeConfig
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}
+
 func runnerWithTools(
 	selectedProvider provider.Provider,
 	executor engine.ToolExecutor,
@@ -764,8 +891,20 @@ func runnerWithTools(
 		Resolve: func(config.Config) (provider.Provider, error) {
 			return selectedProvider, nil
 		},
-		ResolveTools: func(config.Config) (engine.ToolExecutor, error) {
+		ResolveToolsContext: func(context.Context, config.Config) (engine.ToolExecutor, error) {
 			return executor, nil
+		},
+	}
+}
+
+func runnerWithoutTools(emitter engine.Emitter) engine.Runner {
+	return engine.Runner{
+		Emitter: emitter,
+		ResolveToolsContext: func(
+			context.Context,
+			config.Config,
+		) (engine.ToolExecutor, error) {
+			return &staticToolExecutor{}, nil
 		},
 	}
 }
@@ -829,6 +968,8 @@ type recordedEvent struct {
 	data      any
 }
 
+type emitterFunc func(events.Type, any)
+
 type scriptedProvider struct {
 	responses []runtimeapi.CompletionResponse
 	requests  []runtimeapi.CompletionRequest
@@ -883,8 +1024,16 @@ func (executor *staticToolExecutor) Execute(
 	return result, executor.err
 }
 
+func (executor *staticToolExecutor) Close(context.Context) error {
+	return nil
+}
+
 func (emitter *recordingEmitter) Emit(eventType events.Type, _ any) {
 	emitter.types = append(emitter.types, eventType)
+}
+
+func (emit emitterFunc) Emit(eventType events.Type, data any) {
+	emit(eventType, data)
 }
 
 func (emitter *dataRecordingEmitter) Emit(eventType events.Type, data any) {
@@ -905,10 +1054,15 @@ func (emitter *dataRecordingEmitter) first(eventType events.Type) map[string]any
 }
 
 func (emitter *recordingEmitter) has(eventType events.Type) bool {
+	return emitter.count(eventType) > 0
+}
+
+func (emitter *recordingEmitter) count(eventType events.Type) int {
+	var count int
 	for _, candidate := range emitter.types {
 		if candidate == eventType {
-			return true
+			count++
 		}
 	}
-	return false
+	return count
 }

--- a/runtimes/reference/internal/engine/envelope.go
+++ b/runtimes/reference/internal/engine/envelope.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	"encoding/json"
+	"io"
 	"time"
 
 	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
+	"github.com/MFS-code/Kontext/runtimes/reference/internal/events"
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
@@ -18,8 +20,12 @@ type Metadata struct {
 	ToolCalls   int32
 }
 
-func Success(response runtimeapi.CompletionResponse, metadata Metadata) resultv1alpha1.Envelope {
-	text := runtimeapi.MessageText(response.Message)
+func Success(
+	message runtimeapi.Message,
+	usage runtimeapi.Usage,
+	metadata Metadata,
+) resultv1alpha1.Envelope {
+	text := runtimeapi.MessageText(message)
 	value, _ := json.Marshal(text)
 	turns := metadata.Turns
 	toolCalls := metadata.ToolCalls
@@ -32,7 +38,7 @@ func Success(response runtimeapi.CompletionResponse, metadata Metadata) resultv1
 			MediaType: resultv1alpha1.DefaultMediaType,
 			Value:     value,
 		},
-		Usage: envelopeUsage(response.Usage),
+		Usage: envelopeUsage(usage),
 		Timing: &resultv1alpha1.Timing{
 			StartedAt:      &metadata.StartedAt,
 			CompletedAt:    &metadata.CompletedAt,
@@ -48,7 +54,7 @@ func Success(response runtimeapi.CompletionResponse, metadata Metadata) resultv1
 	}
 }
 
-func Failure(
+func failureEnvelope(
 	code string,
 	message string,
 	retryable *bool,
@@ -78,6 +84,29 @@ func Failure(
 			Retryable: retryable,
 		},
 	}
+}
+
+// EmitFailure emits the error event and terminal envelope used when execution
+// cannot reach Runner, such as invalid environment configuration.
+func EmitFailure(
+	writer io.Writer,
+	emitter Emitter,
+	code string,
+	message string,
+	retryable *bool,
+	metadata Metadata,
+) error {
+	if emitter != nil {
+		emitter.Emit(events.TypeError, map[string]any{
+			"code":      code,
+			"message":   message,
+			"retryable": retryable,
+		})
+	}
+	return resultv1alpha1.WriteEnvelopeLine(
+		writer,
+		failureEnvelope(code, message, retryable, metadata),
+	)
 }
 
 func envelopeUsage(providerUsage runtimeapi.Usage) *resultv1alpha1.Usage {

--- a/runtimes/reference/internal/engine/envelope_test.go
+++ b/runtimes/reference/internal/engine/envelope_test.go
@@ -1,17 +1,19 @@
 package engine_test
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
+	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/engine"
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
-func TestSuccessPreservesStructuredUsageAndOpaqueModel(t *testing.T) {
+func TestSuccessUsesExplicitCumulativeUsageAndOpaqueModel(t *testing.T) {
 	zero := int64(0)
-	outputTokens := int64(4)
-	reasoningTokens := int64(3)
+	outputTokens := int64(14)
+	reasoningTokens := int64(7)
 	response := runtimeapi.CompletionResponse{
 		Message: runtimeapi.Message{
 			Role: runtimeapi.RoleAssistant,
@@ -19,16 +21,16 @@ func TestSuccessPreservesStructuredUsageAndOpaqueModel(t *testing.T) {
 				{Type: runtimeapi.ContentTypeText, Text: "answer"},
 			},
 		},
-		Usage: runtimeapi.Usage{
-			InputTokens:     &zero,
-			OutputTokens:    &outputTokens,
-			ReasoningTokens: &reasoningTokens,
-		},
 		StopReason: runtimeapi.StopReasonEndTurn,
 		RequestID:  "request-1",
 	}
+	cumulativeUsage := runtimeapi.Usage{
+		InputTokens:     &zero,
+		OutputTokens:    &outputTokens,
+		ReasoningTokens: &reasoningTokens,
+	}
 	started := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
-	envelope := engine.Success(response, engine.Metadata{
+	envelope := engine.Success(response.Message, cumulativeUsage, engine.Metadata{
 		Provider:    "fake",
 		Model:       "vendor/model@2026:beta",
 		RequestID:   response.RequestID,
@@ -49,14 +51,18 @@ func TestSuccessPreservesStructuredUsageAndOpaqueModel(t *testing.T) {
 	if envelope.Usage.TotalTokens != nil {
 		t.Fatalf("missing total tokens must remain absent: %#v", envelope.Usage)
 	}
-	if envelope.Usage.ReasoningTokens == nil || *envelope.Usage.ReasoningTokens != 3 {
+	if envelope.Usage.OutputTokens == nil || *envelope.Usage.OutputTokens != 14 ||
+		envelope.Usage.ReasoningTokens == nil || *envelope.Usage.ReasoningTokens != 7 {
 		t.Fatalf("reasoning tokens were lost: %#v", envelope.Usage)
 	}
 }
 
-func TestFailureBuildsValidatedFailureEnvelope(t *testing.T) {
+func TestEmitFailureBuildsValidatedFailureEnvelope(t *testing.T) {
 	started := time.Now().UTC()
-	envelope := engine.Failure(
+	var output bytes.Buffer
+	if err := engine.EmitFailure(
+		&output,
+		nil,
 		"provider_error",
 		"unavailable",
 		nil,
@@ -66,7 +72,18 @@ func TestFailureBuildsValidatedFailureEnvelope(t *testing.T) {
 			StartedAt:   started,
 			CompletedAt: started,
 		},
-	)
+	); err != nil {
+		t.Fatalf("emit failure: %v", err)
+	}
+	payload, found := resultv1alpha1.ExtractEnvelopePayload(output.Bytes())
+	if !found {
+		t.Fatalf("failure envelope not found in %q", output.String())
+	}
+	parsed, err := resultv1alpha1.Parse(string(payload))
+	if err != nil || parsed.Envelope == nil {
+		t.Fatalf("parse failure envelope: parsed=%#v err=%v", parsed, err)
+	}
+	envelope := *parsed.Envelope
 	if err := envelope.Validate(); err != nil {
 		t.Fatalf("validate envelope: %v", err)
 	}

--- a/runtimes/reference/internal/engine/loop.go
+++ b/runtimes/reference/internal/engine/loop.go
@@ -8,7 +8,6 @@ import (
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/conversation"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/events"
-	"github.com/MFS-code/Kontext/runtimes/reference/internal/provider"
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
@@ -47,40 +46,6 @@ func (state *loopState) metadata(
 	}
 }
 
-func (state *loopState) failure(
-	runner Runner,
-	runtimeConfig config.Config,
-	code string,
-	message string,
-	retryable *bool,
-	requestID string,
-) Result {
-	runner.emitError(code, message, retryable)
-	result := failed(
-		code,
-		message,
-		retryable,
-		state.metadata(runtimeConfig, requestID),
-	)
-	result.Envelope.Usage = envelopeUsage(state.usage)
-	return result
-}
-
-func (state *loopState) limitFailure(
-	runner Runner,
-	runtimeConfig config.Config,
-	code string,
-	message string,
-	requestID string,
-) Result {
-	return runner.limitFailure(
-		code,
-		message,
-		state.usage,
-		state.metadata(runtimeConfig, requestID),
-	)
-}
-
 type turnOutcomeKind uint8
 
 const (
@@ -97,46 +62,31 @@ type turnOutcome struct {
 	result   Result
 }
 
-func (runner Runner) providerTurn(
+func (execution *execution) providerTurn(
 	ctx context.Context,
-	runtimeConfig config.Config,
-	selectedProvider provider.Provider,
 	definitions []runtimeapi.ToolDefinition,
-	state *loopState,
 ) turnOutcome {
-	if limitReached(runtimeConfig.MaxTurns, int64(state.turns)) {
+	state := execution.state
+	if violation := execution.limits.checkBeforeProviderTurn(state); violation != nil {
 		return turnOutcome{
-			kind: turnOutcomeFailed,
-			result: state.limitFailure(
-				runner,
-				runtimeConfig,
-				"turn_limit_exceeded",
-				"maximum provider turns reached before final output",
-				state.lastRequestID,
-			),
+			kind:   turnOutcomeFailed,
+			result: execution.failLimit(violation, state.lastRequestID),
 		}
 	}
 
 	requestStartedAt := state.now().UTC()
 	state.turns++
-	response, err := selectedProvider.Complete(ctx, runtimeapi.CompletionRequest{
-		Model:     runtimeConfig.Model,
+	response, err := execution.provider.Complete(ctx, runtimeapi.CompletionRequest{
+		Model:     execution.config.Model,
 		Messages:  state.conversation.Messages(),
-		MaxTokens: remainingTokenBudget(runtimeConfig.TokenBudget, state.consumedTokens),
+		MaxTokens: execution.limits.remainingTokenBudget(state.consumedTokens),
 		Tools:     runtimeapi.CloneToolDefinitions(definitions),
 	})
 	if err != nil {
 		code, message, retryable, requestID := normalizeError(ctx, err)
 		return turnOutcome{
-			kind: turnOutcomeFailed,
-			result: state.failure(
-				runner,
-				runtimeConfig,
-				code,
-				message,
-				retryable,
-				requestID,
-			),
+			kind:   turnOutcomeFailed,
+			result: execution.fail(code, message, retryable, requestID),
 		}
 	}
 
@@ -145,9 +95,7 @@ func (runner Runner) providerTurn(
 		message := fmt.Sprintf("provider returned an invalid response: %v", err)
 		return turnOutcome{
 			kind: turnOutcomeFailed,
-			result: state.failure(
-				runner,
-				runtimeConfig,
+			result: execution.fail(
 				"invalid_provider_response",
 				message,
 				nil,
@@ -161,28 +109,22 @@ func (runner Runner) providerTurn(
 		state.consumedTokens,
 		measuredTokens(response.Usage),
 	)
-	runner.emit(events.TypeLifecycle, map[string]any{
+	execution.emit(events.TypeLifecycle, map[string]any{
 		"phase":          "provider_completed",
 		"turn":           state.turns,
 		"stopReason":     response.StopReason,
 		"durationMillis": state.now().UTC().Sub(requestStartedAt).Milliseconds(),
 	})
 	if usage := envelopeUsage(response.Usage); usage != nil {
-		runner.emit(events.TypeUsage, map[string]any{
+		execution.emit(events.TypeUsage, map[string]any{
 			"turn":  state.turns,
 			"usage": usage,
 		})
 	}
-	if tokenBudgetExceeded(runtimeConfig.TokenBudget, state.consumedTokens) {
+	if violation := execution.limits.checkAfterResponse(state); violation != nil {
 		return turnOutcome{
-			kind: turnOutcomeFailed,
-			result: state.limitFailure(
-				runner,
-				runtimeConfig,
-				"token_limit_exceeded",
-				"measured provider usage exceeded the run token budget",
-				response.RequestID,
-			),
+			kind:   turnOutcomeFailed,
+			result: execution.failLimit(violation, response.RequestID),
 		}
 	}
 
@@ -196,9 +138,7 @@ func (runner Runner) providerTurn(
 			)
 			return turnOutcome{
 				kind: turnOutcomeFailed,
-				result: state.failure(
-					runner,
-					runtimeConfig,
+				result: execution.fail(
 					"invalid_provider_response",
 					message,
 					nil,
@@ -220,132 +160,58 @@ func (runner Runner) providerTurn(
 		response.StopReason != runtimeapi.StopReasonStopSequence {
 		code, message := terminalStopFailure(response.StopReason)
 		return turnOutcome{
-			kind: turnOutcomeFailed,
-			result: state.failure(
-				runner,
-				runtimeConfig,
-				code,
-				message,
-				nil,
-				response.RequestID,
-			),
+			kind:   turnOutcomeFailed,
+			result: execution.fail(code, message, nil, response.RequestID),
 		}
 	}
 
-	response.Usage = state.usage
 	return turnOutcome{
 		kind:     turnOutcomeFinal,
 		response: response,
 		result: Result{
 			Envelope: Success(
-				response,
-				state.metadata(runtimeConfig, response.RequestID),
+				response.Message,
+				state.usage,
+				state.metadata(execution.config, response.RequestID),
 			),
 			ExitCode: 0,
 		},
 	}
 }
 
-func (runner Runner) executeToolBatch(
+func (execution *execution) executeToolBatch(
 	ctx context.Context,
-	runtimeConfig config.Config,
-	executor ToolExecutor,
-	state *loopState,
 	outcome turnOutcome,
 ) *Result {
+	state := execution.state
 	requestID := outcome.response.RequestID
-	if limitReached(runtimeConfig.TokenBudget, state.consumedTokens) {
-		result := state.limitFailure(
-			runner,
-			runtimeConfig,
-			"token_limit_exceeded",
-			"run token budget was exhausted before tool results could be returned",
-			requestID,
-		)
-		return &result
-	}
-	if limitReached(runtimeConfig.MaxTurns, int64(state.turns)) {
-		result := state.limitFailure(
-			runner,
-			runtimeConfig,
-			"turn_limit_exceeded",
-			"maximum provider turns reached before tool results could be returned",
-			requestID,
-		)
-		return &result
-	}
-	if batchExceedsLimit(
-		runtimeConfig.MaxToolCalls,
-		int64(state.toolCalls),
+	if violation := execution.limits.checkBeforeToolBatch(
+		state,
 		int64(len(outcome.calls)),
-	) {
-		result := state.limitFailure(
-			runner,
-			runtimeConfig,
-			"tool_call_limit_exceeded",
-			"maximum tool calls reached before final output",
-			requestID,
-		)
-		return &result
-	}
-	if limitReached(
-		runtimeConfig.MaxTotalToolOutputBytes,
-		state.totalToolOutputBytes,
-	) {
-		result := state.limitFailure(
-			runner,
-			runtimeConfig,
-			"tool_output_limit_exceeded",
-			"total tool-output limit reached before final output",
-			requestID,
-		)
+	); violation != nil {
+		result := execution.failLimit(violation, requestID)
 		return &result
 	}
 
 	resultBlocks := make([]runtimeapi.ContentBlock, 0, len(outcome.calls))
 	for _, call := range outcome.calls {
-		if limitReached(runtimeConfig.MaxToolCalls, int64(state.toolCalls)) {
-			result := state.limitFailure(
-				runner,
-				runtimeConfig,
-				"tool_call_limit_exceeded",
-				"maximum tool calls reached before final output",
-				requestID,
-			)
-			return &result
-		}
-		if limitReached(
-			runtimeConfig.MaxTotalToolOutputBytes,
-			state.totalToolOutputBytes,
-		) {
-			result := state.limitFailure(
-				runner,
-				runtimeConfig,
-				"tool_output_limit_exceeded",
-				"total tool-output limit reached before final output",
-				requestID,
-			)
+		// Output from an earlier call in this batch can consume the remaining
+		// byte budget, so this per-call check is reachable.
+		if violation := execution.limits.checkBeforeToolCall(state); violation != nil {
+			result := execution.failLimit(violation, requestID)
 			return &result
 		}
 
 		state.toolCalls++
 		toolStartedAt := state.now().UTC()
-		toolResult, err := executor.Execute(ctx, call)
+		toolResult, err := execution.toolExecutor.Execute(ctx, call)
 		if err != nil {
 			code, message, retryable, _ := normalizeError(ctx, err)
-			result := state.failure(
-				runner,
-				runtimeConfig,
-				code,
-				message,
-				retryable,
-				requestID,
-			)
+			result := execution.fail(code, message, retryable, requestID)
 			return &result
 		}
-		toolResult = applyToolOutputLimits(
+		toolResult = execution.limits.applyToolOutput(
 			toolResult,
-			runtimeConfig,
 			&state.totalToolOutputBytes,
 		)
 		toolEvent := map[string]any{
@@ -358,10 +224,10 @@ func (runner Runner) executeToolBatch(
 			"truncated":      toolResult.Truncated,
 			"outputBytes":    len(toolResult.Content),
 		}
-		if runtimeConfig.EmitToolOutput {
+		if execution.config.EmitToolOutput {
 			toolEvent["output"] = toolResult.Content
 		}
-		runner.emit(events.TypeTool, toolEvent)
+		execution.emit(events.TypeTool, toolEvent)
 		resultCopy := toolResult
 		resultBlocks = append(resultBlocks, runtimeapi.ContentBlock{
 			Type:       runtimeapi.ContentTypeToolResult,

--- a/runtimes/reference/internal/tools/knowledge_test.go
+++ b/runtimes/reference/internal/tools/knowledge_test.go
@@ -25,7 +25,7 @@ func TestReadKnowledgeReadsAndBoundsMountedFile(t *testing.T) {
 	); err != nil {
 		t.Fatalf("write knowledge: %v", err)
 	}
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed:          []string{tools.NameReadKnowledge},
 		KnowledgeRoot:    root,
 		MaxCapturedBytes: 16,
@@ -65,7 +65,7 @@ func TestReadKnowledgeTruncatesAtUTF8Boundary(t *testing.T) {
 	); err != nil {
 		t.Fatalf("write knowledge: %v", err)
 	}
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed:          []string{tools.NameReadKnowledge},
 		KnowledgeRoot:    root,
 		MaxCapturedBytes: 20,
@@ -106,7 +106,7 @@ func TestReadKnowledgeRejectsTraversalAndEscapingSymlinks(t *testing.T) {
 	if err := os.Symlink(outside, filepath.Join(root, "link.txt")); err != nil {
 		t.Fatalf("create symlink: %v", err)
 	}
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed:       []string{tools.NameReadKnowledge},
 		KnowledgeRoot: root,
 	})
@@ -136,7 +136,7 @@ func TestReadKnowledgeRejectsTraversalAndEscapingSymlinks(t *testing.T) {
 }
 
 func TestReadKnowledgeRejectsUnknownArguments(t *testing.T) {
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed:       []string{tools.NameReadKnowledge},
 		KnowledgeRoot: t.TempDir(),
 	})

--- a/runtimes/reference/internal/tools/kubernetes_test.go
+++ b/runtimes/reference/internal/tools/kubernetes_test.go
@@ -28,7 +28,7 @@ func TestKubernetesReadUsesCurrentNamespaceAndServiceAccount(t *testing.T) {
 		_, _ = writer.Write([]byte(`{"kind":"Pod","metadata":{"name":"pod-1"}}`))
 	}))
 	defer server.Close()
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed: []string{tools.NameKubernetesRead},
 		Kubernetes: tools.KubernetesConfig{
 			BaseURL:   server.URL,
@@ -89,7 +89,7 @@ func TestKubernetesReadSchemaAndRoutingShareResourceRegistry(t *testing.T) {
 		_, _ = writer.Write([]byte(`{"items":[]}`))
 	}))
 	defer server.Close()
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed: []string{tools.NameKubernetesRead},
 		Kubernetes: tools.KubernetesConfig{
 			BaseURL:   server.URL,
@@ -157,7 +157,7 @@ func TestKubernetesReadBoundsListsAndNeverAllowsSecrets(t *testing.T) {
 		_, _ = writer.Write([]byte(`{"kind":"DeploymentList","items":[]}`))
 	}))
 	defer server.Close()
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed: []string{tools.NameKubernetesRead},
 		Kubernetes: tools.KubernetesConfig{
 			BaseURL:   server.URL,
@@ -211,7 +211,7 @@ func TestKubernetesReadReturnsRBACDenialToModel(t *testing.T) {
 		_, _ = writer.Write([]byte(`{"message":"forbidden"}`))
 	}))
 	defer server.Close()
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed:          []string{tools.NameKubernetesRead},
 		MaxCapturedBytes: 8,
 		Kubernetes: tools.KubernetesConfig{
@@ -251,7 +251,7 @@ func TestKubernetesReadBoundsUTF8Response(t *testing.T) {
 		_, _ = writer.Write([]byte(`"éééééééééééé"`))
 	}))
 	defer server.Close()
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed:          []string{tools.NameKubernetesRead},
 		MaxCapturedBytes: maxBytes,
 		Kubernetes: tools.KubernetesConfig{
@@ -300,7 +300,7 @@ func TestKubernetesReadBuildsIPv6ServiceURL(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader(`{"kind":"PodList","items":[]}`)),
 		}, nil
 	})}
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed: []string{tools.NameKubernetesRead},
 		Kubernetes: tools.KubernetesConfig{
 			Namespace: "current",

--- a/runtimes/reference/internal/tools/shell_test.go
+++ b/runtimes/reference/internal/tools/shell_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestShellUsesExplicitDirectoryAndFilteredEnvironment(t *testing.T) {
 	var streamed bytes.Buffer
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed: []string{tools.NameShell},
 		Stdout:  &streamed,
 	})
@@ -60,7 +60,10 @@ func TestShellUsesExplicitDirectoryAndFilteredEnvironment(t *testing.T) {
 }
 
 func TestShellRejectsSensitiveEnvironmentAndRelativeDirectory(t *testing.T) {
-	registry, err := tools.New(tools.Config{Allowed: []string{tools.NameShell}})
+	registry, err := tools.NewWithContext(
+		context.Background(),
+		tools.Config{Allowed: []string{tools.NameShell}},
+	)
 	if err != nil {
 		t.Fatalf("create registry: %v", err)
 	}
@@ -94,7 +97,7 @@ func TestShellRejectsSensitiveEnvironmentAndRelativeDirectory(t *testing.T) {
 
 func TestShellBoundsCapturedOutputButStreamsFullLogs(t *testing.T) {
 	var streamed bytes.Buffer
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed:          []string{tools.NameShell},
 		MaxCapturedBytes: 4,
 		Stdout:           &streamed,
@@ -128,7 +131,10 @@ func TestShellBoundsCapturedOutputButStreamsFullLogs(t *testing.T) {
 }
 
 func TestShellCancellationTerminatesProcessGroup(t *testing.T) {
-	registry, err := tools.New(tools.Config{Allowed: []string{tools.NameShell}})
+	registry, err := tools.NewWithContext(
+		context.Background(),
+		tools.Config{Allowed: []string{tools.NameShell}},
+	)
 	if err != nil {
 		t.Fatalf("create registry: %v", err)
 	}

--- a/runtimes/reference/internal/tools/tools.go
+++ b/runtimes/reference/internal/tools/tools.go
@@ -65,10 +65,6 @@ func (err *Error) Error() string {
 	return fmt.Sprintf("%s: %s", err.Code, err.Message)
 }
 
-func New(toolConfig Config) (*Registry, error) {
-	return NewWithContext(context.Background(), toolConfig)
-}
-
 func NewWithContext(ctx context.Context, toolConfig Config) (*Registry, error) {
 	config := toolConfig
 	if config.MaxCapturedBytes <= 0 {

--- a/runtimes/reference/internal/tools/tools_test.go
+++ b/runtimes/reference/internal/tools/tools_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestRegistryExposesOnlyAllowedTools(t *testing.T) {
-	registry, err := tools.New(tools.Config{
+	registry, err := tools.NewWithContext(context.Background(), tools.Config{
 		Allowed: []string{tools.NameReadKnowledge, tools.NameReadKnowledge},
 	})
 	if err != nil {
@@ -30,7 +30,10 @@ func TestRegistryExposesOnlyAllowedTools(t *testing.T) {
 }
 
 func TestRegistryRejectsUnknownConfiguredTool(t *testing.T) {
-	_, err := tools.New(tools.Config{Allowed: []string{"not-built-in"}})
+	_, err := tools.NewWithContext(
+		context.Background(),
+		tools.Config{Allowed: []string{"not-built-in"}},
+	)
 	var toolError *tools.Error
 	if !errors.As(err, &toolError) || toolError.Code != "unknown_tool" {
 		t.Fatalf("unexpected error %v", err)
@@ -38,7 +41,10 @@ func TestRegistryRejectsUnknownConfiguredTool(t *testing.T) {
 }
 
 func TestRegistryReturnsDeniedAndUnknownCallsToModel(t *testing.T) {
-	registry, err := tools.New(tools.Config{Allowed: []string{tools.NameReadKnowledge}})
+	registry, err := tools.NewWithContext(
+		context.Background(),
+		tools.Config{Allowed: []string{tools.NameReadKnowledge}},
+	)
 	if err != nil {
 		t.Fatalf("create registry: %v", err)
 	}

--- a/runtimes/reference/main.go
+++ b/runtimes/reference/main.go
@@ -35,11 +35,9 @@ func run(
 	if err != nil {
 		fmt.Fprintf(stderr, "kontext reference runtime: %v\n", err)
 		startedAt := now().UTC()
-		emitter.Emit(events.TypeError, map[string]any{
-			"code":    "invalid_configuration",
-			"message": err.Error(),
-		})
-		envelope := engine.Failure(
+		if emitErr := engine.EmitFailure(
+			stdout,
+			emitter,
 			"invalid_configuration",
 			err.Error(),
 			nil,
@@ -49,8 +47,7 @@ func run(
 				StartedAt:   startedAt,
 				CompletedAt: now().UTC(),
 			},
-		)
-		if emitErr := resultv1alpha1.WriteEnvelopeLine(stdout, envelope); emitErr != nil {
+		); emitErr != nil {
 			fmt.Fprintf(stderr, "kontext reference runtime: emit result: %v\n", emitErr)
 		}
 		return 2

--- a/runtimes/reference/main_test.go
+++ b/runtimes/reference/main_test.go
@@ -66,6 +66,12 @@ func TestRunEmitsFailureEnvelopeForInvalidConfiguration(t *testing.T) {
 	if !strings.Contains(stderr.String(), "KONTEXT_MODEL is required") {
 		t.Fatalf("expected actionable stderr, got %q", stderr.String())
 	}
+	if got := strings.Count(stdout.String(), `"type":"error"`); got != 1 {
+		t.Fatalf("expected one terminal error event, got %d: %s", got, stdout.String())
+	}
+	if got := strings.Count(stdout.String(), resultv1alpha1.EnvelopeLinePrefix); got != 1 {
+		t.Fatalf("expected one terminal envelope, got %d: %s", got, stdout.String())
+	}
 }
 
 func resultLine(t *testing.T, output string) resultv1alpha1.Envelope {


### PR DESCRIPTION
## Summary
- introduce an execution object that owns runtime dependencies, loop state, failure handling, and cleanup
- centralize typed limit checks while preserving exact token-budget boundary semantics and shared tool-output bounding
- require explicit context-aware tool resolution, mandatory executor cleanup, and explicit cumulative success usage

## Tests
- `make verify`
- `make test`
- `go test ./runtimes/reference/internal/engine ./runtimes/reference/internal/tools ./runtimes/reference`
- `make docker-build-reference REFERENCE_IMG=kontext-reference:issue-63`
- `docker run --rm --entrypoint /kontext-reporter -e KONTEXT_RUN_NAME=issue-63-smoke -e KONTEXT_GOAL='Explain the runtime contract' -e KONTEXT_PROVIDER=fake -e KONTEXT_MODEL=smoke-model kontext-reference:issue-63 --format kontext-envelope --termination-log /tmp/termination-log -- /kontext-reference`

Closes #63