### PR TITLE
Extract shared AgentRun snapshot factory

### DIFF
--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -13,13 +12,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 	"github.com/MFS-code/Kontext/internal/conditions"
 	"github.com/MFS-code/Kontext/internal/podbuilder"
-	"github.com/MFS-code/Kontext/internal/runtimepolicy"
+	"github.com/MFS-code/Kontext/internal/runfactory"
 	"github.com/MFS-code/Kontext/internal/status"
 )
 
@@ -104,8 +102,8 @@ func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1
 	}
 	nextSuffix := runs.maxSuffix + 1
 	runName := fmt.Sprintf("%s-%d", agent.Name, nextSuffix)
-	run := r.buildServiceRun(agent, runName)
-	if err := controllerutil.SetControllerReference(agent, run, r.Scheme); err != nil {
+	run, err := runfactory.NewForAgent(agent, runName, agent.Spec.Goal, r.Scheme)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -247,41 +245,6 @@ func (runs observedServiceRuns) status(generation int64) kontextv1alpha1.AgentSt
 		next.LastRunName = runs.previous.Name
 	}
 	return next
-}
-
-func (r *AgentReconciler) buildServiceRun(agent *kontextv1alpha1.Agent, runName string) *kontextv1alpha1.AgentRun {
-	provider := runtimepolicy.NormalizeProvider(agent.Spec.Provider)
-	agentSpec := agent.Spec.DeepCopy()
-
-	run := &kontextv1alpha1.AgentRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      runName,
-			Namespace: agent.Namespace,
-			Labels: map[string]string{
-				podbuilder.LabelAgentName: agent.Name,
-			},
-		},
-		Spec: kontextv1alpha1.AgentRunSpec{
-			AgentRef: &kontextv1alpha1.AgentRef{Name: agent.Name},
-			Goal:     agent.Spec.Goal,
-			Provider: provider,
-			Model:    agent.Spec.Model,
-			Tools:    slices.Clone(agent.Spec.Tools),
-			Budget:   agent.Spec.Budget,
-			Runtime:  *agent.Spec.Runtime.DeepCopy(),
-			Env:      agentSpec.Env,
-		},
-	}
-	if agent.Spec.SecretRef != nil {
-		run.Spec.SecretRef = &kontextv1alpha1.SecretRef{Name: agent.Spec.SecretRef.Name}
-	}
-	if agent.Spec.KnowledgeConfigMapRef != nil {
-		run.Spec.KnowledgeConfigMapRef = &kontextv1alpha1.ConfigMapRef{Name: agent.Spec.KnowledgeConfigMapRef.Name}
-	}
-	if agent.Spec.ServiceAccountName != "" {
-		run.Spec.ServiceAccountName = agent.Spec.ServiceAccountName
-	}
-	return run
 }
 
 func (r *AgentReconciler) backoffDelay(agent kontextv1alpha1.Agent, restarts int32) time.Duration {

--- a/internal/controller/agent_controller_test.go
+++ b/internal/controller/agent_controller_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -96,6 +97,186 @@ func TestAgentReconcilerMintsServiceRun(t *testing.T) {
 	if run.Spec.Env[0].ValueFrom.SecretKeyRef.Name != "mcp-auth" ||
 		run.Spec.Env[0].ValueFrom.SecretKeyRef.Key != "token" {
 		t.Fatalf("child run Secret ref drifted with Agent update: %#v", run.Spec.Env)
+	}
+}
+
+func TestAgentReconcilerServiceRunMatchesLegacyBuildOutput(t *testing.T) {
+	ctx := context.Background()
+	agent := &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy-output-owner",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:     kontextv1alpha1.AgentModeService,
+			Goal:     "serve requests",
+			Provider: " OpenAI ",
+			Model:    "opaque-model",
+			Tools:    []string{"shell", "read_knowledge"},
+			Budget: &kontextv1alpha1.BudgetSpec{
+				Tokens:    testPtr(int32(2048)),
+				Wallclock: "10m",
+				Dollars:   testPtr(1.25),
+			},
+			SecretRef:             &kontextv1alpha1.SecretRef{Name: "provider-secret"},
+			KnowledgeConfigMapRef: &kontextv1alpha1.ConfigMapRef{Name: "knowledge"},
+			ServiceAccountName:    "runtime-identity",
+			Runtime: kontextv1alpha1.RuntimeSpec{
+				Image:   "example/runtime:v1",
+				Command: []string{"/runtime"},
+				Args:    []string{"serve", "--json"},
+				Result: &kontextv1alpha1.RuntimeResultSpec{
+					Source: kontextv1alpha1.ResultSourceStdout,
+					Format: kontextv1alpha1.ResultFormatKontextEnvelope,
+				},
+				SecurityContext: &kontextv1alpha1.RuntimeSecurityContext{
+					AllowPrivilegeEscalation: testPtr(false),
+					ReadOnlyRootFilesystem:   testPtr(true),
+					RunAsNonRoot:             testPtr(true),
+					Capabilities: &kontextv1alpha1.RuntimeCapabilities{
+						Drop: []string{"ALL"},
+					},
+					SeccompProfile: &kontextv1alpha1.RuntimeSeccompProfile{
+						Type: "RuntimeDefault",
+					},
+				},
+			},
+			Env: []kontextv1alpha1.EnvVar{
+				{Name: "LITERAL", Value: testPtr("value")},
+				{
+					Name: "SECRET",
+					ValueFrom: &kontextv1alpha1.EnvVarSource{
+						SecretKeyRef: kontextv1alpha1.SecretKeySelector{
+							Name: "runtime-secret",
+							Key:  "token",
+						},
+					},
+				},
+			},
+			Backoff: &kontextv1alpha1.BackoffSpec{
+				InitialSeconds: 7,
+				MaxSeconds:     70,
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
+
+	var run kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      "legacy-output-owner-1",
+		Namespace: agent.Namespace,
+	}, &run); err != nil {
+		t.Fatalf("get service run: %v", err)
+	}
+	wantSpec := kontextv1alpha1.AgentRunSpec{
+		AgentRef: &kontextv1alpha1.AgentRef{Name: agent.Name},
+		Goal:     "serve requests",
+		Provider: "openai",
+		Model:    "opaque-model",
+		Tools:    []string{"shell", "read_knowledge"},
+		Budget: &kontextv1alpha1.BudgetSpec{
+			Tokens:    testPtr(int32(2048)),
+			Wallclock: "10m",
+			Dollars:   testPtr(1.25),
+		},
+		SecretRef:             &kontextv1alpha1.SecretRef{Name: "provider-secret"},
+		KnowledgeConfigMapRef: &kontextv1alpha1.ConfigMapRef{Name: "knowledge"},
+		ServiceAccountName:    "runtime-identity",
+		Runtime: kontextv1alpha1.RuntimeSpec{
+			Image:   "example/runtime:v1",
+			Command: []string{"/runtime"},
+			Args:    []string{"serve", "--json"},
+			Result: &kontextv1alpha1.RuntimeResultSpec{
+				Source: kontextv1alpha1.ResultSourceStdout,
+				Format: kontextv1alpha1.ResultFormatKontextEnvelope,
+			},
+			SecurityContext: &kontextv1alpha1.RuntimeSecurityContext{
+				AllowPrivilegeEscalation: testPtr(false),
+				ReadOnlyRootFilesystem:   testPtr(true),
+				RunAsNonRoot:             testPtr(true),
+				Capabilities: &kontextv1alpha1.RuntimeCapabilities{
+					Drop: []string{"ALL"},
+				},
+				SeccompProfile: &kontextv1alpha1.RuntimeSeccompProfile{
+					Type: "RuntimeDefault",
+				},
+			},
+		},
+		Env: []kontextv1alpha1.EnvVar{
+			{Name: "LITERAL", Value: testPtr("value")},
+			{
+				Name: "SECRET",
+				ValueFrom: &kontextv1alpha1.EnvVarSource{
+					SecretKeyRef: kontextv1alpha1.SecretKeySelector{
+						Name: "runtime-secret",
+						Key:  "token",
+					},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(run.Spec, wantSpec) {
+		t.Fatalf("service AgentRun spec changed:\ngot:  %#v\nwant: %#v", run.Spec, wantSpec)
+	}
+	wantLabels := map[string]string{podbuilder.LabelAgentName: agent.Name}
+	if !reflect.DeepEqual(run.Labels, wantLabels) {
+		t.Fatalf("service AgentRun labels changed: got %v want %v", run.Labels, wantLabels)
+	}
+	controllerRef := true
+	blockOwnerDeletion := true
+	wantOwners := []metav1.OwnerReference{{
+		APIVersion:         kontextv1alpha1.GroupVersion.String(),
+		Kind:               "Agent",
+		Name:               agent.Name,
+		UID:                agent.UID,
+		Controller:         &controllerRef,
+		BlockOwnerDeletion: &blockOwnerDeletion,
+	}}
+	if !reflect.DeepEqual(run.OwnerReferences, wantOwners) {
+		t.Fatalf("service AgentRun ownership changed: got %#v want %#v", run.OwnerReferences, wantOwners)
+	}
+
+	var updated kontextv1alpha1.Agent
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      agent.Name,
+		Namespace: agent.Namespace,
+	}, &updated); err != nil {
+		t.Fatalf("get updated agent: %v", err)
+	}
+	gotStatus := updated.Status
+	for i := range gotStatus.Conditions {
+		if gotStatus.Conditions[i].LastTransitionTime.IsZero() {
+			t.Fatalf("condition transition time was not recorded: %#v", gotStatus.Conditions[i])
+		}
+		gotStatus.Conditions[i].LastTransitionTime = metav1.Time{}
+	}
+	wantStatus := kontextv1alpha1.AgentStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:               conditions.Ready,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: updated.Generation,
+				Reason:             "Recasting",
+				Message:            "Minted service run legacy-output-owner-1.",
+			},
+			{
+				Type:               conditions.Progressing,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: updated.Generation,
+				Reason:             "Recasting",
+				Message:            "Service run is being created.",
+			},
+		},
+		CurrentRunName:     "legacy-output-owner-1",
+		RunsCreated:        1,
+		ObservedGeneration: updated.Generation,
+	}
+	if !reflect.DeepEqual(gotStatus, wantStatus) {
+		t.Fatalf("service Agent status changed:\ngot:  %#v\nwant: %#v", gotStatus, wantStatus)
 	}
 }
 
