### PR TITLE
Reset scroll position when navigating between docs pages

### DIFF
--- a/docs-site/src/components/Layout.tsx
+++ b/docs-site/src/components/Layout.tsx
@@ -1,9 +1,11 @@
 import { NavLink, Outlet } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
+import { ScrollToTop } from "./ScrollToTop";
 
 export function Layout() {
   return (
     <div className="shell">
+      <ScrollToTop />
       <header className="topbar">
         <div className="topbar-inner">
           <a className="brand" href="https://kontext.run">

--- a/docs-site/src/components/ScrollToTop.tsx
+++ b/docs-site/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+// React Router swaps route content in place without resetting window
+// scroll, so a reader deep in one page would land mid-page on the next.
+export function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,13 +27,6 @@ when it dies.
 You can also create a standalone `AgentRun` without an owning `Agent` — useful
 for ad-hoc dispatch and demos.
 
-## What Kontext does not do
-
-Kontext stays general. It never learns consumer vocabulary such as "code
-owner", "repository", or "pull request". Application behavior lives in the
-runtime image. The control plane only owns Pod lifecycle, budgets it can
-enforce, and status projection.
-
 ## Next steps
 
 1. [Install without cloning](/docs/quickstart)


### PR DESCRIPTION
## Summary
- Fixes the docs site carrying the scroll position from one page to the next: if you were at the bottom of a page and clicked a sidebar link, the new page opened at the bottom too. Adds a `ScrollToTop` component that scrolls the window to the top on every pathname change, mounted once in `Layout`.
- Removes the "What Kontext does not do" section from the docs introduction. Listing the consumer vocabulary the control plane refuses to learn is a contributor boundary, not user documentation; that guidance already lives in CONTRIBUTING.md.

## Test plan
- [x] `npm run build` in `docs-site` passes (typecheck + vite build)
- [ ] Manually: scroll to the bottom of Resource model, click another sidebar page, confirm it opens at the top