### PR TITLE
Normalize result parsing around envelopes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -138,6 +138,24 @@ provider did not measure it; a present zero means it measured zero.
 
 `AgentRun` created from an `Agent` carries an owner reference to it → standard GC cascade. Standalone `AgentRun`s are allowed for ad-hoc execution, demos, and direct task dispatch.
 
+### Contract evolution policy
+
+The three public contract surfaces evolve differently:
+
+- **Result envelopes are lenient at the top level.** Consumers ignore unknown
+  top-level fields so producers can add optional result metadata without
+  breaking older readers. Known fields are still fully validated.
+  Runtime/provider-specific JSON belongs in `extensions` under namespaced keys
+  such as `anthropic.com/request`.
+- **Event envelopes are strict.** Consumers reject unknown top-level fields and
+  trailing JSON. Changing the event envelope shape requires a new event
+  contract version so streaming observers never silently interpret a different
+  record shape.
+- **CRDs evolve additively within `v1alpha1`.** Existing fields keep their
+  meaning and new fields are optional. Kubernetes structurally validates CRD
+  data; arbitrary JSON is confined to fields explicitly documented as
+  schemaless, currently `AgentRun.status.output.value`.
+
 ---
 
 ## Runtime image contract
@@ -173,11 +191,13 @@ The controller injects, on the Pod:
 
 ### Output — result
 
-The terminal envelope is optional at the control-plane boundary. An unchanged
-plain image that exits `0` without writing `/dev/termination-log` succeeds with
-absent `status.output` and an empty `status.result`. Native runtimes and images
-using injected stdout capture write richer structured output, usage, timing,
-and execution metadata.
+The terminal envelope is optional at the control-plane boundary. An empty or
+whitespace-only termination message is normalized internally to the current
+result API version with outcome `Succeeded` and no output, usage, or error; it
+is not a legacy wire payload. An unchanged plain image that exits `0` without
+writing `/dev/termination-log` therefore succeeds with absent `status.output`
+and an empty `status.result`. Native runtimes and images using injected stdout
+capture write richer structured output, usage, timing, and execution metadata.
 
 On completion, a runtime that provides a structured result writes a compact
 versioned envelope to `/dev/termination-log` (and may also write
@@ -255,7 +275,8 @@ transition:
 Legacy text becomes `text/plain` structured output. Legacy usage fields are
 recorded only when they are present in the payload. For compatibility, the
 process exit code remains authoritative for legacy payloads; a legacy `error`
-field is retained as diagnostic text but does not turn exit `0` into failure.
+field is retained as diagnostic text but never determines the run outcome and
+does not turn exit `0` into failure.
 
 Exit `0` with no termination payload or with a successful envelope means
 success. A non-zero process exit always fails the run. A failed envelope also

--- a/api/v1alpha1/evolution_policy_test.go
+++ b/api/v1alpha1/evolution_policy_test.go
@@ -1,0 +1,75 @@
+package v1alpha1_test
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+type crdDocument struct {
+	Spec struct {
+		Versions []struct {
+			Name   string `yaml:"name"`
+			Schema struct {
+				OpenAPIV3Schema map[string]any `yaml:"openAPIV3Schema"`
+			} `yaml:"schema"`
+		} `yaml:"versions"`
+	} `yaml:"spec"`
+}
+
+func TestCRDsConfineSchemalessJSONToDocumentedFields(t *testing.T) {
+	for name, test := range map[string]struct {
+		path string
+		want []string
+	}{
+		"Agent": {
+			path: "../../config/crd/bases/kontext.dev_agents.yaml",
+		},
+		"AgentRun": {
+			path: "../../config/crd/bases/kontext.dev_agentruns.yaml",
+			want: []string{"$.status.output.value"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(test.path)
+			if err != nil {
+				t.Fatalf("read CRD: %v", err)
+			}
+			var crd crdDocument
+			if err := yaml.Unmarshal(data, &crd); err != nil {
+				t.Fatalf("decode CRD: %v", err)
+			}
+
+			var preserved []string
+			for _, version := range crd.Spec.Versions {
+				collectPreservedPaths(version.Schema.OpenAPIV3Schema, "$", &preserved)
+			}
+			sort.Strings(preserved)
+			if !reflect.DeepEqual(preserved, test.want) {
+				t.Fatalf("unexpected schemaless CRD fields: got %v want %v", preserved, test.want)
+			}
+		})
+	}
+}
+
+func collectPreservedPaths(node map[string]any, path string, paths *[]string) {
+	if preserved, _ := node["x-kubernetes-preserve-unknown-fields"].(bool); preserved {
+		*paths = append(*paths, path)
+	}
+	if properties, ok := node["properties"].(map[string]any); ok {
+		for name, value := range properties {
+			if property, ok := value.(map[string]any); ok {
+				collectPreservedPaths(property, path+"."+name, paths)
+			}
+		}
+	}
+	if items, ok := node["items"].(map[string]any); ok {
+		collectPreservedPaths(items, path+"[]", paths)
+	}
+	if additional, ok := node["additionalProperties"].(map[string]any); ok {
+		collectPreservedPaths(additional, path+"{}", paths)
+	}
+}

--- a/api/v1alpha1/evolution_policy_test.go
+++ b/api/v1alpha1/evolution_policy_test.go
@@ -55,6 +55,36 @@ func TestCRDsConfineSchemalessJSONToDocumentedFields(t *testing.T) {
 	}
 }
 