@@ -790,4 +971,8 @@ func (c *staleAgentRunListClient) List(
 	runs.Items = filtered
 	c.omitName = types.NamespacedName{}
 	return nil
+}
+
+func testPtr[T any](value T) *T {
+	return &value
 }

--- a/internal/runfactory/runfactory.go
+++ b/internal/runfactory/runfactory.go
@@ -1,0 +1,49 @@
+// Package runfactory builds immutable AgentRun snapshots from Agent definitions.
+package runfactory
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/internal/runtimepolicy"
+)
+
+// NewForAgent builds an owned AgentRun with a fully resolved snapshot of the
+// Agent execution fields and the supplied concrete goal.
+func NewForAgent(
+	agent *kontextv1alpha1.Agent,
+	runName string,
+	goal string,
+	scheme *runtime.Scheme,
+) (*kontextv1alpha1.AgentRun, error) {
+	agentSpec := agent.Spec.DeepCopy()
+	run := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runName,
+			Namespace: agent.Namespace,
+			Labels: map[string]string{
+				podbuilder.LabelAgentName: agent.Name,
+			},
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			AgentRef:              &kontextv1alpha1.AgentRef{Name: agent.Name},
+			Goal:                  goal,
+			Provider:              runtimepolicy.NormalizeProvider(agentSpec.Provider),
+			Model:                 agentSpec.Model,
+			Tools:                 agentSpec.Tools,
+			Budget:                agentSpec.Budget,
+			SecretRef:             agentSpec.SecretRef,
+			KnowledgeConfigMapRef: agentSpec.KnowledgeConfigMapRef,
+			ServiceAccountName:    agentSpec.ServiceAccountName,
+			Runtime:               agentSpec.Runtime,
+			Env:                   agentSpec.Env,
+		},
+	}
+	if err := controllerutil.SetControllerReference(agent, run, scheme); err != nil {
+		return nil, err
+	}
+	return run, nil
+}

