### PR TITLE
Make eval suite assertions declarative

### DIFF
--- a/EVALS.md
+++ b/EVALS.md
@@ -43,6 +43,13 @@ spec:
     namespace: kontext-system
     timeout: 2m
     runtimeImage: kontext-reference:dev
+  assertions:
+    - type: fieldsEqual
+      records: [fake-success-model-a, fake-success-model-b]
+      fields: [statusResult]
+    - type: forbiddenMarkers
+      fields: [statusResult, statusOutput, collectionErrors]
+      markers: [credential-placeholder]
   cases:
     - id: fake-success-model-a
       description: Deterministic reference-runtime success
@@ -82,19 +89,31 @@ Other deterministic graders are `envelopeErrorCode`, `envelopeTurns`,
 Status-result matching supports exactly one of `exact`, `contains`, or
 `notContains`.
 
-The JSONL record contains only grader-requested status/model output, projected
-envelope fields, collection errors, and bounded event metadata rather than raw
-logs or `status.message`. The runner never automatically reads Pod environments
-or Secret values. Optional usage fields retain the distinction between missing
-and measured zero. A summary JSON file reports pass/fail totals and the record
-path.
+Suite assertions run after all case records exist and are separate from
+per-record graders. `fieldsEqual` compares each declared record field across at
+least two named cases. `forbiddenMarkers` scans the declared fields on every
+record, or only its optional `records` list. Supported fields are
+`terminalPhase`, `statusResult`, `statusOutput`, `statusUsage`, `podExitCode`,
+`envelope`, `events`, `grades`, `judge`, `collectionErrors`, and
+`durationMillis`. Unknown assertion types, case IDs, and fields fail suite
+validation.
 
-Artifact collection is grader-driven. Only fields named by deterministic
-graders are retained in a record. Phase and duration graders do not require a
-Pod that the wallclock controller has already deleted. Envelope graders parse
-the runtime container's authoritative termination message, event graders read
-only a bounded log tail, and exit-code graders require a terminated Pod.
-Missing or incomplete required artifacts fail the case.
+The JSONL record contains only explicitly requested status/model output,
+projected envelope fields, collection errors, and bounded event metadata rather
+than raw logs or `status.message`. The runner never automatically reads Pod
+environments or Secret values. Optional usage fields retain the distinction
+between missing and measured zero. A summary JSON file reports case totals,
+each suite assertion result, an overall pass flag, and the record path.
+
+Artifact collection remains least-privilege. Suite assertions can request
+`statusResult`, `statusOutput`, `statusUsage`, or `podExitCode` for their
+targeted records. Their `envelope` and `events` fields scan only projections
+already requested by per-record graders; they never trigger full envelope or
+raw-log capture. Phase and duration graders do not require a Pod that the
+wallclock controller has already deleted. Envelope graders parse the runtime
+container's authoritative termination message, event graders read only a
+bounded log tail, and exit-code graders require a terminated Pod. Missing or
+incomplete required artifacts fail the case.
 
 `scripts/eval-kind.sh` runs the complete keyless suite against the existing
 kind cluster, validates the records, checks controller timeout cleanup, and

--- a/EVALS.md
+++ b/EVALS.md
@@ -102,8 +102,9 @@ The JSONL record contains only explicitly requested status/model output,
 projected envelope fields, collection errors, and bounded event metadata rather
 than raw logs or `status.message`. The runner never automatically reads Pod
 environments or Secret values. Optional usage fields retain the distinction
-between missing and measured zero. A summary JSON file reports case totals,
-each suite assertion result, an overall pass flag, and the record path.
+between missing and measured zero. A summary JSON file reports expected and
+actual case totals, collection-error counts and affected cases, each suite
+assertion result, an overall pass flag, and the record path.
 
 Artifact collection remains least-privilege. Suite assertions can request
 `statusResult`, `statusOutput`, `statusUsage`, or `podExitCode` for their

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -40,6 +40,12 @@ to estimate ordinary variance; then compare another model with the same prompt,
 limits, tools, context, and grader. Retain normalized usage and duration, and
 compare against a deterministic Job/script baseline for the same task.
 
+Declare cross-case checks under `spec.assertions`. `fieldsEqual` names at least
+two case records and the fields that must match. `forbiddenMarkers` names
+markers and record fields to scan, with an optional case list. These checks run
+once after record collection, appear separately in the JSON summary, and make
+the CLI fail without adding synthetic failures to individual case grades.
+
 The keyless suite at `evals/suites/keyless.yaml` covers:
 
 - one goal through two opaque fake model IDs;
@@ -64,13 +70,15 @@ external provider endpoint.
 ## Records and privacy
 
 Eval records use `kontext.dev/eval/v1alpha1`. They may contain status/model
-output only when a grader explicitly requests it. They do not retain
-`status.message`; failure evidence is the phase, projected envelope error code,
-grades, and collection errors. Envelope records are projections limited to the
-requested outcome, error code, model, turn count, or tool-call count. The runner
-never automatically reads Pod environments, Secret values, raw logs, artifacts,
-extensions, request IDs, or private reasoning. Optional usage retains missing
-versus measured-zero semantics.
+output only when a grader or suite assertion explicitly requests it. They do
+not retain `status.message`; failure evidence is the phase, projected envelope
+error code, grades, collection errors, and separate suite assertion results.
+Envelope records are projections limited to the requested outcome, error code,
+model, turn count, or tool-call count. Suite assertions scan those retained
+projections; they do not expand envelope or event collection into raw data. The
+runner never automatically reads Pod environments, Secret values, raw logs,
+artifacts, extensions, request IDs, or private reasoning. Optional usage
+retains missing versus measured-zero semantics.
 
 The dispatch-only provider workflow writes a separate bounded
 `ProviderAcceptanceRecord` with provider, opaque model, scenario, commit/run

--- a/evals/suites/keyless.yaml
+++ b/evals/suites/keyless.yaml
@@ -7,6 +7,22 @@ spec:
     namespace: kontext-eval
     timeout: 45s
     runtimeImage: kontext-reference:dev
