### PR TITLE
Decompose MCP client responsibilities

### DIFF
--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -1,0 +1,18 @@
+// Package environment provides deterministic process environment encoding.
+package environment
+
+import "sort"
+
+// Sorted returns name=value entries ordered by variable name.
+func Sorted(values map[string]string) []string {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	encoded := make([]string, 0, len(names))
+	for _, name := range names {
+		encoded = append(encoded, name+"="+values[name])
+	}
+	return encoded
+}

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -1,0 +1,18 @@
+package environment
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSortedOrdersEnvironmentNames(t *testing.T) {
+	got := Sorted(map[string]string{
+		"ZED":    "last",
+		"ALPHA":  "first",
+		"MIDDLE": "middle",
+	})
+	want := []string{"ALPHA=first", "MIDDLE=middle", "ZED=last"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("environment = %#v, want %#v", got, want)
+	}
+}

--- a/runtimes/reference/internal/mcpclient/client.go
+++ b/runtimes/reference/internal/mcpclient/client.go
@@ -1,19 +1,14 @@
 package mcpclient
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os/exec"
-	"regexp"
-	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -21,28 +16,14 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/MFS-code/Kontext/internal/procgroup"
-	"github.com/MFS-code/Kontext/internal/tooloutput"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const (
-	maxCapturedBytes            = int64(8 << 20)
-	maxHTTPWireBytes            = int64(64 << 20)
-	maxStdioFrameBytes          = int64(64 << 20)
-	maxDiscoveredTools          = 256
-	maxToolDescriptionBytes     = 16 << 10
-	maxToolSchemaBytes          = 256 << 10
-	maxToolDefinitionBytes      = 280 << 10
-	maxTotalToolDefinitionBytes = 4 << 20
-	maxExternalErrorBytes       = int64(4 << 10)
-	maxStderrLineBytes          = 64 << 10
-	httpCloseRequestTimeout     = 2 * time.Second
-	processTerminationGrace     = 500 * time.Millisecond
-	fallbackDescriptionPrefix   = "MCP tool"
+	maxStdioFrameBytes      = int64(64 << 20)
+	processTerminationGrace = 500 * time.Millisecond
 )