+func TestCollectPreservedPathsTraversesCompositionKeywords(t *testing.T) {
+	for _, keyword := range []string{"allOf", "anyOf", "oneOf"} {
+		t.Run(keyword, func(t *testing.T) {
+			schema := map[string]any{
+				"properties": map[string]any{
+					"container": map[string]any{
+						keyword: []any{
+							map[string]any{"type": "object"},
+							map[string]any{
+								"properties": map[string]any{
+									"value": map[string]any{
+										"x-kubernetes-preserve-unknown-fields": true,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			var preserved []string
+			collectPreservedPaths(schema, "$", &preserved)
+			want := []string{"$.container.value"}
+			if !reflect.DeepEqual(preserved, want) {
+				t.Fatalf("composition path not detected: got %v want %v", preserved, want)
+			}
+		})
+	}
+}
+
 func collectPreservedPaths(node map[string]any, path string, paths *[]string) {
 	if preserved, _ := node["x-kubernetes-preserve-unknown-fields"].(bool); preserved {
 		*paths = append(*paths, path)
@@ -71,5 +101,14 @@ func collectPreservedPaths(node map[string]any, path string, paths *[]string) {
 	}
 	if additional, ok := node["additionalProperties"].(map[string]any); ok {
 		collectPreservedPaths(additional, path+"{}", paths)
+	}
+	for _, keyword := range []string{"allOf", "anyOf", "oneOf"} {
+		if schemas, ok := node[keyword].([]any); ok {
+			for _, value := range schemas {
+				if schema, ok := value.(map[string]any); ok {
+					collectPreservedPaths(schema, path, paths)
+				}
+			}
+		}
 	}
 }

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -1,4 +1,11 @@
-// Package v1alpha1 contains API Schema definitions for the kontext v1alpha1 API group.
+// Package v1alpha1 contains API Schema definitions for the kontext v1alpha1
+// API group.
+//
+// CRDs evolve additively: existing fields retain their meaning and new
+// optional fields may be introduced within the version. Arbitrary JSON is
+// accepted only by fields explicitly documented and marked schemaless, such as
+// AgentRun status output values; every other field remains structurally
+// validated by Kubernetes.
 //
 // +kubebuilder:object:generate=true
 // +groupName=kontext.dev

--- a/internal/eval/runner.go
+++ b/internal/eval/runner.go
@@ -257,16 +257,16 @@ func (runner Runner) finishRecord(
 			if terminated == nil {
 				record.CollectionErrors = append(record.CollectionErrors, "required runtime termination message was unavailable")
 			} else {
-				envelope, legacy, err := resultv1alpha1.Parse(terminated.Message)
-				if err != nil {
-					record.CollectionErrors = append(
-						record.CollectionErrors,
-						fmt.Sprintf("parse required runtime termination message: %v", err),
-					)
-				} else if legacy || strings.TrimSpace(terminated.Message) == "" {
+				envelope, err := resultv1alpha1.ParseVersioned(terminated.Message)
+				if errors.Is(err, resultv1alpha1.ErrVersionedEnvelopeRequired) {
 					record.CollectionErrors = append(
 						record.CollectionErrors,
 						"required versioned result envelope was absent from runtime termination message",
+					)
+				} else if err != nil {
+					record.CollectionErrors = append(
+						record.CollectionErrors,
+						fmt.Sprintf("parse required runtime termination message: %v", err),
 					)
 				} else {
 					record.Envelope = projectEnvelope(envelope, requirements)

--- a/internal/eval/runner.go
+++ b/internal/eval/runner.go
@@ -257,19 +257,19 @@ func (runner Runner) finishRecord(
 			if terminated == nil {
 				record.CollectionErrors = append(record.CollectionErrors, "required runtime termination message was unavailable")
 			} else {
-				parsed, err := resultv1alpha1.Parse(terminated.Message)
+				envelope, legacy, err := resultv1alpha1.Parse(terminated.Message)
 				if err != nil {
 					record.CollectionErrors = append(
 						record.CollectionErrors,
 						fmt.Sprintf("parse required runtime termination message: %v", err),
 					)
-				} else if parsed.Envelope == nil {
+				} else if legacy || strings.TrimSpace(terminated.Message) == "" {
 					record.CollectionErrors = append(
 						record.CollectionErrors,
 						"required versioned result envelope was absent from runtime termination message",
 					)
 				} else {
-					record.Envelope = projectEnvelope(*parsed.Envelope, requirements)
+					record.Envelope = projectEnvelope(envelope, requirements)
 				}
 			}
 		}

--- a/internal/eval/runner_test.go
+++ b/internal/eval/runner_test.go
@@ -329,6 +329,48 @@ func TestEnvelopeGradersUseTerminationMessageWithoutLogs(t *testing.T) {
 	}
 }
 
+func TestEnvelopeGradersRequireVersionedWireEnvelope(t *testing.T) {
+	item := Case{Graders: []Grader{{
+		Type:    GraderEnvelopeOutcome,
+		Outcome: resultv1alpha1.OutcomeSucceeded,
+	}}}
+	requirements := mustArtifactRequirements(t, item.Graders)
+	for name, message := range map[string]string{
+		"empty":      " \t\n",
+		"plain text": "legacy result",
+		"legacy JSON": `{
+			"result":"legacy result",
+			"tokensUsed":0
+		}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			pod := &corev1.Pod{}
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name: "runtime",
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					ExitCode: 0,
+					Message:  message,
+				}},
+			}}
+			record := Record{StartedAt: time.Unix(0, 0)}
+			finished := (Runner{}).finishRecord(
+				context.Background(),
+				&record,
+				item,
+				requirements,
+				nil,
+				pod,
+				false,
+				func() time.Time { return time.Unix(1, 0) },
+			)
+			if finished.Pass ||
+				!containsCollectionError(finished.CollectionErrors, "required versioned result envelope was absent") {
+				t.Fatalf("non-versioned wire payload was accepted: %#v", finished)
+			}
+		})
+	}
+}
+
 func TestEventGradersFailTransportAndTruncationErrors(t *testing.T) {
 	pod := &corev1.Pod{}
 	pod.Namespace = "evals"

--- a/internal/status/pod.go
+++ b/internal/status/pod.go
@@ -92,13 +92,13 @@ func runtimeContainerStatus(pod *corev1.Pod) *corev1.ContainerStatus {
 
 func observationFromTermination(terminated *corev1.ContainerStateTerminated) PodObservation {
 	message := strings.TrimSpace(terminated.Message)
-	parsed, parseErr := resultv1alpha1.Parse(message)
+	envelope, _, parseErr := resultv1alpha1.Parse(message)
 	if parseErr != nil {
 		parseErr = fmt.Errorf("parse termination payload: %w", parseErr)
 	}
-	output := outputStatus(parsed)
-	usage := usageStatus(parsed)
-	legacyResult := resultv1alpha1.ProjectLegacyResult(parsed.Output)
+	output := outputStatus(envelope)
+	usage := usageStatus(envelope)
+	legacyResult := resultv1alpha1.ProjectLegacyResult(envelope.Output)
 
 	if terminated.ExitCode == 0 {
 		if parseErr != nil {
@@ -110,10 +110,10 @@ func observationFromTermination(terminated *corev1.ContainerStateTerminated) Pod
 				Message: fmt.Sprintf("Agent run exited 0 but the termination payload was malformed: %v", parseErr),
 			}
 		}
-		if parsed.Outcome == resultv1alpha1.OutcomeFailed {
+		if envelope.Outcome == resultv1alpha1.OutcomeFailed {
 			message := "Agent runtime reported a failed outcome."
-			if parsed.Error != nil {
-				message = fmt.Sprintf("%s %s", message, parsed.Error.Message)
+			if envelope.Error != nil {
+				message = fmt.Sprintf("%s %s", message, envelope.Error.Message)
 			}
 			return PodObservation{
 				Phase:   kontextv1alpha1.AgentRunPhaseFailed,
@@ -133,8 +133,8 @@ func observationFromTermination(terminated *corev1.ContainerStateTerminated) Pod
 	}
 
 	message = fmt.Sprintf("Agent run exited with code %d.", terminated.ExitCode)
-	if parsed.Error != nil {
-		message = fmt.Sprintf("%s %s", message, parsed.Error.Message)
+	if envelope.Error != nil {
+		message = fmt.Sprintf("%s %s", message, envelope.Error.Message)
 	}
 	if parseErr != nil {
 		message = fmt.Sprintf("%s (malformed termination payload: %v)", message, parseErr)
@@ -150,26 +150,26 @@ func observationFromTermination(terminated *corev1.ContainerStateTerminated) Pod
 	}
 }
 
-func outputStatus(parsed resultv1alpha1.ParsedResult) *kontextv1alpha1.OutputStatus {
-	if parsed.Output == nil {
+func outputStatus(envelope resultv1alpha1.Envelope) *kontextv1alpha1.OutputStatus {
+	if envelope.Output == nil {
 		return nil
 	}
 	return &kontextv1alpha1.OutputStatus{
-		MediaType: parsed.Output.MediaType,
+		MediaType: envelope.Output.MediaType,
 		Value: runtime.RawExtension{
-			Raw: append([]byte(nil), parsed.Output.Value...),
+			Raw: append([]byte(nil), envelope.Output.Value...),
 		},
 	}
 }
 
-func usageStatus(parsed resultv1alpha1.ParsedResult) *kontextv1alpha1.UsageStatus {
-	if parsed.Usage == nil {
+func usageStatus(envelope resultv1alpha1.Envelope) *kontextv1alpha1.UsageStatus {
+	if envelope.Usage == nil {
 		return nil
 	}
 	return &kontextv1alpha1.UsageStatus{
-		Tokens:       parsed.Usage.TotalTokens,
-		InputTokens:  parsed.Usage.InputTokens,
-		OutputTokens: parsed.Usage.OutputTokens,
-		Dollars:      parsed.Usage.Dollars,
+		Tokens:       envelope.Usage.TotalTokens,
+		InputTokens:  envelope.Usage.InputTokens,
+		OutputTokens: envelope.Usage.OutputTokens,
+		Dollars:      envelope.Usage.Dollars,
 	}
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -39,6 +39,30 @@ func TestObservePodPlainTextTermination(t *testing.T) {
 	}
 }
 
+func TestObservePodEmptyTerminationIsExplicitSuccess(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: podbuilder.RuntimeContainerName,
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 0,
+						Message:  " \t\n",
+					},
+				},
+			}},
+		},
+	}
+
+	observation := status.ObservePod(pod)
+	if observation.Phase != kontextv1alpha1.AgentRunPhaseSucceeded {
+		t.Fatalf("expected Succeeded, got %s", observation.Phase)
+	}
+	if observation.Result != "" || observation.Output != nil || observation.Usage != nil {
+		t.Fatalf("empty success invented status data: %#v", observation)
+	}
+}
+
 func TestObservePodMalformedTerminationOnSuccessFails(t *testing.T) {
 	exitCode := int32(0)
 	pod := &corev1.Pod{

--- a/pkg/event/v1alpha1/types.go
+++ b/pkg/event/v1alpha1/types.go
@@ -1,5 +1,9 @@
 // Package v1alpha1 defines the versioned JSONL event contract shared by
 // Kontext runtimes and external observers.
+//
+// Event envelopes are strict records: parsers reject unknown top-level fields
+// and trailing data. Additive event changes therefore require a new contract
+// version rather than silently changing the shape consumed by observers.
 package v1alpha1
 
 import (

--- a/pkg/result/v1alpha1/parse.go
+++ b/pkg/result/v1alpha1/parse.go
@@ -15,61 +15,46 @@ type LegacyPayload struct {
 	Error       string   `json:"error,omitempty"`
 }
 
-// ParsedResult is the normalized representation of a termination message.
-type ParsedResult struct {
-	Envelope *Envelope
-	Output   *Output
-	Usage    *Usage
-	Error    *ErrorInfo
-	Outcome  Outcome
-	Legacy   bool
-}
-
-// Parse decodes a versioned envelope, legacy payload, or plain-text result.
-func Parse(message string) (ParsedResult, error) {
+// Parse decodes a termination message into the current result envelope.
+// The returned boolean reports whether the message used a legacy JSON or
+// plain-text wire format.
+func Parse(message string) (Envelope, bool, error) {
 	message = strings.TrimSpace(message)
 	if message == "" {
-		return ParsedResult{}, nil
+		return successfulEnvelope(), false, nil
 	}
 	if !strings.HasPrefix(message, "{") {
-		return parsedPlainText(message), nil
+		envelope := successfulEnvelope()
+		envelope.Output = outputFromText(message)
+		return envelope, true, nil
 	}
 
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(message), &fields); err != nil {
-		return ParsedResult{}, fmt.Errorf("decode termination payload: %w", err)
+		return Envelope{}, false, fmt.Errorf("decode termination payload: %w", err)
 	}
 	if _, versioned := fields["apiVersion"]; versioned {
 		var envelope Envelope
 		if err := json.Unmarshal([]byte(message), &envelope); err != nil {
-			return ParsedResult{}, fmt.Errorf("decode result envelope: %w", err)
+			return Envelope{}, false, fmt.Errorf("decode result envelope: %w", err)
 		}
 		if err := envelope.Validate(); err != nil {
-			return ParsedResult{}, fmt.Errorf("validate result envelope: %w", err)
+			return Envelope{}, false, fmt.Errorf("validate result envelope: %w", err)
 		}
-		return ParsedResult{
-			Envelope: &envelope,
-			Output:   envelope.Output,
-			Usage:    envelope.Usage,
-			Error:    envelope.Error,
-			Outcome:  envelope.Outcome,
-		}, nil
+		return envelope, false, nil
 	}
 
 	var legacy LegacyPayload
 	if err := json.Unmarshal([]byte(message), &legacy); err != nil {
-		return ParsedResult{}, fmt.Errorf("decode legacy termination payload: %w", err)
+		return Envelope{}, false, fmt.Errorf("decode legacy termination payload: %w", err)
 	}
-	parsed := ParsedResult{
-		Output:  outputFromText(legacy.Result),
-		Usage:   usageFromLegacy(legacy),
-		Outcome: OutcomeSucceeded,
-		Legacy:  true,
-	}
+	envelope := successfulEnvelope()
+	envelope.Output = outputFromText(legacy.Result)
+	envelope.Usage = usageFromLegacy(legacy)
 	if legacy.Error != "" {
-		parsed.Error = &ErrorInfo{Message: legacy.Error}
+		envelope.Error = &ErrorInfo{Message: legacy.Error}
 	}
-	return parsed, nil
+	return envelope, true, nil
 }
 
 // ProjectLegacyResult deterministically projects structured output into the
@@ -92,11 +77,10 @@ func ProjectLegacyResult(output *Output) string {
 	return compact.String()
 }
 
-func parsedPlainText(message string) ParsedResult {
-	return ParsedResult{
-		Output:  outputFromText(message),
-		Outcome: OutcomeSucceeded,
-		Legacy:  true,
+func successfulEnvelope() Envelope {
+	return Envelope{
+		APIVersion: APIVersion,
+		Outcome:    OutcomeSucceeded,
 	}
 }
 

--- a/pkg/result/v1alpha1/parse.go
+++ b/pkg/result/v1alpha1/parse.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -14,6 +15,10 @@ type LegacyPayload struct {
 	DollarsUsed *float64 `json:"dollarsUsed,omitempty"`
 	Error       string   `json:"error,omitempty"`
 }
+
+// ErrVersionedEnvelopeRequired indicates that a termination message was empty
+// or used a legacy wire format where a versioned envelope was required.
+var ErrVersionedEnvelopeRequired = errors.New("versioned result envelope required")
 
 // Parse decodes a termination message into the current result envelope.
 // The returned boolean reports whether the message used a legacy JSON or
@@ -55,6 +60,19 @@ func Parse(message string) (Envelope, bool, error) {
 		envelope.Error = &ErrorInfo{Message: legacy.Error}
 	}
 	return envelope, true, nil
+}
+
+// ParseVersioned decodes a termination message only when the wire payload
+// contains a versioned result envelope.
+func ParseVersioned(message string) (Envelope, error) {
+	envelope, legacy, err := Parse(message)
+	if err != nil {
+		return Envelope{}, err
+	}
+	if legacy || strings.TrimSpace(message) == "" {
+		return Envelope{}, ErrVersionedEnvelopeRequired
+	}
+	return envelope, nil
 }
 
 // ProjectLegacyResult deterministically projects structured output into the

--- a/pkg/result/v1alpha1/result_test.go
+++ b/pkg/result/v1alpha1/result_test.go
@@ -2,6 +2,7 @@ package v1alpha1_test
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -140,6 +141,38 @@ func TestParseVersionedEnvelopeToleratesUnknownTopLevelFields(t *testing.T) {
 	}
 	if legacy || envelope.Outcome != resultv1alpha1.OutcomeSucceeded {
 		t.Fatalf("unexpected parsed envelope %#v legacy=%v", envelope, legacy)
+	}
+}
+
+func TestParseVersionedRequiresVersionedWirePayload(t *testing.T) {
+	for name, message := range map[string]string{
+		"empty":       "",
+		"whitespace":  " \t\r\n ",
+		"plain text":  "plain answer",
+		"legacy JSON": `{"result":"done"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := resultv1alpha1.ParseVersioned(message); !errors.Is(err, resultv1alpha1.ErrVersionedEnvelopeRequired) {
+				t.Fatalf("expected versioned-envelope sentinel, got %v", err)
+			}
+		})
+	}
+
+	envelope, err := resultv1alpha1.ParseVersioned(`{
+		"apiVersion":"kontext.dev/result/v1alpha1",
+		"outcome":"Succeeded",
+		"futureField":true
+	}`)
+	if err != nil {
+		t.Fatalf("parse versioned envelope: %v", err)
+	}
+	if envelope.Outcome != resultv1alpha1.OutcomeSucceeded {
+		t.Fatalf("unexpected versioned envelope %#v", envelope)
+	}
+
+	if _, err := resultv1alpha1.ParseVersioned(`{"apiVersion":`); err == nil ||
+		errors.Is(err, resultv1alpha1.ErrVersionedEnvelopeRequired) {
+		t.Fatalf("expected underlying malformed-payload error, got %v", err)
 	}
 }
 

--- a/pkg/result/v1alpha1/result_test.go
+++ b/pkg/result/v1alpha1/result_test.go
@@ -17,11 +17,11 @@ func TestParseVersionedEnvelopeWithArbitraryJSONOutput(t *testing.T) {
 		"extensions":{"anthropic.com/request":{"region":"us-east-1"}}
 	}`
 
-	parsed, err := resultv1alpha1.Parse(message)
+	parsed, legacy, err := resultv1alpha1.Parse(message)
 	if err != nil {
 		t.Fatalf("parse envelope: %v", err)
 	}
-	if parsed.Envelope == nil || parsed.Legacy {
+	if legacy {
 		t.Fatalf("expected versioned envelope, got %#v", parsed)
 	}
 	if got := resultv1alpha1.ProjectLegacyResult(parsed.Output); got != `{"answer":42,"items":[true,null]}` {
@@ -42,11 +42,11 @@ func TestParseVersionedEnvelopeWithArbitraryJSONOutput(t *testing.T) {
 }
 
 func TestParseLegacyPayload(t *testing.T) {
-	parsed, err := resultv1alpha1.Parse(`{"result":"done","tokensUsed":0,"dollarsUsed":1.5}`)
+	parsed, legacy, err := resultv1alpha1.Parse(`{"result":"done","tokensUsed":0,"dollarsUsed":1.5}`)
 	if err != nil {
 		t.Fatalf("parse legacy payload: %v", err)
 	}
-	if !parsed.Legacy || parsed.Envelope != nil {
+	if !legacy || parsed.APIVersion != resultv1alpha1.APIVersion {
 		t.Fatalf("expected legacy payload, got %#v", parsed)
 	}
 	if got := resultv1alpha1.ProjectLegacyResult(parsed.Output); got != "done" {
@@ -61,9 +61,12 @@ func TestParseLegacyPayload(t *testing.T) {
 }
 
 func TestParseLegacyPayloadWithoutUsageLeavesUsageAbsent(t *testing.T) {
-	parsed, err := resultv1alpha1.Parse(`{"result":"done"}`)
+	parsed, legacy, err := resultv1alpha1.Parse(`{"result":"done"}`)
 	if err != nil {
 		t.Fatalf("parse legacy payload: %v", err)
+	}
+	if !legacy {
+		t.Fatal("expected legacy wire format")
 	}
 	if parsed.Outcome != resultv1alpha1.OutcomeSucceeded {
 		t.Fatalf("expected explicit successful outcome, got %q", parsed.Outcome)
@@ -74,9 +77,12 @@ func TestParseLegacyPayloadWithoutUsageLeavesUsageAbsent(t *testing.T) {
 }
 
 func TestParseLegacyErrorPreservesExitCodeAuthority(t *testing.T) {
-	parsed, err := resultv1alpha1.Parse(`{"result":"done","error":"informational warning"}`)
+	parsed, legacy, err := resultv1alpha1.Parse(`{"result":"done","error":"informational warning"}`)
 	if err != nil {
 		t.Fatalf("parse legacy payload: %v", err)
+	}
+	if !legacy {
+		t.Fatal("expected legacy wire format")
 	}
 	if parsed.Outcome != resultv1alpha1.OutcomeSucceeded {
 		t.Fatalf("legacy error must not override a successful process exit, got %q", parsed.Outcome)
@@ -87,15 +93,53 @@ func TestParseLegacyErrorPreservesExitCodeAuthority(t *testing.T) {
 }
 
 func TestParsePlainText(t *testing.T) {
-	parsed, err := resultv1alpha1.Parse("plain answer")
+	parsed, legacy, err := resultv1alpha1.Parse("plain answer")
 	if err != nil {
 		t.Fatalf("parse plain text: %v", err)
+	}
+	if !legacy {
+		t.Fatal("expected plain text to be reported as legacy wire format")
 	}
 	if parsed.Outcome != resultv1alpha1.OutcomeSucceeded {
 		t.Fatalf("expected explicit successful outcome, got %q", parsed.Outcome)
 	}
 	if got := resultv1alpha1.ProjectLegacyResult(parsed.Output); got != "plain answer" {
 		t.Fatalf("expected plain answer, got %q", got)
+	}
+}
+
+func TestParseEmptyMessageSynthesizesSuccessfulEnvelope(t *testing.T) {
+	for _, message := range []string{"", " \t\r\n "} {
+		t.Run(message, func(t *testing.T) {
+			envelope, legacy, err := resultv1alpha1.Parse(message)
+			if err != nil {
+				t.Fatalf("parse empty message: %v", err)
+			}
+			if legacy {
+				t.Fatal("empty message must not be reported as a legacy wire payload")
+			}
+			if envelope.APIVersion != resultv1alpha1.APIVersion ||
+				envelope.Outcome != resultv1alpha1.OutcomeSucceeded {
+				t.Fatalf("unexpected empty-message envelope %#v", envelope)
+			}
+			if envelope.Output != nil || envelope.Usage != nil || envelope.Error != nil {
+				t.Fatalf("empty success must not invent result data: %#v", envelope)
+			}
+		})
+	}
+}
+
+func TestParseVersionedEnvelopeToleratesUnknownTopLevelFields(t *testing.T) {
+	envelope, legacy, err := resultv1alpha1.Parse(`{
+		"apiVersion":"kontext.dev/result/v1alpha1",
+		"outcome":"Succeeded",
+		"futureField":{"nested":true}
+	}`)
+	if err != nil {
+		t.Fatalf("parse forward-compatible envelope: %v", err)
+	}
+	if legacy || envelope.Outcome != resultv1alpha1.OutcomeSucceeded {
+		t.Fatalf("unexpected parsed envelope %#v legacy=%v", envelope, legacy)
 	}
 }
 
@@ -106,7 +150,7 @@ func TestParseRejectsMalformedAndPartiallyWrittenPayloads(t *testing.T) {
 	}
 	for _, message := range cases {
 		t.Run(message, func(t *testing.T) {
-			if _, err := resultv1alpha1.Parse(message); err == nil {
+			if _, _, err := resultv1alpha1.Parse(message); err == nil {
 				t.Fatalf("expected malformed payload error")
 			}
 		})
@@ -114,14 +158,20 @@ func TestParseRejectsMalformedAndPartiallyWrittenPayloads(t *testing.T) {
 }
 
 func TestParseAcceptsSuccessfulAndFailedOutcomes(t *testing.T) {
-	success, err := resultv1alpha1.Parse(`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded"}`)
+	success, legacy, err := resultv1alpha1.Parse(`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded"}`)
 	if err != nil || success.Outcome != resultv1alpha1.OutcomeSucceeded {
 		t.Fatalf("unexpected success result %#v, error %v", success, err)
 	}
+	if legacy {
+		t.Fatal("versioned success was reported as legacy")
+	}
 
-	failure, err := resultv1alpha1.Parse(`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Failed","error":{"code":"provider_error","message":"unavailable","retryable":true}}`)
+	failure, legacy, err := resultv1alpha1.Parse(`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Failed","error":{"code":"provider_error","message":"unavailable","retryable":true}}`)
 	if err != nil {
 		t.Fatalf("parse failed outcome: %v", err)
+	}
+	if legacy {
+		t.Fatal("versioned failure was reported as legacy")
 	}
 	if failure.Outcome != resultv1alpha1.OutcomeFailed || failure.Error == nil || failure.Error.Code != "provider_error" {
 		t.Fatalf("unexpected failed result %#v", failure)
@@ -137,10 +187,11 @@ func TestParseRejectsInvalidEnvelope(t *testing.T) {
 		`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","output":{"mediaType":"application/json","value":`,
 		`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","usage":{"reasoningTokens":-1}}`,
 		`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","usage":{"outputTokens":4,"reasoningTokens":5}}`,
+		`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","extensions":{"unnamespaced":true}}`,
 	}
 	for _, message := range cases {
 		t.Run(message, func(t *testing.T) {
-			if _, err := resultv1alpha1.Parse(message); err == nil {
+			if _, _, err := resultv1alpha1.Parse(message); err == nil {
 				t.Fatalf("expected invalid envelope error")
 			}
 		})
@@ -178,19 +229,22 @@ func TestCompactProducesValidBoundedEnvelope(t *testing.T) {
 	if !json.Valid(compacted) {
 		t.Fatalf("compacted envelope is invalid JSON: %s", compacted)
 	}
-	parsed, err := resultv1alpha1.Parse(string(compacted))
+	parsed, legacy, err := resultv1alpha1.Parse(string(compacted))
 	if err != nil {
 		t.Fatalf("parse compacted envelope: %v", err)
 	}
-	if parsed.Envelope.Truncation == nil || !parsed.Envelope.Truncation.OutputTruncated {
-		t.Fatalf("expected explicit output truncation, got %#v", parsed.Envelope.Truncation)
+	if legacy {
+		t.Fatal("compacted envelope was reported as legacy")
+	}
+	if parsed.Truncation == nil || !parsed.Truncation.OutputTruncated {
+		t.Fatalf("expected explicit output truncation, got %#v", parsed.Truncation)
 	}
 	marker := resultv1alpha1.TruncatedOutput()
-	if parsed.Envelope.Output == nil ||
-		parsed.Envelope.Output.MediaType != resultv1alpha1.TruncatedOutputMediaType ||
-		parsed.Envelope.Output.MediaType != marker.MediaType ||
-		string(parsed.Envelope.Output.Value) != string(marker.Value) {
-		t.Fatalf("compaction did not use the shared truncation marker: %#v", parsed.Envelope.Output)
+	if parsed.Output == nil ||
+		parsed.Output.MediaType != resultv1alpha1.TruncatedOutputMediaType ||
+		parsed.Output.MediaType != marker.MediaType ||
+		string(parsed.Output.Value) != string(marker.Value) {
+		t.Fatalf("compaction did not use the shared truncation marker: %#v", parsed.Output)
 	}
 }
 

--- a/pkg/result/v1alpha1/stream_test.go
+++ b/pkg/result/v1alpha1/stream_test.go
@@ -30,11 +30,11 @@ func TestWriteEnvelopeLineRoundTripsThroughExtract(t *testing.T) {
 	if !found {
 		t.Fatalf("payload not recognized in %q", line)
 	}
-	parsed, err := resultv1alpha1.Parse(string(payload))
+	parsed, legacy, err := resultv1alpha1.Parse(string(payload))
 	if err != nil {
 		t.Fatalf("parse payload: %v", err)
 	}
-	if parsed.Envelope == nil || parsed.Envelope.Outcome != resultv1alpha1.OutcomeFailed {
+	if legacy || parsed.Outcome != resultv1alpha1.OutcomeFailed {
 		t.Fatalf("unexpected parsed result %#v", parsed)
 	}
 }

--- a/pkg/result/v1alpha1/types.go
+++ b/pkg/result/v1alpha1/types.go
@@ -1,5 +1,11 @@
 // Package v1alpha1 defines the versioned result contract shared by Kontext
 // runtimes, reporters, and the control plane.
+//
+// Result envelopes are forward-compatible at the top level: parsers ignore
+// unknown top-level fields while validating every known field. Runtime- or
+// provider-specific data belongs under Extensions and must use namespaced
+// keys. Parse also normalizes the transitional legacy JSON and plain-text wire
+// formats into the current Envelope shape.
 package v1alpha1
 
 import (

--- a/runtimes/reference/main_test.go
+++ b/runtimes/reference/main_test.go
@@ -75,14 +75,14 @@ func resultLine(t *testing.T, output string) resultv1alpha1.Envelope {
 		if !found {
 			continue
 		}
-		parsed, err := resultv1alpha1.Parse(string(payload))
+		envelope, legacy, err := resultv1alpha1.Parse(string(payload))
 		if err != nil {
 			t.Fatalf("parse result line: %v", err)
 		}
-		if parsed.Envelope == nil {
+		if legacy {
 			t.Fatalf("result line was not a versioned envelope")
 		}
-		return *parsed.Envelope
+		return envelope
 	}
 	t.Fatalf("result line not found in %q", output)
 	return resultv1alpha1.Envelope{}

--- a/runtimes/reporter/reporter.go
+++ b/runtimes/reporter/reporter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
@@ -93,14 +94,14 @@ func envelopeFromPrefixedCandidate(captured CapturedResult) resultv1alpha1.Envel
 		return failureEnvelope("result_invalid", "prefixed Kontext result exceeded the capture limit")
 	}
 
-	parsed, err := resultv1alpha1.Parse(string(captured.Data))
+	envelope, legacy, err := resultv1alpha1.Parse(string(captured.Data))
 	if err != nil {
 		return failureEnvelope("result_invalid", fmt.Sprintf("invalid prefixed Kontext result: %v", err))
 	}
-	if parsed.Envelope == nil {
+	if legacy || strings.TrimSpace(string(captured.Data)) == "" {
 		return failureEnvelope("result_invalid", "prefixed Kontext result must be a versioned envelope")
 	}
-	return *parsed.Envelope
+	return envelope
 }
 
 func failureEnvelope(code string, message string) resultv1alpha1.Envelope {

--- a/runtimes/reporter/reporter.go
+++ b/runtimes/reporter/reporter.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	resultv1alpha1 "github.com/MFS-code/Kontext/pkg/result/v1alpha1"
 )
@@ -94,12 +93,12 @@ func envelopeFromPrefixedCandidate(captured CapturedResult) resultv1alpha1.Envel
 		return failureEnvelope("result_invalid", "prefixed Kontext result exceeded the capture limit")
 	}
 
-	envelope, legacy, err := resultv1alpha1.Parse(string(captured.Data))
+	envelope, err := resultv1alpha1.ParseVersioned(string(captured.Data))
+	if errors.Is(err, resultv1alpha1.ErrVersionedEnvelopeRequired) {
+		return failureEnvelope("result_invalid", "prefixed Kontext result must be a versioned envelope")
+	}
 	if err != nil {
 		return failureEnvelope("result_invalid", fmt.Sprintf("invalid prefixed Kontext result: %v", err))
-	}
-	if legacy || strings.TrimSpace(string(captured.Data)) == "" {
-		return failureEnvelope("result_invalid", "prefixed Kontext result must be a versioned envelope")
 	}
 	return envelope
 }

--- a/runtimes/reporter/reporter_test.go
+++ b/runtimes/reporter/reporter_test.go
@@ -76,7 +76,7 @@ func TestEnvelopeFromPrefixedCandidate(t *testing.T) {
 	valid := CapturedResult{
 		Found: true,
 		Data: []byte(
-			`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","output":{"mediaType":"application/json","value":{"ok":true}}}`,
+			`{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","output":{"mediaType":"application/json","value":{"ok":true}},"futureField":true}`,
 		),
 	}
 	envelope := envelopeFromCapture(CaptureFormatKontextEnvelope, valid, 0)
@@ -91,6 +91,8 @@ func TestEnvelopeFromPrefixedCandidate(t *testing.T) {
 		{name: "missing"},
 		{name: "truncated", captured: CapturedResult{Found: true, Truncated: true, Data: []byte(`{}`)}},
 		{name: "malformed", captured: CapturedResult{Found: true, Data: []byte(`{"apiVersion":`)}},
+		{name: "empty", captured: CapturedResult{Found: true}},
+		{name: "plain text", captured: CapturedResult{Found: true, Data: []byte(`old result`)}},
 		{name: "legacy", captured: CapturedResult{Found: true, Data: []byte(`{"result":"old"}`)}},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Summary
- replace `ParsedResult` with a normalized `Envelope` plus legacy-wire indicator across status, reporter, eval, and reference-runtime callers
- make empty success explicit, preserve legacy exit-code authority, and keep versioned results forward-compatible at the top level
- document and test the distinct result, event, and CRD evolution policies

## Tests
- `make fmt`
- `go test ./api/v1alpha1 ./pkg/result/... ./pkg/event/... ./internal/status ./runtimes/reporter ./internal/eval ./runtimes/reference`
- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.32.0 -p path)" go test ./internal/controller/...`
- `make verify`
- `make test`
- `make docker-build-reporter REPORTER_IMG=kontext-reporter:issue-60`
- `make docker-build-reference REFERENCE_IMG=kontext-reference:issue-60`

Closes #60