+  assertions:
+    - type: fieldsEqual
+      records: [same-goal-model-a, same-goal-model-b]
+      fields: [statusResult]
+    - type: forbiddenMarkers
+      fields:
+        - statusResult
+        - statusOutput
+        - envelope
+        - events
+        - grades
+        - judge
+        - collectionErrors
+      markers:
+        - keyless-placeholder
+        - fixture process is exiting
   cases:
     - id: same-goal-model-a
       description: Same deterministic goal through the first opaque model identifier

--- a/internal/eval/cli.go
+++ b/internal/eval/cli.go
@@ -121,6 +121,7 @@ func Execute(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	completedAt := time.Now().UTC()
 	summary := BuildSummary(
 		suite.Metadata.Name,
+		len(suite.Spec.Cases),
 		startedAt,
 		completedAt,
 		records,
@@ -133,11 +134,13 @@ func Execute(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(
 		stdout,
-		"suite=%s total=%d passed=%d failed=%d assertionFailures=%d records=%s summary=%s\n",
+		"suite=%s expected=%d total=%d passed=%d failed=%d collectionErrors=%d assertionFailures=%d records=%s summary=%s\n",
 		summary.Suite,
+		summary.ExpectedTotal,
 		summary.Total,
 		summary.Passed,
 		summary.Failed,
+		summary.CollectionErrorCount,
 		summary.AssertionFailures,
 		recordPath,
 		summaryPath,

--- a/internal/eval/cli.go
+++ b/internal/eval/cli.go
@@ -117,23 +117,32 @@ func Execute(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		},
 	}
 	records := runner.RunSuite(ctx, suite)
+	assertions := EvaluateSuiteAssertions(suite.Spec.Assertions, records)
 	completedAt := time.Now().UTC()
-	summary := BuildSummary(suite.Metadata.Name, startedAt, completedAt, records, recordPath)
+	summary := BuildSummary(
+		suite.Metadata.Name,
+		startedAt,
+		completedAt,
+		records,
+		assertions,
+		recordPath,
+	)
 	if err := WriteOutputs(recordPath, summaryPath, records, summary); err != nil {
 		fmt.Fprintf(stderr, "write evaluation outputs: %v\n", err)
 		return 1
 	}
 	fmt.Fprintf(
 		stdout,
-		"suite=%s total=%d passed=%d failed=%d records=%s summary=%s\n",
+		"suite=%s total=%d passed=%d failed=%d assertionFailures=%d records=%s summary=%s\n",
 		summary.Suite,
 		summary.Total,
 		summary.Passed,
 		summary.Failed,
+		summary.AssertionFailures,
 		recordPath,
 		summaryPath,
 	)
-	if !RecordsPass(records, len(suite.Spec.Cases)) {
+	if !summary.Pass {
 		return 1
 	}
 	return 0

--- a/internal/eval/output.go
+++ b/internal/eval/output.go
@@ -22,25 +22,35 @@ func WriteOutputs(recordPath, summaryPath string, records []Record, summary Summ
 
 func BuildSummary(
 	suite string,
+	expectedTotal int,
 	startedAt, completedAt time.Time,
 	records []Record,
 	assertions []SuiteAssertionResult,
 	recordPath string,
 ) Summary {
 	summary := Summary{
-		APIVersion:  APIVersion,
-		Suite:       suite,
-		StartedAt:   startedAt,
-		CompletedAt: completedAt,
-		Total:       len(records),
-		Assertions:  assertions,
-		RecordPath:  recordPath,
+		APIVersion:    APIVersion,
+		Suite:         suite,
+		StartedAt:     startedAt,
+		CompletedAt:   completedAt,
+		ExpectedTotal: expectedTotal,
+		Total:         len(records),
+		Assertions:    assertions,
+		RecordPath:    recordPath,
 	}
-	for _, record := range records {
+	for index, record := range records {
 		if record.Pass {
 			summary.Passed++
 		} else {
 			summary.Failed++
+		}
+		if len(record.CollectionErrors) > 0 {
+			summary.CollectionErrorCount += len(record.CollectionErrors)
+			caseID := record.CaseID
+			if caseID == "" {
+				caseID = fmt.Sprintf("record[%d]", index)
+			}
+			summary.CollectionErrorCases = append(summary.CollectionErrorCases, caseID)
 		}
 	}
 	for _, assertion := range assertions {
@@ -48,8 +58,10 @@ func BuildSummary(
 			summary.AssertionFailures++
 		}
 	}
-	summary.Pass = summary.Failed == 0 &&
+	summary.Pass = summary.Total == summary.ExpectedTotal &&
+		summary.Failed == 0 &&
 		summary.Passed == summary.Total &&
+		summary.CollectionErrorCount == 0 &&
 		summary.AssertionFailures == 0
 	return summary
 }

--- a/internal/eval/output.go
+++ b/internal/eval/output.go
@@ -20,13 +20,20 @@ func WriteOutputs(recordPath, summaryPath string, records []Record, summary Summ
 	return nil
 }
 
-func BuildSummary(suite string, startedAt, completedAt time.Time, records []Record, recordPath string) Summary {
+func BuildSummary(
+	suite string,
+	startedAt, completedAt time.Time,
+	records []Record,
+	assertions []SuiteAssertionResult,
+	recordPath string,
+) Summary {
 	summary := Summary{
 		APIVersion:  APIVersion,
 		Suite:       suite,
 		StartedAt:   startedAt,
 		CompletedAt: completedAt,
 		Total:       len(records),
+		Assertions:  assertions,
 		RecordPath:  recordPath,
 	}
 	for _, record := range records {
@@ -36,6 +43,14 @@ func BuildSummary(suite string, startedAt, completedAt time.Time, records []Reco
 			summary.Failed++
 		}
 	}
+	for _, assertion := range assertions {
+		if !assertion.Pass {
+			summary.AssertionFailures++
+		}
+	}
+	summary.Pass = summary.Failed == 0 &&
+		summary.Passed == summary.Total &&
+		summary.AssertionFailures == 0
 	return summary
 }
 

--- a/internal/eval/output_judge_test.go
+++ b/internal/eval/output_judge_test.go
@@ -30,7 +30,7 @@ func TestWriteOutputsProducesJSONLAndSummary(t *testing.T) {
 		Message: "field mismatch",
 	}}
 	now := time.Now().UTC()
-	summary := BuildSummary("s", now, now, records, assertions, recordPath)
+	summary := BuildSummary("s", 2, now, now, records, assertions, recordPath)
 	if err := WriteOutputs(recordPath, summaryPath, records, summary); err != nil {
 		t.Fatalf("WriteOutputs: %v", err)
 	}
@@ -50,6 +50,7 @@ func TestWriteOutputsProducesJSONLAndSummary(t *testing.T) {
 		t.Fatal(err)
 	}
 	if decoded.Total != 2 ||
+		decoded.ExpectedTotal != 2 ||
 		decoded.Passed != 1 ||
 		decoded.Failed != 1 ||
 		decoded.AssertionFailures != 1 ||
@@ -69,10 +70,11 @@ func TestWriteOutputsProducesJSONLAndSummary(t *testing.T) {
 	}
 }
 
-func TestBuildSummaryWithoutAssertionsRemainsPassing(t *testing.T) {
+func TestBuildSummaryHappyPathWithoutAssertions(t *testing.T) {
 	now := time.Now().UTC()
 	summary := BuildSummary(
 		"legacy-suite",
+		1,
 		now,
 		now,
 		[]Record{{CaseID: "case", Pass: true}},
@@ -90,6 +92,100 @@ func TestBuildSummaryWithoutAssertionsRemainsPassing(t *testing.T) {
 	}
 	if bytes.Contains(encoded, []byte(`"assertions"`)) {
 		t.Fatalf("empty assertions should be omitted: %s", encoded)
+	}
+}
+
+func TestBuildSummaryRequiresExactRecordCount(t *testing.T) {
+	now := time.Now().UTC()
+	passingRecords := []Record{
+		{CaseID: "a", Pass: true},
+		{CaseID: "b", Pass: true},
+	}
+	for name, test := range map[string]struct {
+		expected int
+		records  []Record
+		wantPass bool
+	}{
+		"exact": {
+			expected: 2,
+			records:  passingRecords,
+			wantPass: true,
+		},
+		"missing": {
+			expected: 2,
+			records:  passingRecords[:1],
+		},
+		"extra": {
+			expected: 1,
+			records:  passingRecords,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			summary := BuildSummary(
+				"suite",
+				test.expected,
+				now,
+				now,
+				test.records,
+				nil,
+				"records.jsonl",
+			)
+			if summary.Pass != test.wantPass ||
+				summary.ExpectedTotal != test.expected ||
+				summary.Total != len(test.records) {
+				t.Fatalf("unexpected count summary: %#v", summary)
+			}
+		})
+	}
+}
+
+func TestBuildSummaryFailsPassingRecordWithCollectionErrors(t *testing.T) {
+	now := time.Now().UTC()
+	summary := BuildSummary(
+		"suite",
+		1,
+		now,
+		now,
+		[]Record{{
+			CaseID:           "case-a",
+			Pass:             true,
+			CollectionErrors: []string{"fetch logs", "decode event"},
+		}},
+		nil,
+		"records.jsonl",
+	)
+	if summary.Pass ||
+		summary.Passed != 1 ||
+		summary.Failed != 0 ||
+		summary.CollectionErrorCount != 2 ||
+		len(summary.CollectionErrorCases) != 1 ||
+		summary.CollectionErrorCases[0] != "case-a" {
+		t.Fatalf("collection errors did not fail summary: %#v", summary)
+	}
+}
+
+func TestBuildSummaryCombinesCollectionAndAssertionFailures(t *testing.T) {
+	now := time.Now().UTC()
+	summary := BuildSummary(
+		"suite",
+		1,
+		now,
+		now,
+		[]Record{{
+			CaseID:           "case-a",
+			Pass:             true,
+			CollectionErrors: []string{"incomplete artifacts"},
+		}},
+		[]SuiteAssertionResult{
+			{Type: SuiteAssertionFieldsEqual, Pass: false},
+			{Type: SuiteAssertionForbiddenMarkers, Pass: false},
+		},
+		"records.jsonl",
+	)
+	if summary.Pass ||
+		summary.CollectionErrorCount != 1 ||
+		summary.AssertionFailures != 2 {
+		t.Fatalf("combined failures were not preserved: %#v", summary)
 	}
 }
 

--- a/internal/eval/output_judge_test.go
+++ b/internal/eval/output_judge_test.go
@@ -23,8 +23,14 @@ func TestWriteOutputsProducesJSONLAndSummary(t *testing.T) {
 		{APIVersion: APIVersion, Kind: RecordKind, Suite: "s", CaseID: "a", Pass: true},
 		{APIVersion: APIVersion, Kind: RecordKind, Suite: "s", CaseID: "b", Pass: false},
 	}
+	assertions := []SuiteAssertionResult{{
+		Type:    SuiteAssertionFieldsEqual,
+		Fields:  []string{"statusResult"},
+		Pass:    false,
+		Message: "field mismatch",
+	}}
 	now := time.Now().UTC()
-	summary := BuildSummary("s", now, now, records, recordPath)
+	summary := BuildSummary("s", now, now, records, assertions, recordPath)
 	if err := WriteOutputs(recordPath, summaryPath, records, summary); err != nil {
 		t.Fatalf("WriteOutputs: %v", err)
 	}
@@ -43,7 +49,13 @@ func TestWriteOutputsProducesJSONLAndSummary(t *testing.T) {
 	if err := json.Unmarshal(summaryData, &decoded); err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Total != 2 || decoded.Passed != 1 || decoded.Failed != 1 || decoded.RecordPath != recordPath {
+	if decoded.Total != 2 ||
+		decoded.Passed != 1 ||
+		decoded.Failed != 1 ||
+		decoded.AssertionFailures != 1 ||
+		decoded.Pass ||
+		len(decoded.Assertions) != 1 ||
+		decoded.RecordPath != recordPath {
 		t.Fatalf("unexpected summary %#v", decoded)
 	}
 	for _, path := range []string{recordPath, summaryPath} {
@@ -54,6 +66,30 @@ func TestWriteOutputsProducesJSONLAndSummary(t *testing.T) {
 		if permissions := info.Mode().Perm(); permissions != 0o600 {
 			t.Fatalf("%s permissions = %o, want 600", path, permissions)
 		}
+	}
+}
+
+func TestBuildSummaryWithoutAssertionsRemainsPassing(t *testing.T) {
+	now := time.Now().UTC()
+	summary := BuildSummary(
+		"legacy-suite",
+		now,
+		now,
+		[]Record{{CaseID: "case", Pass: true}},
+		nil,
+		"records.jsonl",
+	)
+	if !summary.Pass ||
+		summary.AssertionFailures != 0 ||
+		summary.Assertions != nil {
+		t.Fatalf("suite without assertions changed behavior: %#v", summary)
+	}
+	encoded, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(`"assertions"`)) {
+		t.Fatalf("empty assertions should be omitted: %s", encoded)
 	}
 }
 

--- a/internal/eval/runner.go
+++ b/internal/eval/runner.go
@@ -167,6 +167,26 @@ func (runner Runner) runCase(ctx context.Context, suite EvalSuite, item Case) Re
 			now,
 		)
 	}
+	if err := requirementsForSuiteAssertions(
+		suite.Spec.Assertions,
+		item.ID,
+		&requirements,
+	); err != nil {
+		record.CollectionErrors = append(
+			record.CollectionErrors,
+			fmt.Sprintf("resolve suite assertion requirements: %v", err),
+		)
+		return runner.finishRecord(
+			ctx,
+			&record,
+			item,
+			requirements,
+			nil,
+			nil,
+			false,
+			now,
+		)
+	}
 	run := newAgentRun(name, namespace, item.AgentRun, ownershipLabels)
 	caseCtx, cancel := context.WithTimeout(ctx, item.Timeout.Duration)
 	defer cancel()
@@ -668,16 +688,4 @@ func labelValue(value string) string {
 		value = value[:63]
 	}
 	return value
-}
-
-func RecordsPass(records []Record, expected int) bool {
-	if len(records) != expected {
-		return false
-	}
-	for _, record := range records {
-		if !record.Pass {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/eval/suite.go
+++ b/internal/eval/suite.go
@@ -113,6 +113,11 @@ func prepareSuite(suite *EvalSuite, runtimeImageOverride string) error {
 			}
 		}
 	}
+	for assertionIndex, assertion := range suite.Spec.Assertions {
+		if err := validateSuiteAssertion(assertion, seen); err != nil {
+			return fmt.Errorf("spec.assertions[%d]: %w", assertionIndex, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/eval/suite_assertions.go
+++ b/internal/eval/suite_assertions.go
@@ -1,0 +1,363 @@
+package eval
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type suiteAssertionSpec struct {
+	validate     func(SuiteAssertion, map[string]struct{}) error
+	requirements func(SuiteAssertion, string, *artifactRequirements)
+	evaluate     func(SuiteAssertion, []Record) SuiteAssertionResult
+}
+
+var suiteAssertionSpecs = map[SuiteAssertionType]suiteAssertionSpec{
+	SuiteAssertionFieldsEqual: {
+		validate:     validateFieldsEqualAssertion,
+		requirements: requireAssertionFields,
+		evaluate:     evaluateFieldsEqual,
+	},
+	SuiteAssertionForbiddenMarkers: {
+		validate:     validateForbiddenMarkersAssertion,
+		requirements: requireAssertionFields,
+		evaluate:     evaluateForbiddenMarkers,
+	},
+}
+
+type suiteRecordFieldSpec struct {
+	value        func(Record) any
+	requirements func(*artifactRequirements)
+}
+
+var suiteRecordFieldSpecs = map[string]suiteRecordFieldSpec{
+	"terminalPhase": {
+		value: func(record Record) any { return record.TerminalPhase },
+	},
+	"statusResult": {
+		value: func(record Record) any { return record.StatusResult },
+		requirements: func(requirements *artifactRequirements) {
+			requirements.statusResult = true
+		},
+	},
+	"statusOutput": {
+		value: func(record Record) any { return record.StatusOutput },
+		requirements: func(requirements *artifactRequirements) {
+			requirements.statusOutput = true
+		},
+	},
+	"statusUsage": {
+		value: func(record Record) any { return record.StatusUsage },
+		requirements: func(requirements *artifactRequirements) {
+			requirements.statusUsage = true
+		},
+	},
+	"podExitCode": {
+		value: func(record Record) any { return record.PodExitCode },
+		requirements: func(requirements *artifactRequirements) {
+			requirements.pod = true
+			requirements.exitCode = true
+		},
+	},
+	"envelope": {
+		value: func(record Record) any { return record.Envelope },
+	},
+	"events": {
+		value: func(record Record) any { return record.Events },
+	},
+	"grades": {
+		value: func(record Record) any { return record.Grades },
+	},
+	"judge": {
+		value: func(record Record) any { return record.Judge },
+	},
+	"collectionErrors": {
+		value: func(record Record) any { return record.CollectionErrors },
+	},
+	"durationMillis": {
+		value: func(record Record) any { return record.DurationMillis },
+	},
+}
+
+func suiteAssertionSpecFor(assertionType SuiteAssertionType) (suiteAssertionSpec, error) {
+	spec, ok := suiteAssertionSpecs[assertionType]
+	if !ok {
+		return suiteAssertionSpec{}, fmt.Errorf("unsupported suite assertion type %q", assertionType)
+	}
+	if spec.validate == nil || spec.requirements == nil || spec.evaluate == nil {
+		return suiteAssertionSpec{}, fmt.Errorf(
+			"suite assertion type %q has an incomplete dispatch spec",
+			assertionType,
+		)
+	}
+	return spec, nil
+}
+
+func validateSuiteAssertion(assertion SuiteAssertion, caseIDs map[string]struct{}) error {
+	spec, err := suiteAssertionSpecFor(assertion.Type)
+	if err != nil {
+		return err
+	}
+	return spec.validate(assertion, caseIDs)
+}
+
+func validateFieldsEqualAssertion(assertion SuiteAssertion, caseIDs map[string]struct{}) error {
+	if len(assertion.Records) < 2 {
+		return errors.New("records must contain at least two case IDs")
+	}
+	if len(assertion.Markers) != 0 {
+		return errors.New("markers are not valid for fieldsEqual")
+	}
+	if err := validateAssertionRecords(assertion.Records, caseIDs); err != nil {
+		return err
+	}
+	return validateAssertionFields(assertion.Fields)
+}
+
+func validateForbiddenMarkersAssertion(assertion SuiteAssertion, caseIDs map[string]struct{}) error {
+	if len(assertion.Records) != 0 {
+		if err := validateAssertionRecords(assertion.Records, caseIDs); err != nil {
+			return err
+		}
+	}
+	if err := validateAssertionFields(assertion.Fields); err != nil {
+		return err
+	}
+	if len(assertion.Markers) == 0 {
+		return errors.New("markers must not be empty")
+	}
+	seen := make(map[string]struct{}, len(assertion.Markers))
+	for index, marker := range assertion.Markers {
+		if strings.TrimSpace(marker) == "" {
+			return fmt.Errorf("markers[%d] must not be blank", index)
+		}
+		if _, exists := seen[marker]; exists {
+			return fmt.Errorf("duplicate marker %q", marker)
+		}
+		seen[marker] = struct{}{}
+	}
+	return nil
+}
+
+func validateAssertionRecords(records []string, caseIDs map[string]struct{}) error {
+	seen := make(map[string]struct{}, len(records))
+	for index, caseID := range records {
+		if strings.TrimSpace(caseID) == "" {
+			return fmt.Errorf("records[%d] must not be blank", index)
+		}
+		if _, exists := caseIDs[caseID]; !exists {
+			return fmt.Errorf("record case %q does not exist in spec.cases", caseID)
+		}
+		if _, exists := seen[caseID]; exists {
+			return fmt.Errorf("duplicate record case %q", caseID)
+		}
+		seen[caseID] = struct{}{}
+	}
+	return nil
+}
+
+func validateAssertionFields(fields []string) error {
+	if len(fields) == 0 {
+		return errors.New("fields must not be empty")
+	}
+	seen := make(map[string]struct{}, len(fields))
+	for index, field := range fields {
+		if strings.TrimSpace(field) == "" {
+			return fmt.Errorf("fields[%d] must not be blank", index)
+		}
+		if _, exists := suiteRecordFieldSpecs[field]; !exists {
+			return fmt.Errorf("unsupported record field %q", field)
+		}
+		if _, exists := seen[field]; exists {
+			return fmt.Errorf("duplicate record field %q", field)
+		}
+		seen[field] = struct{}{}
+	}
+	return nil
+}
+
+func requirementsForSuiteAssertions(
+	assertions []SuiteAssertion,
+	caseID string,
+	requirements *artifactRequirements,
+) error {
+	for _, assertion := range assertions {
+		spec, err := suiteAssertionSpecFor(assertion.Type)
+		if err != nil {
+			return err
+		}
+		spec.requirements(assertion, caseID, requirements)
+	}
+	return nil
+}
+
+func requireAssertionFields(
+	assertion SuiteAssertion,
+	caseID string,
+	requirements *artifactRequirements,
+) {
+	if !assertionTargetsCase(assertion, caseID) {
+		return
+	}
+	for _, field := range assertion.Fields {
+		if fieldSpec, exists := suiteRecordFieldSpecs[field]; exists &&
+			fieldSpec.requirements != nil {
+			fieldSpec.requirements(requirements)
+		}
+	}
+}
+
+func assertionTargetsCase(assertion SuiteAssertion, caseID string) bool {
+	if len(assertion.Records) == 0 {
+		return true
+	}
+	for _, target := range assertion.Records {
+		if target == caseID {
+			return true
+		}
+	}
+	return false
+}
+
+func EvaluateSuiteAssertions(
+	assertions []SuiteAssertion,
+	records []Record,
+) []SuiteAssertionResult {
+	if len(assertions) == 0 {
+		return nil
+	}
+	results := make([]SuiteAssertionResult, 0, len(assertions))
+	for _, assertion := range assertions {
+		spec, err := suiteAssertionSpecFor(assertion.Type)
+		if err != nil {
+			results = append(results, SuiteAssertionResult{
+				Type:    assertion.Type,
+				Records: assertion.Records,
+				Fields:  assertion.Fields,
+				Pass:    false,
+				Message: err.Error(),
+			})
+			continue
+		}
+		results = append(results, spec.evaluate(assertion, records))
+	}
+	return results
+}
+
+func evaluateFieldsEqual(assertion SuiteAssertion, records []Record) SuiteAssertionResult {
+	result := newSuiteAssertionResult(assertion)
+	selected, err := selectAssertionRecords(assertion.Records, records)
+	if err != nil {
+		result.Message = err.Error()
+		return result
+	}
+	for _, field := range assertion.Fields {
+		fieldSpec := suiteRecordFieldSpecs[field]
+		reference := fieldSpec.value(selected[0])
+		for index := 1; index < len(selected); index++ {
+			if !reflect.DeepEqual(reference, fieldSpec.value(selected[index])) {
+				result.Message = fmt.Sprintf(
+					"field %q differs between records %q and %q",
+					field,
+					selected[0].CaseID,
+					selected[index].CaseID,
+				)
+				return result
+			}
+		}
+	}
+	result.Pass = true
+	result.Message = fmt.Sprintf(
+		"%d field(s) matched across %d records",
+		len(assertion.Fields),
+		len(selected),
+	)
+	return result
+}
+
+func evaluateForbiddenMarkers(
+	assertion SuiteAssertion,
+	records []Record,
+) SuiteAssertionResult {
+	result := newSuiteAssertionResult(assertion)
+	selected, err := selectAssertionRecords(assertion.Records, records)
+	if err != nil {
+		result.Message = err.Error()
+		return result
+	}
+	for _, record := range selected {
+		for _, field := range assertion.Fields {
+			encoded, err := encodeAssertionField(suiteRecordFieldSpecs[field].value(record))
+			if err != nil {
+				result.Message = fmt.Sprintf(
+					"encode record %q field %q: %v",
+					record.CaseID,
+					field,
+					err,
+				)
+				return result
+			}
+			for markerIndex, marker := range assertion.Markers {
+				if bytes.Contains(encoded, []byte(marker)) {
+					result.Message = fmt.Sprintf(
+						"record %q field %q contains forbidden marker at index %d",
+						record.CaseID,
+						field,
+						markerIndex,
+					)
+					return result
+				}
+			}
+		}
+	}
+	result.Pass = true
+	result.Message = fmt.Sprintf(
+		"%d field(s) across %d record(s) contained no forbidden markers",
+		len(assertion.Fields),
+		len(selected),
+	)
+	return result
+}
+
+func encodeAssertionField(value any) ([]byte, error) {
+	var encoded bytes.Buffer
+	encoder := json.NewEncoder(&encoded)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+	return encoded.Bytes(), nil
+}
+
+func newSuiteAssertionResult(assertion SuiteAssertion) SuiteAssertionResult {
+	return SuiteAssertionResult{
+		Type:    assertion.Type,
+		Records: append([]string(nil), assertion.Records...),
+		Fields:  append([]string(nil), assertion.Fields...),
+	}
+}
+
+func selectAssertionRecords(caseIDs []string, records []Record) ([]Record, error) {
+	byCaseID := make(map[string]Record, len(records))
+	for _, record := range records {
+		byCaseID[record.CaseID] = record
+	}
+	if len(caseIDs) == 0 {
+		if len(records) == 0 {
+			return nil, errors.New("no evaluation records were available")
+		}
+		return records, nil
+	}
+	selected := make([]Record, 0, len(caseIDs))
+	for _, caseID := range caseIDs {
+		record, exists := byCaseID[caseID]
+		if !exists {
+			return nil, fmt.Errorf("evaluation record %q was absent", caseID)
+		}
+		selected = append(selected, record)
+	}
+	return selected, nil
+}

--- a/internal/eval/suite_assertions_test.go
+++ b/internal/eval/suite_assertions_test.go
@@ -1,0 +1,202 @@
+package eval
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSuiteAssertionDispatchCoversEveryType(t *testing.T) {
+	assertions := []SuiteAssertion{
+		{
+			Type:    SuiteAssertionFieldsEqual,
+			Records: []string{"a", "b"},
+			Fields:  []string{"statusResult"},
+		},
+		{
+			Type:    SuiteAssertionForbiddenMarkers,
+			Fields:  []string{"statusResult"},
+			Markers: []string{"secret-marker"},
+		},
+	}
+	caseIDs := map[string]struct{}{"a": {}, "b": {}}
+	if len(suiteAssertionSpecs) != len(assertions) {
+		t.Fatalf(
+			"dispatch has %d types, test covers %d",
+			len(suiteAssertionSpecs),
+			len(assertions),
+		)
+	}
+	for _, assertion := range assertions {
+		t.Run(string(assertion.Type), func(t *testing.T) {
+			if err := validateSuiteAssertion(assertion, caseIDs); err != nil {
+				t.Fatalf("validateSuiteAssertion: %v", err)
+			}
+			spec, err := suiteAssertionSpecFor(assertion.Type)
+			if err != nil {
+				t.Fatalf("suiteAssertionSpecFor: %v", err)
+			}
+			requirements := artifactRequirements{}
+			spec.requirements(assertion, "a", &requirements)
+			result := spec.evaluate(assertion, []Record{
+				{CaseID: "a", StatusResult: "same"},
+				{CaseID: "b", StatusResult: "same"},
+			})
+			if !result.Pass {
+				t.Fatalf("valid assertion failed: %#v", result)
+			}
+		})
+	}
+}
+
+func TestParseSuiteRejectsInvalidSuiteAssertions(t *testing.T) {
+	tests := map[string]struct {
+		assertion string
+		want      string
+	}{
+		"unknown type": {
+			assertion: `
+    - type: futureAssertion
+      fields: [statusResult]
+`,
+			want: `unsupported suite assertion type "futureAssertion"`,
+		},
+		"missing case": {
+			assertion: `
+    - type: fieldsEqual
+      records: [prompt-model-a, absent-case]
+      fields: [statusResult]
+`,
+			want: `record case "absent-case" does not exist`,
+		},
+		"missing field": {
+			assertion: `
+    - type: fieldsEqual
+      records: [prompt-model-a, prompt-model-b]
+      fields: []
+`,
+			want: "fields must not be empty",
+		},
+		"unknown field": {
+			assertion: `
+    - type: forbiddenMarkers
+      fields: [rawLogs]
+      markers: [secret]
+`,
+			want: `unsupported record field "rawLogs"`,
+		},
+		"missing marker": {
+			assertion: `
+    - type: forbiddenMarkers
+      fields: [statusResult]
+`,
+			want: "markers must not be empty",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			input := strings.Replace(
+				validSuiteYAML,
+				"  cases:\n",
+				"  assertions:\n"+test.assertion+"  cases:\n",
+				1,
+			)
+			_, err := ParseSuite([]byte(input), "")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ParseSuite error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestFieldsEqualAssertionReportsAbsentRecordAndMismatch(t *testing.T) {
+	assertion := SuiteAssertion{
+		Type:    SuiteAssertionFieldsEqual,
+		Records: []string{"a", "b"},
+		Fields:  []string{"statusResult"},
+	}
+	for name, test := range map[string]struct {
+		records []Record
+		want    string
+	}{
+		"absent record": {
+			records: []Record{{CaseID: "a", StatusResult: "same"}},
+			want:    `evaluation record "b" was absent`,
+		},
+		"mismatch": {
+			records: []Record{
+				{CaseID: "a", StatusResult: "first"},
+				{CaseID: "b", StatusResult: "second"},
+			},
+			want: `field "statusResult" differs`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := EvaluateSuiteAssertions([]SuiteAssertion{assertion}, test.records)
+			if len(result) != 1 || result[0].Pass ||
+				!strings.Contains(result[0].Message, test.want) {
+				t.Fatalf("unexpected assertion result: %#v", result)
+			}
+		})
+	}
+}
+
+func TestForbiddenMarkersScansDeclaredRecordsAndFields(t *testing.T) {
+	assertion := SuiteAssertion{
+		Type:    SuiteAssertionForbiddenMarkers,
+		Records: []string{"a", "b"},
+		Fields:  []string{"statusResult", "collectionErrors"},
+		Markers: []string{"credential-placeholder"},
+	}
+	records := []Record{
+		{CaseID: "a", StatusResult: "safe"},
+		{CaseID: "b", CollectionErrors: []string{"leaked credential-placeholder"}},
+	}
+	result := EvaluateSuiteAssertions([]SuiteAssertion{assertion}, records)
+	if len(result) != 1 || result[0].Pass ||
+		!strings.Contains(result[0].Message, `record "b" field "collectionErrors"`) ||
+		strings.Contains(result[0].Message, assertion.Markers[0]) {
+		t.Fatalf("marker was not reported clearly: %#v", result)
+	}
+
+	records[1].CollectionErrors = []string{"redacted"}
+	result = EvaluateSuiteAssertions([]SuiteAssertion{assertion}, records)
+	if len(result) != 1 || !result[0].Pass {
+		t.Fatalf("clean records failed marker assertion: %#v", result)
+	}
+}
+
+func TestSuiteAssertionsDriveOnlyDeclaredArtifactCollection(t *testing.T) {
+	assertions := []SuiteAssertion{
+		{
+			Type:    SuiteAssertionFieldsEqual,
+			Records: []string{"a", "b"},
+			Fields:  []string{"statusResult"},
+		},
+		{
+			Type:    SuiteAssertionForbiddenMarkers,
+			Records: []string{"b"},
+			Fields:  []string{"statusOutput"},
+			Markers: []string{"secret"},
+		},
+	}
+	for caseID, want := range map[string]struct {
+		result bool
+		output bool
+	}{
+		"a": {result: true},
+		"b": {result: true, output: true},
+		"c": {},
+	} {
+		t.Run(caseID, func(t *testing.T) {
+			requirements := artifactRequirements{}
+			if err := requirementsForSuiteAssertions(assertions, caseID, &requirements); err != nil {
+				t.Fatal(err)
+			}
+			if requirements.statusResult != want.result ||
+				requirements.statusOutput != want.output ||
+				requirements.pod || requirements.logs || requirements.envelope {
+				t.Fatalf("unexpected requirements: %#v", requirements)
+			}
+		})
+	}
+}

--- a/internal/eval/suite_test.go
+++ b/internal/eval/suite_test.go
@@ -75,6 +75,11 @@ func TestRepositoryKeylessSuiteParsesAndKeepsPerCaseImages(t *testing.T) {
 	if len(suite.Spec.Cases) != 10 {
 		t.Fatalf("expected 10 keyless cases, got %d", len(suite.Spec.Cases))
 	}
+	if len(suite.Spec.Assertions) != 2 ||
+		suite.Spec.Assertions[0].Type != SuiteAssertionFieldsEqual ||
+		suite.Spec.Assertions[1].Type != SuiteAssertionForbiddenMarkers {
+		t.Fatalf("keyless suite assertions changed: %#v", suite.Spec.Assertions)
+	}
 
 	var availableNotUsed, crash *Case
 	for index := range suite.Spec.Cases {

--- a/internal/eval/types.go
+++ b/internal/eval/types.go
@@ -247,17 +247,20 @@ type Record struct {
 }
 
 type Summary struct {
-	APIVersion        string                 `json:"apiVersion"`
-	Suite             string                 `json:"suite"`
-	StartedAt         time.Time              `json:"startedAt"`
-	CompletedAt       time.Time              `json:"completedAt"`
-	Total             int                    `json:"total"`
-	Passed            int                    `json:"passed"`
-	Failed            int                    `json:"failed"`
-	Assertions        []SuiteAssertionResult `json:"assertions,omitempty"`
-	AssertionFailures int                    `json:"assertionFailures"`
-	Pass              bool                   `json:"pass"`
-	RecordPath        string                 `json:"recordPath"`
+	APIVersion           string                 `json:"apiVersion"`
+	Suite                string                 `json:"suite"`
+	StartedAt            time.Time              `json:"startedAt"`
+	CompletedAt          time.Time              `json:"completedAt"`
+	ExpectedTotal        int                    `json:"expectedTotal"`
+	Total                int                    `json:"total"`
+	Passed               int                    `json:"passed"`
+	Failed               int                    `json:"failed"`
+	CollectionErrorCount int                    `json:"collectionErrorCount"`
+	CollectionErrorCases []string               `json:"collectionErrorCases,omitempty"`
+	Assertions           []SuiteAssertionResult `json:"assertions,omitempty"`
+	AssertionFailures    int                    `json:"assertionFailures"`
+	Pass                 bool                   `json:"pass"`
+	RecordPath           string                 `json:"recordPath"`
 }
 
 func podExitCode(pod *corev1.Pod) *int32 {

--- a/internal/eval/types.go
+++ b/internal/eval/types.go
@@ -52,8 +52,9 @@ type Metadata struct {
 }
 
 type SuiteSpec struct {
-	Defaults SuiteDefaults `json:"defaults"`
-	Cases    []Case        `json:"cases"`
+	Defaults   SuiteDefaults    `json:"defaults"`
+	Assertions []SuiteAssertion `json:"assertions,omitempty"`
+	Cases      []Case           `json:"cases"`
 }
 
 type SuiteDefaults struct {
@@ -68,6 +69,28 @@ type Case struct {
 	AgentRun    kontextv1alpha1.AgentRunSpec `json:"agentRun"`
 	Timeout     *Duration                    `json:"timeout,omitempty"`
 	Graders     []Grader                     `json:"graders"`
+}
+
+type SuiteAssertionType string
+
+const (
+	SuiteAssertionFieldsEqual      SuiteAssertionType = "fieldsEqual"
+	SuiteAssertionForbiddenMarkers SuiteAssertionType = "forbiddenMarkers"
+)
+
+type SuiteAssertion struct {
+	Type    SuiteAssertionType `json:"type"`
+	Records []string           `json:"records,omitempty"`
+	Fields  []string           `json:"fields"`
+	Markers []string           `json:"markers,omitempty"`
+}
+
+type SuiteAssertionResult struct {
+	Type    SuiteAssertionType `json:"type"`
+	Records []string           `json:"records,omitempty"`
+	Fields  []string           `json:"fields"`
+	Pass    bool               `json:"pass"`
+	Message string             `json:"message"`
 }
 
 type GraderType string
@@ -224,14 +247,17 @@ type Record struct {
 }
 
 type Summary struct {
-	APIVersion  string    `json:"apiVersion"`
-	Suite       string    `json:"suite"`
-	StartedAt   time.Time `json:"startedAt"`
-	CompletedAt time.Time `json:"completedAt"`
-	Total       int       `json:"total"`
-	Passed      int       `json:"passed"`
-	Failed      int       `json:"failed"`
-	RecordPath  string    `json:"recordPath"`
+	APIVersion        string                 `json:"apiVersion"`
+	Suite             string                 `json:"suite"`
+	StartedAt         time.Time              `json:"startedAt"`
+	CompletedAt       time.Time              `json:"completedAt"`
+	Total             int                    `json:"total"`
+	Passed            int                    `json:"passed"`
+	Failed            int                    `json:"failed"`
+	Assertions        []SuiteAssertionResult `json:"assertions,omitempty"`
+	AssertionFailures int                    `json:"assertionFailures"`
+	Pass              bool                   `json:"pass"`
+	RecordPath        string                 `json:"recordPath"`
 }
 
 func podExitCode(pod *corev1.Pod) *int32 {

--- a/scripts/eval-kind.sh
+++ b/scripts/eval-kind.sh
@@ -96,76 +96,17 @@ echo "==> running external keyless evaluation suite"
     --keep-runs
 )
 
-echo "==> validating machine-readable evaluation records"
+echo "==> validating machine-readable evaluation summary"
 jq -e '
   .apiVersion == "kontext.dev/eval/v1alpha1"
   and .suite == "keyless"
   and .total == 10
   and .passed == 10
   and .failed == 0
+  and .assertionFailures == 0
+  and .pass == true
+  and ((.assertions // []) | all(.pass == true))
 ' "${SUMMARY}" >/dev/null
-
-jq -s -e '
-  length == 10
-  and all(.[];
-    .apiVersion == "kontext.dev/eval/v1alpha1"
-    and .kind == "EvalRecord"
-    and .pass == true
-    and (.collectionErrors | length == 0)
-  )
-  and (
-    map(select(.caseId == "same-goal-model-a"))[0] as $a
-    | map(select(.caseId == "same-goal-model-b"))[0] as $b
-    | $a.statusResult == $b.statusResult
-    and $a.envelope.execution.model == "opaque/vendor-model-a@eval"
-    and $b.envelope.execution.model == "opaque/vendor-model-b@eval"
-  )
-  and (
-    map(select(.caseId == "read-knowledge-used"))[0]
-    | .envelope.execution.toolCalls == 1
-    and ([
-      .events.tools[]
-      | select(.name == "read_knowledge" and ((.isError // false) == false))
-    ] | length) == 1
-  )
-  and (
-    map(select(.caseId == "read-knowledge-available-not-used"))[0]
-    | .envelope.execution.toolCalls == 0
-    and ((.events.counts.tool // 0) == 0)
-  )
-  and (
-    map(select(.caseId == "kubernetes-read-rbac-denied"))[0]
-    | [.events.tools[] | select(
-        .name == "kubernetes_read"
-        and .isError == true
-        and .errorCode == "kubernetes_rbac_denied"
-      )] | length == 1
-  )
-  and (
-    map(select(.caseId == "missing-provider-credential"))[0]
-    | .terminalPhase == "Failed"
-    and .envelope.error.code == "missing_provider_credentials"
-  )
-  and (
-    map(select(.caseId == "provider-network-failure"))[0]
-    | .terminalPhase == "Failed"
-    and .envelope.error.code == "provider_network_error"
-  )
-  and (
-    map(select(.caseId == "controller-wallclock"))[0]
-    | .terminalPhase == "BudgetExceeded"
-  )
-  and (
-    map(select(.caseId == "malformed-provider-response"))[0]
-    | .terminalPhase == "Failed"
-    and .envelope.error.code == "invalid_provider_response"
-  )
-  and (
-    map(select(.caseId == "reporter-process-crash"))[0]
-    | .terminalPhase == "Failed"
-    and .podExitCode == 7
-  )
-' "${RECORDS}" >/dev/null
 
 wallclock_pod="$(
   jq -r 'select(.caseId == "controller-wallclock") | .run.podName' "${RECORDS}"
@@ -188,14 +129,6 @@ if [[ -z "${wallclock_pod}" ||
   "${wallclock_phase}" != "BudgetExceeded" ]] ||
   kubectl get pod "${wallclock_pod}" -n "${EVAL_NAMESPACE}" >/dev/null 2>&1; then
   echo "wallclock case did not record and clean up its runtime Pod" >&2
-  exit 1
-fi
-
-if jq -s -e '
-  tostring
-  | test("keyless-placeholder|fixture process is exiting")
-' "${RECORDS}" "${SUMMARY}" >/dev/null; then
-  echo "evaluation outputs contain a credential marker or raw fixture log" >&2
   exit 1
 fi
 

--- a/scripts/eval-kind.sh
+++ b/scripts/eval-kind.sh
@@ -100,9 +100,11 @@ echo "==> validating machine-readable evaluation summary"
 jq -e '
   .apiVersion == "kontext.dev/eval/v1alpha1"
   and .suite == "keyless"
-  and .total == 10
-  and .passed == 10
+  and .expectedTotal == .total
+  and .total > 0
+  and .passed == .total
   and .failed == 0
+  and .collectionErrorCount == 0
   and .assertionFailures == 0
   and .pass == true
   and ((.assertions // []) | all(.pass == true))


### PR DESCRIPTION
## Summary
- add validated suite-level `fieldsEqual` and `forbiddenMarkers` assertions with explicit record and field selection
- fail the shared summary contract on missing/extra records, collection errors, case failures, or suite assertion failures
- expose expected/actual record totals and collection-error counts/cases in JSON output
- move keyless result equality and credential-marker hygiene into suite YAML, leaving the shell script with summary and live-cluster checks

## Tests
- `go test ./internal/eval ./cmd/...`
- `make verify`
- `make test`
- `bash -n scripts/eval-kind.sh`
- `./scripts/test-shell-common.sh`
- disposable kind: installed with `KIND_CLUSTER_NAME=kontext-issue64-eval`, ran `scripts/eval-kind.sh` (expected 10, actual 10, 0 collection errors, 2/2 assertions passed), then deleted the cluster

Closes #64