-
-var mcpToolNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,128}$`)
 
 type Error struct {
 	Code    string
@@ -74,12 +55,6 @@ type remoteTool struct {
 	name   string
 	server *server
 	schema *jsonschema.Resolved
-}
-
-type frozenTool struct {
-	name       string
-	definition runtimeapi.ToolDefinition
-	schema     *jsonschema.Resolved
 }
 
 type server struct {
@@ -175,11 +150,19 @@ func (manager *Manager) Execute(
 	arguments json.RawMessage,
 ) (Result, error) {
 	if manager == nil {
-		return Result{IsError: true, ErrorCode: "mcp_unavailable", Content: "MCP execution is unavailable"}, nil
+		return Result{
+			IsError:   true,
+			ErrorCode: "mcp_unavailable",
+			Content:   "MCP execution is unavailable",
+		}, nil
 	}
 	selected, exists := manager.tools[name]
 	if !exists {
-		return Result{IsError: true, ErrorCode: "unknown_tool", Content: fmt.Sprintf("tool %q is not available", name)}, nil
+		return Result{
+			IsError:   true,
+			ErrorCode: "unknown_tool",
+			Content:   fmt.Sprintf("tool %q is not available", name),
+		}, nil
 	}
 	if err := validateArguments(selected.name, selected.schema, arguments); err != nil {
 		return Result{
@@ -376,7 +359,7 @@ func (current *server) call(
 		}, nil
 	}
 
-	content, normalizeErr := normalizeResult(response, current.redactor)
+	content, truncated, normalizeErr := normalizeResult(response, current.redactor)
 	if normalizeErr != nil {
 		return Result{
 			IsError:   true,
@@ -384,7 +367,6 @@ func (current *server) call(
 			Content:   normalizeErr.Message,
 		}, nil
 	}
-	content, truncated := tooloutput.Bound(content, maxCapturedBytes)
 	return Result{
 		Content:   content,
 		IsError:   response.IsError,
@@ -451,271 +433,6 @@ func (current *server) terminateCommand(ctx context.Context, command *managedCom
 	)
 }
 
-func discoverTools(
-	ctx context.Context,
-	serverName string,
-	session *mcp.ClientSession,
-	redactor redactor,
-) ([]frozenTool, error) {
-	var discovered []frozenTool
-	seen := make(map[string]struct{})
-	totalDefinitionBytes := 0
-	for tool, err := range session.Tools(ctx, nil) {
-		if err != nil {
-			return nil, fmt.Errorf("discover tools: %w", err)
-		}
-		if len(discovered) >= maxDiscoveredTools {
-			return nil, &Error{
-				Code: "mcp_discovery_limit_exceeded",
-				Message: fmt.Sprintf(
-					"MCP server %q exposes more than %d tools",
-					serverName,
-					maxDiscoveredTools,
-				),
-			}
-		}
-		if tool == nil || !mcpToolNamePattern.MatchString(tool.Name) {
-			return nil, &Error{
-				Code: "mcp_invalid_tool_definition",
-				Message: fmt.Sprintf(
-					"MCP server %q returned a tool name outside the 1..128 [A-Za-z0-9_.-]+ constraint",
-					serverName,
-				),
-			}
-		}
-		if redactor.containsSensitive(tool.Name) {
-			return nil, &Error{
-				Code:    "mcp_invalid_tool_definition",
-				Message: fmt.Sprintf("MCP server %q returned a tool name containing a resolved sensitive value", serverName),
-			}
-		}
-		if _, duplicate := seen[tool.Name]; duplicate {
-			return nil, &Error{
-				Code:    "mcp_invalid_tool_definition",
-				Message: fmt.Sprintf("MCP server %q returned duplicate tool %q", serverName, tool.Name),
-			}
-		}
-		seen[tool.Name] = struct{}{}
-		description := strings.TrimSpace(tool.Description)
-		if description == "" {
-			description = fmt.Sprintf("%s %q from server %q.", fallbackDescriptionPrefix, tool.Name, serverName)
-		}
-		description = redactor.replace(description)
-		if len(description) > maxToolDescriptionBytes {
-			return nil, discoveryLimitError(
-				serverName,
-				tool.Name,
-				"description",
-				len(description),
-				maxToolDescriptionBytes,
-			)
-		}
-		rawSchema, marshalErr := json.Marshal(tool.InputSchema)
-		if marshalErr != nil {
-			return nil, &Error{
-				Code:    "mcp_invalid_tool_definition",
-				Message: fmt.Sprintf("MCP server %q tool %q schema cannot be encoded", serverName, tool.Name),
-			}
-		}
-		if redactor.containsSensitive(string(rawSchema)) {
-			return nil, &Error{
-				Code: "mcp_invalid_tool_definition",
-				Message: fmt.Sprintf(
-					"MCP server %q tool %q schema contains a resolved sensitive value",
-					serverName,
-					tool.Name,
-				),
-			}
-		}
-		if tool.InputSchema != nil && len(rawSchema) > maxToolSchemaBytes {
-			return nil, discoveryLimitError(
-				serverName,
-				tool.Name,
-				"schema",
-				len(rawSchema),
-				maxToolSchemaBytes,
-			)
-		}
-		schema, resolvedSchema, err := normalizeSchema(tool.InputSchema)
-		if err != nil {
-			return nil, &Error{
-				Code:    "mcp_invalid_tool_definition",
-				Message: fmt.Sprintf("MCP server %q tool %q: %v", serverName, tool.Name, err),
-			}
-		}
-		if len(schema) > maxToolSchemaBytes {
-			return nil, discoveryLimitError(
-				serverName,
-				tool.Name,
-				"schema",
-				len(schema),
-				maxToolSchemaBytes,
-			)
-		}
-		definitionBytes := len(tool.Name) + len(description) + len(schema)
-		if definitionBytes > maxToolDefinitionBytes {
-			return nil, discoveryLimitError(
-				serverName,
-				tool.Name,
-				"definition",
-				definitionBytes,
-				maxToolDefinitionBytes,
-			)
-		}
-		totalDefinitionBytes += definitionBytes
-		if totalDefinitionBytes > maxTotalToolDefinitionBytes {
-			return nil, &Error{
-				Code: "mcp_discovery_limit_exceeded",
-				Message: fmt.Sprintf(
-					"MCP server %q tool definitions exceed the %d-byte total limit",
-					serverName,
-					maxTotalToolDefinitionBytes,
-				),
-			}
-		}
-		discovered = append(discovered, frozenTool{
-			name: tool.Name,
-			definition: runtimeapi.ToolDefinition{
-				Name:        tool.Name,
-				Description: description,
-				InputSchema: schema,
-			},
-			schema: resolvedSchema,
-		})
-	}
-	return discovered, nil
-}
-
-func normalizeSchema(schema any) (json.RawMessage, *jsonschema.Resolved, error) {
-	if schema == nil {
-		schema = json.RawMessage(`{"type":"object"}`)
-	}
-	encoded, err := json.Marshal(schema)
-	if err != nil {
-		return nil, nil, fmt.Errorf("input schema cannot be encoded: %w", err)
-	}
-	var object map[string]json.RawMessage
-	if err := json.Unmarshal(encoded, &object); err != nil || object == nil {
-		return nil, nil, errors.New("input schema must be a top-level JSON object")
-	}
-	var validationSchema jsonschema.Schema
-	if err := json.Unmarshal(encoded, &validationSchema); err != nil {
-		return nil, nil, fmt.Errorf("input schema is invalid: %w", err)
-	}
-	resolved, err := validationSchema.Resolve(nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("input schema is invalid: %w", err)
-	}
-	var compacted bytes.Buffer
-	if err := json.Compact(&compacted, encoded); err != nil {
-		return nil, nil, fmt.Errorf("input schema is malformed: %w", err)
-	}
-	return json.RawMessage(compacted.String()), resolved, nil
-}
-
-func discoveryLimitError(
-	serverName string,
-	toolName string,
-	part string,
-	actual int,
-	limit int,
-) *Error {
-	return &Error{
-		Code: "mcp_discovery_limit_exceeded",
-		Message: fmt.Sprintf(
-			"MCP server %q tool %q %s is %d bytes; limit is %d bytes",
-			serverName,
-			toolName,
-			part,
-			actual,
-			limit,
-		),
-	}
-}
-
-type resultError struct {
-	Code    string
-	Message string
-}
-
-func normalizeResult(
-	response *mcp.CallToolResult,
-	redactor redactor,
-) (string, *resultError) {
-	if response == nil {
-		return "", &resultError{Code: "mcp_invalid_response", Message: "MCP server returned an empty tool response"}
-	}
-	if response.StructuredContent != nil {
-		encoded, err := json.Marshal(response.StructuredContent)
-		if err != nil {
-			return "", &resultError{Code: "mcp_invalid_response", Message: "MCP structured content could not be encoded"}
-		}
-		var object map[string]any
-		decoder := json.NewDecoder(bytes.NewReader(encoded))
-		decoder.UseNumber()
-		if err := decoder.Decode(&object); err != nil || object == nil {
-			return "", &resultError{Code: "mcp_invalid_response", Message: "MCP structured content must be a JSON object"}
-		}
-		redacted := redactStructuredValue(object, redactor)
-		encoded, err = json.Marshal(redacted)
-		if err != nil {
-			return "", &resultError{Code: "mcp_invalid_response", Message: "MCP structured content could not be normalized"}
-		}
-		return string(encoded), nil
-	}
-	for _, item := range response.Content {
-		if _, text := item.(*mcp.TextContent); !text {
-			return "", &resultError{
-				Code:    "mcp_unsupported_content",
-				Message: "MCP tool returned unsupported non-text content",
-			}
-		}
-	}
-	text := make([]string, 0, len(response.Content))
-	for _, item := range response.Content {
-		text = append(text, redactor.replace(item.(*mcp.TextContent).Text))
-	}
-	return strings.Join(text, "\n"), nil
-}
-
-func redactStructuredValue(value any, redactor redactor) any {
-	switch typed := value.(type) {
-	case string:
-		return redactor.replace(typed)
-	case []any:
-		for index := range typed {
-			typed[index] = redactStructuredValue(typed[index], redactor)
-		}
-		return typed
-	case map[string]any:
-		for key, child := range typed {
-			typed[key] = redactStructuredValue(child, redactor)
-		}
-		return typed
-	default:
-		return value
-	}
-}
-
-func sameTools(left []frozenTool, right []frozenTool) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	rightByName := make(map[string]runtimeapi.ToolDefinition, len(right))
-	for _, tool := range right {
-		rightByName[tool.name] = tool.definition
-	}
-	for _, tool := range left {
-		candidate, exists := rightByName[tool.name]
-		if !exists ||
-			tool.definition.Description != candidate.Description ||
-			string(tool.definition.InputSchema) != string(candidate.InputSchema) {
-			return false
-		}
-	}
-	return true
-}
-
 func operationContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout <= 0 {
 		return context.WithCancel(parent)
@@ -740,263 +457,12 @@ func validateArguments(
 	return nil
 }
 
-type boundedHTTPTransport struct {
-	base           http.RoundTripper
-	endpointOrigin string
-	headers        map[string]string
-	maxWireBytes   int64
-}
-
-var errMCPHTTPWireLimit = errors.New("mcp_http_wire_limit_exceeded")
-
-func (transport *boundedHTTPTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	cloned := request.Clone(request.Context())
-	cloned.Header = request.Header.Clone()
-	if origin(cloned.URL) == transport.endpointOrigin {
-		for name, value := range transport.headers {
-			cloned.Header.Set(name, value)
-		}
-	} else {
-		for name := range transport.headers {
-			cloned.Header.Del(name)
-		}
-	}
-	var cancel context.CancelFunc
-	if cloned.Method == http.MethodDelete {
-		closeCtx, closeCancel := context.WithTimeout(cloned.Context(), httpCloseRequestTimeout)
-		cancel = closeCancel
-		cloned = cloned.Clone(closeCtx)
-	}
-	response, err := transport.base.RoundTrip(cloned)
-	if err != nil {
-		if cancel != nil {
-			cancel()
-		}
-		return nil, err
-	}
-	wireLimit := transport.maxWireBytes
-	if wireLimit <= 0 {
-		wireLimit = maxHTTPWireBytes
-	}
-	if response.ContentLength > wireLimit {
-		_ = response.Body.Close()
-		if cancel != nil {
-			cancel()
-		}
-		return nil, fmt.Errorf(
-			"%w: MCP HTTP response Content-Length exceeds %d-byte wire limit",
-			errMCPHTTPWireLimit,
-			wireLimit,
-		)
-	}
-	response.Body = &countingReadCloser{
-		body:   response.Body,
-		limit:  wireLimit,
-		cancel: cancel,
-	}
-	return response, nil
-}
-
-type countingReadCloser struct {
-	body      io.ReadCloser
-	limit     int64
-	read      int64
-	exceeded  bool
-	cancel    context.CancelFunc
-	closeOnce sync.Once
-	closeErr  error
-}
-
-func (reader *countingReadCloser) Read(buffer []byte) (int, error) {
-	if reader.exceeded {
-		return 0, errMCPHTTPWireLimit
-	}
-	if len(buffer) == 0 {
-		return 0, nil
-	}
-	remaining := reader.limit - reader.read
-	maximumRead := int64(len(buffer))
-	if maximumRead > remaining+1 {
-		maximumRead = remaining + 1
-	}
-	if maximumRead < 1 {
-		maximumRead = 1
-	}
-	count, err := reader.body.Read(buffer[:maximumRead])
-	if int64(count) > remaining {
-		allowed := int(max(remaining, 0))
-		reader.read += int64(allowed)
-		reader.exceeded = true
-		return allowed, errMCPHTTPWireLimit
-	}
-	reader.read += int64(count)
-	return count, err
-}
-
-func (reader *countingReadCloser) Close() error {
-	reader.closeOnce.Do(func() {
-		reader.closeErr = reader.body.Close()
-		if reader.cancel != nil {
-			reader.cancel()
-		}
-	})
-	return reader.closeErr
-}
-
-func sameOriginRedirectPolicy(endpoint *url.URL) func(*http.Request, []*http.Request) error {
-	expectedOrigin := origin(endpoint)
-	return func(request *http.Request, via []*http.Request) error {
-		if origin(request.URL) != expectedOrigin {
-			return errors.New("MCP cross-origin redirect is not allowed")
-		}
-		if len(via) >= 10 {
-			return errors.New("MCP redirect limit exceeded")
-		}
-		return nil
-	}
-}
-
-func origin(value *url.URL) string {
-	if value == nil {
-		return ""
-	}
-	scheme := strings.ToLower(value.Scheme)
-	port := value.Port()
-	if port == "" {
-		switch scheme {
-		case "http":
-			port = "80"
-		case "https":
-			port = "443"
-		}
-	}
-	host := strings.ToLower(value.Hostname())
-	if port == "" {
-		return scheme + "://" + host
-	}
-	return scheme + "://" + net.JoinHostPort(host, port)
-}
-
 func cloneStrings(values map[string]string) map[string]string {
 	cloned := make(map[string]string, len(values))
 	for name, value := range values {
 		cloned[name] = value
 	}
 	return cloned
-}
-
-type redactor struct {
-	values []string
-}
-
-func newRedactor(values []string) redactor {
-	cloned := append([]string(nil), values...)
-	sort.Slice(cloned, func(left int, right int) bool {
-		return len(cloned[left]) > len(cloned[right])
-	})
-	return redactor{values: cloned}
-}
-
-func (redactor redactor) clean(value string) string {
-	return tooloutput.TruncateUTF8(redactor.replace(value), maxExternalErrorBytes)
-}
-
-func (redactor redactor) replace(value string) string {
-	for _, sensitive := range redactor.values {
-		if sensitive != "" {
-			value = strings.ReplaceAll(value, sensitive, "[REDACTED]")
-		}
-	}
-	return value
-}
-
-func (redactor redactor) containsSensitive(value string) bool {
-	for _, sensitive := range redactor.values {
-		if sensitive == "" {
-			continue
-		}
-		if strings.Contains(value, sensitive) {
-			return true
-		}
-		encoded, _ := json.Marshal(sensitive)
-		escaped := strings.Trim(string(encoded), `"`)
-		if escaped != sensitive && strings.Contains(value, escaped) {
-			return true
-		}
-	}
-	return false
-}
-
-func (current *server) safeMessage(value string) string {
-	return current.redactor.clean(value)
-}
-
-func (current *server) safeError(code string, prefix string, err error) *Error {
-	message := prefix
-	if err != nil {
-		message += ": " + err.Error()
-	}
-	return &Error{Code: code, Message: current.safeMessage(message)}
-}
-
-type redactingLineWriter struct {
-	mu         sync.Mutex
-	sink       io.Writer
-	redactor   redactor
-	buffer     []byte
-	discarding bool
-}
-
-func newRedactingLineWriter(sink io.Writer, redactor redactor) io.Writer {
-	return &redactingLineWriter{sink: sink, redactor: redactor}
-}
-
-func (writer *redactingLineWriter) Write(data []byte) (int, error) {
-	writer.mu.Lock()
-	defer writer.mu.Unlock()
-	originalLength := len(data)
-	for len(data) > 0 {
-		newline := bytes.IndexByte(data, '\n')
-		var part []byte
-		if newline < 0 {
-			part = data
-			data = nil
-		} else {
-			part = data[:newline+1]
-			data = data[newline+1:]
-		}
-		if writer.discarding {
-			if newline >= 0 {
-				writer.discarding = false
-			}
-			continue
-		}
-		if len(writer.buffer)+len(part) > maxStderrLineBytes {
-			writer.buffer = writer.buffer[:0]
-			writer.discarding = newline < 0
-			_, _ = io.WriteString(writer.sink, "MCP stderr line omitted: too long\n")
-			continue
-		}
-		writer.buffer = append(writer.buffer, part...)
-		if newline >= 0 {
-			_, _ = io.WriteString(writer.sink, writer.redactor.clean(string(writer.buffer)))
-			writer.buffer = writer.buffer[:0]
-		}
-	}
-	return originalLength, nil
-}
-
-func sortedEnvironment(values map[string]string) []string {
-	names := make([]string, 0, len(values))
-	for name := range values {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	environment := make([]string, 0, len(names))
-	for _, name := range names {
-		environment = append(environment, name+"="+values[name])
-	}
-	return environment
 }
 
 func errorCode(isError bool) string {

--- a/runtimes/reference/internal/mcpclient/client_test.go
+++ b/runtimes/reference/internal/mcpclient/client_test.go
@@ -630,7 +630,7 @@ func TestResolvedValuesAreRedactedAcrossStderrWrites(t *testing.T) {
 
 func TestStructuredContentRedactionPreservesJSONSyntax(t *testing.T) {
 	secrets := []string{"quote\"\nsecret", `":`, "[]"}
-	content, resultErr := normalizeResult(&mcp.CallToolResult{
+	content, truncated, resultErr := normalizeResult(&mcp.CallToolResult{
 		StructuredContent: map[string]any{
 			"quoted": "prefix quote\"\nsecret suffix",
 			"short":  "[]",
@@ -643,6 +643,9 @@ func TestStructuredContentRedactionPreservesJSONSyntax(t *testing.T) {
 	}, newRedactor(secrets))
 	if resultErr != nil {
 		t.Fatalf("normalize structured content: %v", resultErr)
+	}
+	if truncated {
+		t.Fatal("small structured content was unexpectedly truncated")
 	}
 	if !json.Valid([]byte(content)) {
 		t.Fatalf("redaction corrupted JSON syntax: %q", content)

--- a/runtimes/reference/internal/mcpclient/command.go
+++ b/runtimes/reference/internal/mcpclient/command.go
@@ -32,7 +32,7 @@ func startCommandTransport(
 	frameLimit int64,
 ) (mcp.Transport, *managedCommand, error) {
 	command := exec.Command(serverConfig.Command, serverConfig.Args...)
-	command.Env = sortedEnvironment(serverConfig.Env)
+	command.Env = environment.Sorted(serverConfig.Env)
 	command.Stderr = newRedactingLineWriter(stderr, redactor)
 	procgroup.Prepare(command)
 
@@ -165,8 +165,4 @@ func (reader *lineValidatingReadCloser) Close() error {
 		reader.closeErr = reader.closer.Close()
 	})
 	return reader.closeErr
-}
-
-func sortedEnvironment(values map[string]string) []string {
-	return environment.Sorted(values)
 }

--- a/runtimes/reference/internal/mcpclient/command.go
+++ b/runtimes/reference/internal/mcpclient/command.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/MFS-code/Kontext/internal/environment"
 	"github.com/MFS-code/Kontext/internal/procgroup"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
 )
@@ -164,4 +165,8 @@ func (reader *lineValidatingReadCloser) Close() error {
 		reader.closeErr = reader.closer.Close()
 	})
 	return reader.closeErr
+}
+
+func sortedEnvironment(values map[string]string) []string {
+	return environment.Sorted(values)
 }

--- a/runtimes/reference/internal/mcpclient/command_test.go
+++ b/runtimes/reference/internal/mcpclient/command_test.go
@@ -3,22 +3,9 @@ package mcpclient
 import (
 	"errors"
 	"io"
-	"slices"
 	"strings"
 	"testing"
 )
-
-func TestSortedEnvironmentOrdersNames(t *testing.T) {
-	got := sortedEnvironment(map[string]string{
-		"ZED":    "last",
-		"ALPHA":  "first",
-		"MIDDLE": "middle",
-	})
-	want := []string{"ALPHA=first", "MIDDLE=middle", "ZED=last"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("environment = %#v, want %#v", got, want)
-	}
-}
 
 func TestLineValidatingReaderServesMultipleValidatedFrames(t *testing.T) {
 	const input = "{\"first\":1}\n\n{\"second\":2}"

--- a/runtimes/reference/internal/mcpclient/command_test.go
+++ b/runtimes/reference/internal/mcpclient/command_test.go
@@ -3,9 +3,22 @@ package mcpclient
 import (
 	"errors"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 )
+
+func TestSortedEnvironmentOrdersNames(t *testing.T) {
+	got := sortedEnvironment(map[string]string{
+		"ZED":    "last",
+		"ALPHA":  "first",
+		"MIDDLE": "middle",
+	})
+	want := []string{"ALPHA=first", "MIDDLE=middle", "ZED=last"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("environment = %#v, want %#v", got, want)
+	}
+}
 
 func TestLineValidatingReaderServesMultipleValidatedFrames(t *testing.T) {
 	const input = "{\"first\":1}\n\n{\"second\":2}"

--- a/runtimes/reference/internal/mcpclient/discovery.go
+++ b/runtimes/reference/internal/mcpclient/discovery.go
@@ -1,0 +1,234 @@
+package mcpclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
+)
+
+const (
+	maxDiscoveredTools          = 256
+	maxToolDescriptionBytes     = 16 << 10
+	maxToolSchemaBytes          = 256 << 10
+	maxToolDefinitionBytes      = 280 << 10
+	maxTotalToolDefinitionBytes = 4 << 20
+	fallbackDescriptionPrefix   = "MCP tool"
+)
+
+var mcpToolNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,128}$`)
+
+type frozenTool struct {
+	name       string
+	definition runtimeapi.ToolDefinition
+	schema     *jsonschema.Resolved
+}
+
+func discoverTools(
+	ctx context.Context,
+	serverName string,
+	session *mcp.ClientSession,
+	redactor redactor,
+) ([]frozenTool, error) {
+	var discovered []frozenTool
+	seen := make(map[string]struct{})
+	totalDefinitionBytes := 0
+	for tool, err := range session.Tools(ctx, nil) {
+		if err != nil {
+			return nil, fmt.Errorf("discover tools: %w", err)
+		}
+		if len(discovered) >= maxDiscoveredTools {
+			return nil, &Error{
+				Code: "mcp_discovery_limit_exceeded",
+				Message: fmt.Sprintf(
+					"MCP server %q exposes more than %d tools",
+					serverName,
+					maxDiscoveredTools,
+				),
+			}
+		}
+		if tool == nil || !mcpToolNamePattern.MatchString(tool.Name) {
+			return nil, &Error{
+				Code: "mcp_invalid_tool_definition",
+				Message: fmt.Sprintf(
+					"MCP server %q returned a tool name outside the 1..128 [A-Za-z0-9_.-]+ constraint",
+					serverName,
+				),
+			}
+		}
+		if redactor.containsSensitive(tool.Name) {
+			return nil, &Error{
+				Code:    "mcp_invalid_tool_definition",
+				Message: fmt.Sprintf("MCP server %q returned a tool name containing a resolved sensitive value", serverName),
+			}
+		}
+		if _, duplicate := seen[tool.Name]; duplicate {
+			return nil, &Error{
+				Code:    "mcp_invalid_tool_definition",
+				Message: fmt.Sprintf("MCP server %q returned duplicate tool %q", serverName, tool.Name),
+			}
+		}
+		seen[tool.Name] = struct{}{}
+		description := strings.TrimSpace(tool.Description)
+		if description == "" {
+			description = fmt.Sprintf("%s %q from server %q.", fallbackDescriptionPrefix, tool.Name, serverName)
+		}
+		description = redactor.replace(description)
+		if len(description) > maxToolDescriptionBytes {
+			return nil, discoveryLimitError(
+				serverName,
+				tool.Name,
+				"description",
+				len(description),
+				maxToolDescriptionBytes,
+			)
+		}
+		rawSchema, marshalErr := json.Marshal(tool.InputSchema)
+		if marshalErr != nil {
+			return nil, &Error{
+				Code:    "mcp_invalid_tool_definition",
+				Message: fmt.Sprintf("MCP server %q tool %q schema cannot be encoded", serverName, tool.Name),
+			}
+		}
+		if redactor.containsSensitive(string(rawSchema)) {
+			return nil, &Error{
+				Code: "mcp_invalid_tool_definition",
+				Message: fmt.Sprintf(
+					"MCP server %q tool %q schema contains a resolved sensitive value",
+					serverName,
+					tool.Name,
+				),
+			}
+		}
+		if tool.InputSchema != nil && len(rawSchema) > maxToolSchemaBytes {
+			return nil, discoveryLimitError(
+				serverName,
+				tool.Name,
+				"schema",
+				len(rawSchema),
+				maxToolSchemaBytes,
+			)
+		}
+		schema, resolvedSchema, err := normalizeSchema(tool.InputSchema)
+		if err != nil {
+			return nil, &Error{
+				Code:    "mcp_invalid_tool_definition",
+				Message: fmt.Sprintf("MCP server %q tool %q: %v", serverName, tool.Name, err),
+			}
+		}
+		if len(schema) > maxToolSchemaBytes {
+			return nil, discoveryLimitError(
+				serverName,
+				tool.Name,
+				"schema",
+				len(schema),
+				maxToolSchemaBytes,
+			)
+		}
+		definitionBytes := len(tool.Name) + len(description) + len(schema)
+		if definitionBytes > maxToolDefinitionBytes {
+			return nil, discoveryLimitError(
+				serverName,
+				tool.Name,
+				"definition",
+				definitionBytes,
+				maxToolDefinitionBytes,
+			)
+		}
+		totalDefinitionBytes += definitionBytes
+		if totalDefinitionBytes > maxTotalToolDefinitionBytes {
+			return nil, &Error{
+				Code: "mcp_discovery_limit_exceeded",
+				Message: fmt.Sprintf(
+					"MCP server %q tool definitions exceed the %d-byte total limit",
+					serverName,
+					maxTotalToolDefinitionBytes,
+				),
+			}
+		}
+		discovered = append(discovered, frozenTool{
+			name: tool.Name,
+			definition: runtimeapi.ToolDefinition{
+				Name:        tool.Name,
+				Description: description,
+				InputSchema: schema,
+			},
+			schema: resolvedSchema,
+		})
+	}
+	return discovered, nil
+}
+
+func normalizeSchema(schema any) (json.RawMessage, *jsonschema.Resolved, error) {
+	if schema == nil {
+		schema = json.RawMessage(`{"type":"object"}`)
+	}
+	encoded, err := json.Marshal(schema)
+	if err != nil {
+		return nil, nil, fmt.Errorf("input schema cannot be encoded: %w", err)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &object); err != nil || object == nil {
+		return nil, nil, errors.New("input schema must be a top-level JSON object")
+	}
+	var validationSchema jsonschema.Schema
+	if err := json.Unmarshal(encoded, &validationSchema); err != nil {
+		return nil, nil, fmt.Errorf("input schema is invalid: %w", err)
+	}
+	resolved, err := validationSchema.Resolve(nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("input schema is invalid: %w", err)
+	}
+	var compacted bytes.Buffer
+	if err := json.Compact(&compacted, encoded); err != nil {
+		return nil, nil, fmt.Errorf("input schema is malformed: %w", err)
+	}
+	return json.RawMessage(compacted.String()), resolved, nil
+}
+
+func discoveryLimitError(
+	serverName string,
+	toolName string,
+	part string,
+	actual int,
+	limit int,
+) *Error {
+	return &Error{
+		Code: "mcp_discovery_limit_exceeded",
+		Message: fmt.Sprintf(
+			"MCP server %q tool %q %s is %d bytes; limit is %d bytes",
+			serverName,
+			toolName,
+			part,
+			actual,
+			limit,
+		),
+	}
+}
+
+func sameTools(left []frozenTool, right []frozenTool) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	rightByName := make(map[string]runtimeapi.ToolDefinition, len(right))
+	for _, tool := range right {
+		rightByName[tool.name] = tool.definition
+	}
+	for _, tool := range left {
+		candidate, exists := rightByName[tool.name]
+		if !exists ||
+			tool.definition.Description != candidate.Description ||
+			string(tool.definition.InputSchema) != string(candidate.InputSchema) {
+			return false
+		}
+	}
+	return true
+}

--- a/runtimes/reference/internal/mcpclient/discovery_test.go
+++ b/runtimes/reference/internal/mcpclient/discovery_test.go
@@ -1,0 +1,56 @@
+package mcpclient
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
+)
+
+func TestNormalizeSchemaCompactsObjectSchema(t *testing.T) {
+	schema, resolved, err := normalizeSchema(json.RawMessage(`{
+		"type": "object",
+		"properties": {"value": {"type": "string"}}
+	}`))
+	if err != nil {
+		t.Fatalf("normalize schema: %v", err)
+	}
+	if resolved == nil || string(schema) != `{"type":"object","properties":{"value":{"type":"string"}}}` {
+		t.Fatalf("unexpected normalized schema: %s resolved=%v", schema, resolved)
+	}
+}
+
+func TestDiscoveryLimitErrorIdentifiesBoundedPart(t *testing.T) {
+	err := discoveryLimitError("server", "tool", "schema", 11, 10)
+	if err.Code != "mcp_discovery_limit_exceeded" ||
+		!strings.Contains(err.Message, `"tool" schema is 11 bytes; limit is 10 bytes`) {
+		t.Fatalf("unexpected discovery error: %#v", err)
+	}
+}
+
+func TestSameToolsIgnoresDiscoveryOrderButDetectsDefinitionChanges(t *testing.T) {
+	left := []frozenTool{
+		frozenDefinition("one", "first", `{"type":"object"}`),
+		frozenDefinition("two", "second", `{"type":"object"}`),
+	}
+	right := []frozenTool{left[1], left[0]}
+	if !sameTools(left, right) {
+		t.Fatal("equivalent reordered tools were treated as changed")
+	}
+	right[0].definition.Description = "changed"
+	if sameTools(left, right) {
+		t.Fatal("changed definition was treated as frozen")
+	}
+}
+
+func frozenDefinition(name string, description string, schema string) frozenTool {
+	return frozenTool{
+		name: name,
+		definition: runtimeapi.ToolDefinition{
+			Name:        name,
+			Description: description,
+			InputSchema: json.RawMessage(schema),
+		},
+	}
+}

--- a/runtimes/reference/internal/mcpclient/httptransport.go
+++ b/runtimes/reference/internal/mcpclient/httptransport.go
@@ -1,0 +1,156 @@
+package mcpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	maxHTTPWireBytes        = int64(64 << 20)
+	httpCloseRequestTimeout = 2 * time.Second
+)
+
+var errMCPHTTPWireLimit = errors.New("mcp_http_wire_limit_exceeded")
+
+type boundedHTTPTransport struct {
+	base           http.RoundTripper
+	endpointOrigin string
+	headers        map[string]string
+	maxWireBytes   int64
+}
+
+func (transport *boundedHTTPTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	cloned := request.Clone(request.Context())
+	cloned.Header = request.Header.Clone()
+	if origin(cloned.URL) == transport.endpointOrigin {
+		for name, value := range transport.headers {
+			cloned.Header.Set(name, value)
+		}
+	} else {
+		for name := range transport.headers {
+			cloned.Header.Del(name)
+		}
+	}
+	var cancel context.CancelFunc
+	if cloned.Method == http.MethodDelete {
+		closeCtx, closeCancel := context.WithTimeout(cloned.Context(), httpCloseRequestTimeout)
+		cancel = closeCancel
+		cloned = cloned.Clone(closeCtx)
+	}
+	response, err := transport.base.RoundTrip(cloned)
+	if err != nil {
+		if cancel != nil {
+			cancel()
+		}
+		return nil, err
+	}
+	wireLimit := transport.maxWireBytes
+	if wireLimit <= 0 {
+		wireLimit = maxHTTPWireBytes
+	}
+	if response.ContentLength > wireLimit {
+		_ = response.Body.Close()
+		if cancel != nil {
+			cancel()
+		}
+		return nil, fmt.Errorf(
+			"%w: MCP HTTP response Content-Length exceeds %d-byte wire limit",
+			errMCPHTTPWireLimit,
+			wireLimit,
+		)
+	}
+	response.Body = &countingReadCloser{
+		body:   response.Body,
+		limit:  wireLimit,
+		cancel: cancel,
+	}
+	return response, nil
+}
+
+type countingReadCloser struct {
+	body      io.ReadCloser
+	limit     int64
+	read      int64
+	exceeded  bool
+	cancel    context.CancelFunc
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (reader *countingReadCloser) Read(buffer []byte) (int, error) {
+	if reader.exceeded {
+		return 0, errMCPHTTPWireLimit
+	}
+	if len(buffer) == 0 {
+		return 0, nil
+	}
+	remaining := reader.limit - reader.read
+	maximumRead := int64(len(buffer))
+	if maximumRead > remaining+1 {
+		maximumRead = remaining + 1
+	}
+	if maximumRead < 1 {
+		maximumRead = 1
+	}
+	count, err := reader.body.Read(buffer[:maximumRead])
+	if int64(count) > remaining {
+		allowed := int(max(remaining, 0))
+		reader.read += int64(allowed)
+		reader.exceeded = true
+		return allowed, errMCPHTTPWireLimit
+	}
+	reader.read += int64(count)
+	return count, err
+}
+
+func (reader *countingReadCloser) Close() error {
+	reader.closeOnce.Do(func() {
+		reader.closeErr = reader.body.Close()
+		if reader.cancel != nil {
+			reader.cancel()
+		}
+	})
+	return reader.closeErr
+}
+
+func sameOriginRedirectPolicy(endpoint *url.URL) func(*http.Request, []*http.Request) error {
+	expectedOrigin := origin(endpoint)
+	return func(request *http.Request, via []*http.Request) error {
+		if origin(request.URL) != expectedOrigin {
+			return errors.New("MCP cross-origin redirect is not allowed")
+		}
+		if len(via) >= 10 {
+			return errors.New("MCP redirect limit exceeded")
+		}
+		return nil
+	}
+}
+
+func origin(value *url.URL) string {
+	if value == nil {
+		return ""
+	}
+	scheme := strings.ToLower(value.Scheme)
+	port := value.Port()
+	if port == "" {
+		switch scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+	host := strings.ToLower(value.Hostname())
+	if port == "" {
+		return scheme + "://" + host
+	}
+	return scheme + "://" + net.JoinHostPort(host, port)
+}

--- a/runtimes/reference/internal/mcpclient/httptransport_test.go
+++ b/runtimes/reference/internal/mcpclient/httptransport_test.go
@@ -1,0 +1,38 @@
+package mcpclient
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCountingReadCloserEnforcesWireLimit(t *testing.T) {
+	reader := &countingReadCloser{
+		body:  io.NopCloser(strings.NewReader("12345")),
+		limit: 4,
+	}
+	content, err := io.ReadAll(reader)
+	if string(content) != "1234" || !errors.Is(err, errMCPHTTPWireLimit) {
+		t.Fatalf("read = (%q, %v), want bounded wire-limit failure", content, err)
+	}
+	if _, err := reader.Read(make([]byte, 1)); !errors.Is(err, errMCPHTTPWireLimit) {
+		t.Fatalf("subsequent read error = %v, want wire-limit failure", err)
+	}
+}
+
+func TestSameOriginRedirectPolicyRejectsCrossOriginAndRedirectLoops(t *testing.T) {
+	endpoint := mustParseURL(t, "https://example.test/mcp")
+	policy := sameOriginRedirectPolicy(endpoint)
+	if err := policy(
+		&http.Request{URL: mustParseURL(t, "https://other.test/mcp")},
+		nil,
+	); err == nil {
+		t.Fatal("cross-origin redirect was accepted")
+	}
+	via := make([]*http.Request, 10)
+	if err := policy(&http.Request{URL: endpoint}, via); err == nil {
+		t.Fatal("redirect loop limit was not enforced")
+	}
+}

--- a/runtimes/reference/internal/mcpclient/redact.go
+++ b/runtimes/reference/internal/mcpclient/redact.go
@@ -1,0 +1,142 @@
+package mcpclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/MFS-code/Kontext/internal/tooloutput"
+)
+
+const (
+	maxExternalErrorBytes = int64(4 << 10)
+	maxStderrLineBytes    = 64 << 10
+)
+
+type redactor struct {
+	values         []string
+	sensitiveForms []string
+}
+
+func newRedactor(values []string) redactor {
+	cloned := append([]string(nil), values...)
+	sort.Slice(cloned, func(left int, right int) bool {
+		return len(cloned[left]) > len(cloned[right])
+	})
+	forms := make([]string, 0, len(cloned)*2)
+	for _, sensitive := range cloned {
+		if sensitive == "" {
+			continue
+		}
+		forms = append(forms, sensitive)
+		encoded, _ := json.Marshal(sensitive)
+		escaped := strings.Trim(string(encoded), `"`)
+		if escaped != sensitive {
+			forms = append(forms, escaped)
+		}
+	}
+	return redactor{values: cloned, sensitiveForms: forms}
+}
+
+func (redactor redactor) clean(value string) string {
+	return tooloutput.TruncateUTF8(redactor.replace(value), maxExternalErrorBytes)
+}
+
+func (redactor redactor) replace(value string) string {
+	for _, sensitive := range redactor.values {
+		if sensitive != "" {
+			value = strings.ReplaceAll(value, sensitive, "[REDACTED]")
+		}
+	}
+	return value
+}
+
+func (redactor redactor) containsSensitive(value string) bool {
+	for _, sensitive := range redactor.sensitiveForms {
+		if strings.Contains(value, sensitive) {
+			return true
+		}
+	}
+	return false
+}
+
+func redactStructuredValue(value any, redactor redactor) any {
+	switch typed := value.(type) {
+	case string:
+		return redactor.replace(typed)
+	case []any:
+		for index := range typed {
+			typed[index] = redactStructuredValue(typed[index], redactor)
+		}
+		return typed
+	case map[string]any:
+		for key, child := range typed {
+			typed[key] = redactStructuredValue(child, redactor)
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+func (current *server) safeMessage(value string) string {
+	return current.redactor.clean(value)
+}
+
+func (current *server) safeError(code string, prefix string, err error) *Error {
+	message := prefix
+	if err != nil {
+		message += ": " + err.Error()
+	}
+	return &Error{Code: code, Message: current.safeMessage(message)}
+}
+
+type redactingLineWriter struct {
+	mu         sync.Mutex
+	sink       io.Writer
+	redactor   redactor
+	buffer     []byte
+	discarding bool
+}
+
+func newRedactingLineWriter(sink io.Writer, redactor redactor) io.Writer {
+	return &redactingLineWriter{sink: sink, redactor: redactor}
+}
+
+func (writer *redactingLineWriter) Write(data []byte) (int, error) {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	originalLength := len(data)
+	for len(data) > 0 {
+		newline := bytes.IndexByte(data, '\n')
+		var part []byte
+		if newline < 0 {
+			part = data
+			data = nil
+		} else {
+			part = data[:newline+1]
+			data = data[newline+1:]
+		}
+		if writer.discarding {
+			if newline >= 0 {
+				writer.discarding = false
+			}
+			continue
+		}
+		if len(writer.buffer)+len(part) > maxStderrLineBytes {
+			writer.buffer = writer.buffer[:0]
+			writer.discarding = newline < 0
+			_, _ = io.WriteString(writer.sink, "MCP stderr line omitted: too long\n")
+			continue
+		}
+		writer.buffer = append(writer.buffer, part...)
+		if newline >= 0 {
+			_, _ = io.WriteString(writer.sink, writer.redactor.clean(string(writer.buffer)))
+			writer.buffer = writer.buffer[:0]
+		}
+	}
+	return originalLength, nil
+}

--- a/runtimes/reference/internal/mcpclient/redact_test.go
+++ b/runtimes/reference/internal/mcpclient/redact_test.go
@@ -1,0 +1,33 @@
+package mcpclient
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRedactorDetectsRawAndJSONEscapedSensitiveValues(t *testing.T) {
+	const secret = "quote\"\nsecret"
+	redactor := newRedactor([]string{secret})
+	if !redactor.containsSensitive("raw=" + secret) {
+		t.Fatal("raw sensitive value was not detected")
+	}
+	if !redactor.containsSensitive(`schema="quote\"\nsecret"`) {
+		t.Fatal("JSON-escaped sensitive value was not detected")
+	}
+	if redactor.containsSensitive("safe") {
+		t.Fatal("unrelated value was marked sensitive")
+	}
+}
+
+func TestRedactingLineWriterBoundsBeforeWriting(t *testing.T) {
+	var output bytes.Buffer
+	writer := newRedactingLineWriter(&output, newRedactor([]string{"secret"}))
+	line := strings.Repeat("x", maxStderrLineBytes) + "secret\n"
+	if count, err := writer.Write([]byte(line)); err != nil || count != len(line) {
+		t.Fatalf("write = (%d, %v), want (%d, nil)", count, err, len(line))
+	}
+	if output.String() != "MCP stderr line omitted: too long\n" {
+		t.Fatalf("unexpected bounded stderr output: %q", output.String())
+	}
+}

--- a/runtimes/reference/internal/mcpclient/result.go
+++ b/runtimes/reference/internal/mcpclient/result.go
@@ -1,0 +1,72 @@
+package mcpclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/MFS-code/Kontext/internal/tooloutput"
+)
+
+const maxCapturedBytes = int64(8 << 20)
+
+type resultError struct {
+	Code    string
+	Message string
+}
+
+func normalizeResult(
+	response *mcp.CallToolResult,
+	redactor redactor,
+) (string, bool, *resultError) {
+	if response == nil {
+		return "", false, &resultError{
+			Code:    "mcp_invalid_response",
+			Message: "MCP server returned an empty tool response",
+		}
+	}
+	if response.StructuredContent != nil {
+		encoded, err := json.Marshal(response.StructuredContent)
+		if err != nil {
+			return "", false, &resultError{
+				Code:    "mcp_invalid_response",
+				Message: "MCP structured content could not be encoded",
+			}
+		}
+		var object map[string]any
+		decoder := json.NewDecoder(bytes.NewReader(encoded))
+		decoder.UseNumber()
+		if err := decoder.Decode(&object); err != nil || object == nil {
+			return "", false, &resultError{
+				Code:    "mcp_invalid_response",
+				Message: "MCP structured content must be a JSON object",
+			}
+		}
+		redacted := redactStructuredValue(object, redactor)
+		encoded, err = json.Marshal(redacted)
+		if err != nil {
+			return "", false, &resultError{
+				Code:    "mcp_invalid_response",
+				Message: "MCP structured content could not be normalized",
+			}
+		}
+		content, truncated := tooloutput.Bound(string(encoded), maxCapturedBytes)
+		return content, truncated, nil
+	}
+	for _, item := range response.Content {
+		if _, text := item.(*mcp.TextContent); !text {
+			return "", false, &resultError{
+				Code:    "mcp_unsupported_content",
+				Message: "MCP tool returned unsupported non-text content",
+			}
+		}
+	}
+	text := make([]string, 0, len(response.Content))
+	for _, item := range response.Content {
+		text = append(text, redactor.replace(item.(*mcp.TextContent).Text))
+	}
+	content, truncated := tooloutput.Bound(strings.Join(text, "\n"), maxCapturedBytes)
+	return content, truncated, nil
+}

--- a/runtimes/reference/internal/mcpclient/result_test.go
+++ b/runtimes/reference/internal/mcpclient/result_test.go
@@ -1,0 +1,36 @@
+package mcpclient
+
+import (
+	"encoding/json"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestNormalizeResultDelegatesInvalidUTF8Bounding(t *testing.T) {
+	content, truncated, resultErr := normalizeResult(&mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: "ok\xfftail"}},
+	}, newRedactor(nil))
+	if resultErr != nil {
+		t.Fatalf("normalize result: %v", resultErr)
+	}
+	if !truncated || !json.Valid([]byte(content)) || !utf8.ValidString(content) {
+		t.Fatalf("bounded result = %q truncated=%t", content, truncated)
+	}
+	var envelope struct {
+		Partial string `json:"partial"`
+	}
+	if err := json.Unmarshal([]byte(content), &envelope); err != nil || envelope.Partial != "ok" {
+		t.Fatalf("unexpected partial envelope %q: %#v err=%v", content, envelope, err)
+	}
+}
+
+func TestNormalizeResultRejectsUnsupportedContent(t *testing.T) {
+	_, truncated, resultErr := normalizeResult(&mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.ImageContent{MIMEType: "image/png"}},
+	}, newRedactor(nil))
+	if resultErr == nil || resultErr.Code != "mcp_unsupported_content" || truncated {
+		t.Fatalf("unexpected unsupported-content result: err=%#v truncated=%t", resultErr, truncated)
+	}
+}

--- a/runtimes/reference/internal/tools/shell.go
+++ b/runtimes/reference/internal/tools/shell.go
@@ -11,11 +11,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/MFS-code/Kontext/internal/environment"
 	"github.com/MFS-code/Kontext/internal/procgroup"
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
@@ -205,16 +205,7 @@ func filteredEnvironment(requested map[string]string) ([]string, error) {
 		}
 		values[name] = value
 	}
-	names := make([]string, 0, len(values))
-	for name := range values {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	environment := make([]string, 0, len(names))
-	for _, name := range names {
-		environment = append(environment, name+"="+values[name])
-	}
-	return environment, nil
+	return environment.Sorted(values), nil
 }
 
 func sensitiveEnvironmentName(name string) bool {


### PR DESCRIPTION
## Summary
- split MCP HTTP transport, discovery, redaction, and result normalization into focused modules
- keep manager/session lifecycle on the canonical procgroup cleanup path and delegate output bounding to internal/tooloutput
- share deterministic environment encoding and add focused seam coverage

## Tests
- `go test ./internal/environment ./runtimes/reference/internal/mcpclient ./runtimes/reference/internal/tools`
- `make verify`
- `make test`
- `make docker-build-reference REFERENCE_IMG=kontext-reference:issue61`
- CI-equivalent reference image smoke: fake success, shell tool execution, and expected fake failure

Closes #61