--- a/internal/runfactory/runfactory_test.go
+++ b/internal/runfactory/runfactory_test.go
@@ -1,0 +1,376 @@
+package runfactory_test
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/internal/runfactory"
+)
+
+func TestNewForAgentBuildsCompleteIndependentSnapshot(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := kontextv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add Kontext types to scheme: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		agent   *kontextv1alpha1.Agent
+		runName string
+		goal    string
+		want    *kontextv1alpha1.AgentRun
+		mutate  func(*kontextv1alpha1.Agent)
+	}{
+		{
+			name: "all execution fields",
+			agent: &kontextv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "full-agent",
+					Namespace: "agents",
+					UID:       types.UID("full-agent-uid"),
+				},
+				Spec: kontextv1alpha1.AgentSpec{
+					Mode:         kontextv1alpha1.AgentModeService,
+					Goal:         "source goal",
+					GoalTemplate: "ignored {{ .input }}",
+					Provider:     " OpenAI ",
+					Model:        "gpt-test",
+					Tools:        []string{"shell", "read_knowledge"},
+					Budget: &kontextv1alpha1.BudgetSpec{
+						Tokens:    ptr(int32(1234)),
+						Wallclock: "5m",
+						Dollars:   ptr(2.5),
+					},
+					SecretRef:             &kontextv1alpha1.SecretRef{Name: "provider-auth"},
+					KnowledgeConfigMapRef: &kontextv1alpha1.ConfigMapRef{Name: "knowledge"},
+					ServiceAccountName:    "agent-runner",
+					Runtime: kontextv1alpha1.RuntimeSpec{
+						Image:   "example/runtime:v1",
+						Command: []string{"/runtime"},
+						Args:    []string{"serve", "--json"},
+						Result: &kontextv1alpha1.RuntimeResultSpec{
+							Source: kontextv1alpha1.ResultSourceStdout,
+							Format: kontextv1alpha1.ResultFormatKontextEnvelope,
+						},
+						SecurityContext: &kontextv1alpha1.RuntimeSecurityContext{
+							AllowPrivilegeEscalation: ptr(false),
+							ReadOnlyRootFilesystem:   ptr(true),
+							RunAsNonRoot:             ptr(true),
+							Capabilities: &kontextv1alpha1.RuntimeCapabilities{
+								Drop: []string{"ALL", "NET_RAW"},
+							},
+							SeccompProfile: &kontextv1alpha1.RuntimeSeccompProfile{
+								Type:             "Localhost",
+								LocalhostProfile: "profiles/runtime.json",
+							},
+						},
+					},
+					Env: []kontextv1alpha1.EnvVar{
+						{Name: "LITERAL", Value: ptr("value")},
+						{
+							Name: "SECRET",
+							ValueFrom: &kontextv1alpha1.EnvVarSource{
+								SecretKeyRef: kontextv1alpha1.SecretKeySelector{
+									Name: "runtime-auth",
+									Key:  "token",
+								},
+							},
+						},
+					},
+					Schedule: "ignored schedule",
+					Backoff:  &kontextv1alpha1.BackoffSpec{InitialSeconds: 3, MaxSeconds: 30},
+				},
+			},
+			runName: "full-agent-7",
+			goal:    "concrete resolved goal",
+			want: &kontextv1alpha1.AgentRun{
+				ObjectMeta: ownedRunMetadata(
+					"full-agent",
+					"agents",
+					"full-agent-7",
+					types.UID("full-agent-uid"),
+				),
+				Spec: kontextv1alpha1.AgentRunSpec{
+					AgentRef: &kontextv1alpha1.AgentRef{Name: "full-agent"},
+					Goal:     "concrete resolved goal",
+					Provider: "openai",
+					Model:    "gpt-test",
+					Tools:    []string{"shell", "read_knowledge"},
+					Budget: &kontextv1alpha1.BudgetSpec{
+						Tokens:    ptr(int32(1234)),
+						Wallclock: "5m",
+						Dollars:   ptr(2.5),
+					},
+					SecretRef:             &kontextv1alpha1.SecretRef{Name: "provider-auth"},
+					KnowledgeConfigMapRef: &kontextv1alpha1.ConfigMapRef{Name: "knowledge"},
+					ServiceAccountName:    "agent-runner",
+					Runtime: kontextv1alpha1.RuntimeSpec{
+						Image:   "example/runtime:v1",
+						Command: []string{"/runtime"},
+						Args:    []string{"serve", "--json"},
+						Result: &kontextv1alpha1.RuntimeResultSpec{
+							Source: kontextv1alpha1.ResultSourceStdout,
+							Format: kontextv1alpha1.ResultFormatKontextEnvelope,
+						},
+						SecurityContext: &kontextv1alpha1.RuntimeSecurityContext{
+							AllowPrivilegeEscalation: ptr(false),
+							ReadOnlyRootFilesystem:   ptr(true),
+							RunAsNonRoot:             ptr(true),
+							Capabilities: &kontextv1alpha1.RuntimeCapabilities{
+								Drop: []string{"ALL", "NET_RAW"},
+							},
+							SeccompProfile: &kontextv1alpha1.RuntimeSeccompProfile{
+								Type:             "Localhost",
+								LocalhostProfile: "profiles/runtime.json",
+							},
+						},
+					},
+					Env: []kontextv1alpha1.EnvVar{
+						{Name: "LITERAL", Value: ptr("value")},
+						{
+							Name: "SECRET",
+							ValueFrom: &kontextv1alpha1.EnvVarSource{
+								SecretKeyRef: kontextv1alpha1.SecretKeySelector{
+									Name: "runtime-auth",
+									Key:  "token",
+								},
+							},
+						},
+					},
+				},
+			},
+			mutate: mutateFullAgent,
+		},
+		{
+			name: "nil optional pointers and slices",
+			agent: &kontextv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nil-agent",
+					Namespace: "agents",
+					UID:       types.UID("nil-agent-uid"),
+				},
+				Spec: kontextv1alpha1.AgentSpec{
+					Provider: "",
+					Model:    "default-provider-model",
+					Runtime:  kontextv1alpha1.RuntimeSpec{Image: "example/runtime:minimal"},
+				},
+			},
+			runName: "nil-agent-1",
+			goal:    "minimal goal",
+			want: &kontextv1alpha1.AgentRun{
+				ObjectMeta: ownedRunMetadata(
+					"nil-agent",
+					"agents",
+					"nil-agent-1",
+					types.UID("nil-agent-uid"),
+				),
+				Spec: kontextv1alpha1.AgentRunSpec{
+					AgentRef: &kontextv1alpha1.AgentRef{Name: "nil-agent"},
+					Goal:     "minimal goal",
+					Provider: "anthropic",
+					Model:    "default-provider-model",
+					Runtime:  kontextv1alpha1.RuntimeSpec{Image: "example/runtime:minimal"},
+				},
+			},
+			mutate: func(agent *kontextv1alpha1.Agent) {
+				agent.Spec.Tools = []string{"new-tool"}
+				agent.Spec.Budget = &kontextv1alpha1.BudgetSpec{Tokens: ptr(int32(1))}
+				agent.Spec.SecretRef = &kontextv1alpha1.SecretRef{Name: "new-secret"}
+				agent.Spec.KnowledgeConfigMapRef = &kontextv1alpha1.ConfigMapRef{Name: "new-config"}
+				agent.Spec.Runtime.Command = []string{"/new-command"}
+				agent.Spec.Runtime.Args = []string{"new-arg"}
+				agent.Spec.Runtime.Result = &kontextv1alpha1.RuntimeResultSpec{}
+				agent.Spec.Runtime.SecurityContext = &kontextv1alpha1.RuntimeSecurityContext{}
+				agent.Spec.Env = []kontextv1alpha1.EnvVar{{Name: "NEW", Value: ptr("new")}}
+			},
+		},
+		{
+			name: "allocated empty pointers and slices",
+			agent: &kontextv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-agent",
+					Namespace: "agents",
+					UID:       types.UID("empty-agent-uid"),
+				},
+				Spec: kontextv1alpha1.AgentSpec{
+					Provider:              "FAKE",
+					Model:                 "empty-model",
+					Tools:                 []string{},
+					Budget:                &kontextv1alpha1.BudgetSpec{},
+					SecretRef:             &kontextv1alpha1.SecretRef{},
+					KnowledgeConfigMapRef: &kontextv1alpha1.ConfigMapRef{},
+					Runtime: kontextv1alpha1.RuntimeSpec{
+						Image:           "example/runtime:empty",
+						Command:         []string{},
+						Args:            []string{},
+						Result:          &kontextv1alpha1.RuntimeResultSpec{},
+						SecurityContext: &kontextv1alpha1.RuntimeSecurityContext{},
+					},
+					Env: []kontextv1alpha1.EnvVar{},
+				},
+			},
+			runName: "empty-agent-1",
+			goal:    "empty collections goal",
+			want: &kontextv1alpha1.AgentRun{
+				ObjectMeta: ownedRunMetadata(
+					"empty-agent",
+					"agents",
+					"empty-agent-1",
+					types.UID("empty-agent-uid"),
+				),
+				Spec: kontextv1alpha1.AgentRunSpec{
+					AgentRef:              &kontextv1alpha1.AgentRef{Name: "empty-agent"},
+					Goal:                  "empty collections goal",
+					Provider:              "fake",
+					Model:                 "empty-model",
+					Tools:                 []string{},
+					Budget:                &kontextv1alpha1.BudgetSpec{},
+					SecretRef:             &kontextv1alpha1.SecretRef{},
+					KnowledgeConfigMapRef: &kontextv1alpha1.ConfigMapRef{},
+					Runtime: kontextv1alpha1.RuntimeSpec{
+						Image:           "example/runtime:empty",
+						Command:         []string{},
+						Args:            []string{},
+						Result:          &kontextv1alpha1.RuntimeResultSpec{},
+						SecurityContext: &kontextv1alpha1.RuntimeSecurityContext{},
+					},
+					Env: []kontextv1alpha1.EnvVar{},
+				},
+			},
+			mutate: func(agent *kontextv1alpha1.Agent) {
+				agent.Spec.Tools = append(agent.Spec.Tools, "new-tool")
+				agent.Spec.Budget.Tokens = ptr(int32(1))
+				agent.Spec.SecretRef.Name = "new-secret"
+				agent.Spec.KnowledgeConfigMapRef.Name = "new-config"
+				agent.Spec.Runtime.Command = append(agent.Spec.Runtime.Command, "/new-command")
+				agent.Spec.Runtime.Args = append(agent.Spec.Runtime.Args, "new-arg")
+				agent.Spec.Runtime.Result.Source = kontextv1alpha1.ResultSourceStdout
+				agent.Spec.Runtime.SecurityContext.RunAsNonRoot = ptr(true)
+				agent.Spec.Env = append(agent.Spec.Env, kontextv1alpha1.EnvVar{
+					Name:  "NEW",
+					Value: ptr("new"),
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := runfactory.NewForAgent(test.agent, test.runName, test.goal, scheme)
+			if err != nil {
+				t.Fatalf("build AgentRun snapshot: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("unexpected AgentRun snapshot:\ngot:  %#v\nwant: %#v", got, test.want)
+			}
+
+			test.mutate(test.agent)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("AgentRun snapshot changed after source mutation:\ngot:  %#v\nwant: %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSnapshotFieldCoverage(t *testing.T) {
+	assertStructFields(t, reflect.TypeFor[kontextv1alpha1.AgentSpec](), []string{
+		"Backoff",
+		"Budget",
+		"Env",
+		"Goal",
+		"GoalTemplate",
+		"KnowledgeConfigMapRef",
+		"Mode",
+		"Model",
+		"Provider",
+		"Runtime",
+		"Schedule",
+		"SecretRef",
+		"ServiceAccountName",
+		"Tools",
+	})
+	assertStructFields(t, reflect.TypeFor[kontextv1alpha1.AgentRunSpec](), []string{
+		"AgentRef",
+		"Budget",
+		"Env",
+		"Goal",
+		"KnowledgeConfigMapRef",
+		"Model",
+		"Provider",
+		"Runtime",
+		"SecretRef",
+		"ServiceAccountName",
+		"Tools",
+	})
+}
+
+func assertStructFields(t *testing.T, structType reflect.Type, want []string) {
+	t.Helper()
+	got := make([]string, 0, structType.NumField())
+	for i := range structType.NumField() {
+		got = append(got, structType.Field(i).Name)
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s fields changed; classify the new field in the snapshot factory: got %v want %v", structType, got, want)
+	}
+}
+
+func ownedRunMetadata(agentName, namespace, runName string, uid types.UID) metav1.ObjectMeta {
+	controller := true
+	blockOwnerDeletion := true
+	return metav1.ObjectMeta{
+		Name:      runName,
+		Namespace: namespace,
+		Labels: map[string]string{
+			podbuilder.LabelAgentName: agentName,
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion:         kontextv1alpha1.GroupVersion.String(),
+			Kind:               "Agent",
+			Name:               agentName,
+			UID:                uid,
+			Controller:         &controller,
+			BlockOwnerDeletion: &blockOwnerDeletion,
+		}},
+	}
+}
+
+func mutateFullAgent(agent *kontextv1alpha1.Agent) {
+	agent.Name = "changed-agent"
+	agent.Namespace = "changed-namespace"
+	agent.Spec.Provider = "anthropic"
+	agent.Spec.Model = "changed-model"
+	agent.Spec.Tools[0] = "changed-tool"
+	*agent.Spec.Budget.Tokens = 999
+	agent.Spec.Budget.Wallclock = "1s"
+	*agent.Spec.Budget.Dollars = 99
+	agent.Spec.SecretRef.Name = "changed-secret"
+	agent.Spec.KnowledgeConfigMapRef.Name = "changed-config"
+	agent.Spec.ServiceAccountName = "changed-service-account"
+	agent.Spec.Runtime.Image = "changed/image"
+	agent.Spec.Runtime.Command[0] = "/changed-command"
+	agent.Spec.Runtime.Args[0] = "changed-arg"
+	agent.Spec.Runtime.Result.Format = kontextv1alpha1.ResultFormatLastLine
+	*agent.Spec.Runtime.SecurityContext.AllowPrivilegeEscalation = true
+	*agent.Spec.Runtime.SecurityContext.ReadOnlyRootFilesystem = false
+	*agent.Spec.Runtime.SecurityContext.RunAsNonRoot = false
+	agent.Spec.Runtime.SecurityContext.Capabilities.Drop[0] = "CHANGED"
+	agent.Spec.Runtime.SecurityContext.SeccompProfile.Type = "RuntimeDefault"
+	agent.Spec.Runtime.SecurityContext.SeccompProfile.LocalhostProfile = ""
+	*agent.Spec.Env[0].Value = "changed-value"
+	agent.Spec.Env[1].ValueFrom.SecretKeyRef.Name = "changed-runtime-auth"
+	agent.Spec.Env[1].ValueFrom.SecretKeyRef.Key = "changed-token"
+}
+
+func ptr[T any](value T) *T {
+	return &value
+}


### PR DESCRIPTION
## Summary
- add a mode-neutral factory for fully resolved, owned AgentRun snapshots with normalized providers and deep-copied execution fields
- route Service run creation through the shared factory without changing naming, collision recovery, conditions, counters, or status behavior
- add exhaustive full-field, nil/empty, deep-copy isolation, field-coverage, and Service parity tests

## Tests
- `go test ./internal/runfactory -count=1`
- `KUBEBUILDER_ASSETS="$(bin/setup-envtest use 1.32.0 -p path)" go test ./internal/controller -count=1`
- `make verify`
- `make test`
- `make vulncheck`
- CI-equivalent reporter/reference image build and fake success/tool/failure smoke
- disposable kind install + `./scripts/e2e-kind.sh`
- disposable kind `./scripts/eval-kind.sh` (10/10 passed)
- disposable Calico `./scripts/e2e-kind-network-policy.sh`

Closes #80