### PR TITLE
Remove the reporter's unreachable shutdown path

### DIFF
--- a/runtimes/reporter/config.go
+++ b/runtimes/reporter/config.go
@@ -76,6 +76,7 @@ func parseConfig(args []string, getenv func(string) string) (Config, error) {
 
 func parseCaptureFormat(value string) (CaptureFormat, error) {
 	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
+	// Unhyphenated aliases accept CRD enum values used directly; the controller passes hyphenated forms.
 	switch normalized {
 	case "lastline", string(CaptureFormatLastLine):
 		return CaptureFormatLastLine, nil

--- a/runtimes/reporter/main.go
+++ b/runtimes/reporter/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -46,5 +45,5 @@ func execute(
 	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
 	defer signal.Stop(signals)
 
-	return runReporter(context.Background(), config, stdout, stderr, signals)
+	return runReporter(config, stdout, stderr, signals)
 }

--- a/runtimes/reporter/process_linux_test.go
+++ b/runtimes/reporter/process_linux_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"testing"
 )
 
@@ -19,7 +18,6 @@ fi
 `
 	var stderr bytes.Buffer
 	result, err := runChild(
-		context.Background(),
 		[]string{"sh", "-c", script},
 		&bytes.Buffer{},
 		&stderr,

--- a/runtimes/reporter/reporter.go
+++ b/runtimes/reporter/reporter.go
@@ -48,7 +48,8 @@ func runReporter(
 
 func envelopeFromCapture(format CaptureFormat, captured CapturedResult, childExitCode int) resultv1alpha1.Envelope {
 	var envelope resultv1alpha1.Envelope
-	if format == CaptureFormatLastLine {
+	switch format {
+	case CaptureFormatLastLine:
 		envelope = resultv1alpha1.Envelope{
 			APIVersion: resultv1alpha1.APIVersion,
 			Outcome:    resultv1alpha1.OutcomeSucceeded,
@@ -66,7 +67,7 @@ func envelopeFromCapture(format CaptureFormat, captured CapturedResult, childExi
 				Value:     value,
 			}
 		}
-	} else {
+	case CaptureFormatKontextEnvelope:
 		envelope = envelopeFromPrefixedCandidate(captured)
 	}
 

--- a/runtimes/reporter/reporter.go
+++ b/runtimes/reporter/reporter.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,14 +16,13 @@ const (
 )
 
 func runReporter(
-	ctx context.Context,
 	config Config,
 	stdout io.Writer,
 	stderr io.Writer,
 	signals <-chan os.Signal,
 ) int {
 	capture := newCapture(config.Format, config.MaxCaptureBytes)
-	child, err := runChild(ctx, config.Command, stdout, stderr, capture, signals)
+	child, err := runChild(config.Command, stdout, stderr, capture, signals)
 	if err != nil {
 		exitCode := reporterFailureExitCode
 		errorCode := "reporter_internal"
@@ -50,8 +48,7 @@ func runReporter(
 
 func envelopeFromCapture(format CaptureFormat, captured CapturedResult, childExitCode int) resultv1alpha1.Envelope {
 	var envelope resultv1alpha1.Envelope
-	switch format {
-	case CaptureFormatLastLine:
+	if format == CaptureFormatLastLine {
 		envelope = resultv1alpha1.Envelope{
 			APIVersion: resultv1alpha1.APIVersion,
 			Outcome:    resultv1alpha1.OutcomeSucceeded,
@@ -69,10 +66,8 @@ func envelopeFromCapture(format CaptureFormat, captured CapturedResult, childExi
 				Value:     value,
 			}
 		}
-	case CaptureFormatKontextEnvelope:
+	} else {
 		envelope = envelopeFromPrefixedCandidate(captured)
-	default:
-		envelope = failureEnvelope("result_format_invalid", fmt.Sprintf("unsupported result format %q", format))
 	}
 
 	if childExitCode != 0 && envelope.Outcome != resultv1alpha1.OutcomeFailed {

--- a/runtimes/reporter/reporter_test.go
+++ b/runtimes/reporter/reporter_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -153,7 +152,7 @@ func TestRunReporterPreservesLogsAndChildExit(t *testing.T) {
 		Command:         []string{"sh", "-c", `printf 'log one\nfinal answer\n'; printf 'warning\n' >&2; exit 7`},
 	}
 
-	exitCode := runReporter(context.Background(), config, &stdout, &stderr, nil)
+	exitCode := runReporter(config, &stdout, &stderr, nil)
 	if exitCode != 7 {
 		t.Fatalf("expected child exit 7, got %d", exitCode)
 	}
@@ -186,7 +185,7 @@ func TestRunReporterDistinguishesReporterFailures(t *testing.T) {
 			MaxCaptureBytes: defaultCaptureBytes,
 			Command:         []string{"/definitely/missing/agent"},
 		}
-		if exitCode := runReporter(context.Background(), config, &bytes.Buffer{}, &stderr, nil); exitCode != childStartExitCode {
+		if exitCode := runReporter(config, &bytes.Buffer{}, &stderr, nil); exitCode != childStartExitCode {
 			t.Fatalf("expected child-start exit %d, got %d", childStartExitCode, exitCode)
 		}
 		envelope := readTestEnvelope(t, path)
@@ -203,7 +202,7 @@ func TestRunReporterDistinguishesReporterFailures(t *testing.T) {
 			MaxCaptureBytes: defaultCaptureBytes,
 			Command:         []string{"sh", "-c", "printf output"},
 		}
-		if exitCode := runReporter(context.Background(), config, failingWriter{}, &bytes.Buffer{}, nil); exitCode != reporterFailureExitCode {
+		if exitCode := runReporter(config, failingWriter{}, &bytes.Buffer{}, nil); exitCode != reporterFailureExitCode {
 			t.Fatalf("expected reporter exit %d, got %d", reporterFailureExitCode, exitCode)
 		}
 		envelope := readTestEnvelope(t, path)

--- a/runtimes/reporter/supervisor.go
+++ b/runtimes/reporter/supervisor.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -30,7 +29,6 @@ type ChildResult struct {
 }
 
 func runChild(
-	ctx context.Context,
 	command []string,
 	stdout io.Writer,
 	stderr io.Writer,
@@ -77,7 +75,7 @@ func runChild(
 	signalErrors := &errorRecorder{}
 	go func() {
 		defer close(forwardingDone)
-		forwardSignals(ctx, signals, processGroupID, done, signalErrors)
+		forwardSignals(signals, processGroupID, done, signalErrors)
 	}()
 
 	status, waitErr := waitForMainProcess(processGroupID)
@@ -155,9 +153,7 @@ func channelErrors(errorsChannel <-chan error) []error {
 type streamForwarder struct {
 	sink    io.Writer
 	capture io.Writer
-
-	mu  sync.Mutex
-	err error
+	errorRecorder
 }
 
 func newStreamForwarder(sink io.Writer, capture io.Writer) *streamForwarder {
@@ -169,23 +165,13 @@ func (forwarder *streamForwarder) Write(data []byte) (int, error) {
 		_, _ = forwarder.capture.Write(data)
 	}
 
-	forwarder.mu.Lock()
-	defer forwarder.mu.Unlock()
-	if forwarder.err == nil {
-		if err := writeAll(forwarder.sink, data); err != nil {
-			forwarder.err = err
-		}
+	if forwarder.Err() == nil {
+		forwarder.Set(writeAll(forwarder.sink, data))
 	}
 
 	// Always report the input as consumed so os/exec continues draining the
 	// child's pipe even if the log destination fails.
 	return len(data), nil
-}
-
-func (forwarder *streamForwarder) Err() error {
-	forwarder.mu.Lock()
-	defer forwarder.mu.Unlock()
-	return forwarder.err
 }
 
 func writeAll(writer io.Writer, data []byte) error {
@@ -203,13 +189,11 @@ func writeAll(writer io.Writer, data []byte) error {
 }
 
 func forwardSignals(
-	ctx context.Context,
 	signals <-chan os.Signal,
 	processGroupID int,
 	done <-chan struct{},
 	recorder *errorRecorder,
 ) {
-	contextDone := ctx.Done()
 	for {
 		select {
 		case <-done:
@@ -222,11 +206,6 @@ func forwardSignals(
 			if err := forwardSignal(processGroupID, signal); err != nil {
 				recorder.Set(fmt.Errorf("forward signal %v: %w", signal, err))
 			}
-		case <-contextDone:
-			if err := procgroup.Signal(processGroupID, syscall.SIGTERM); err != nil {
-				recorder.Set(fmt.Errorf("forward context cancellation: %w", err))
-			}
-			contextDone = nil
 		}
 	}
 }

--- a/runtimes/reporter/supervisor_test.go
+++ b/runtimes/reporter/supervisor_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"io"
 	"os"
@@ -19,7 +18,6 @@ func TestRunChildForwardsStreamsConcurrently(t *testing.T) {
 	var stderr bytes.Buffer
 	capture := newCapture(CaptureFormatLastLine, defaultCaptureBytes)
 	result, err := runChild(
-		context.Background(),
 		[]string{"sh", "-c", `printf 'out-1\n'; printf 'err-1\n' >&2; printf 'out-2\n'; printf 'err-2\n' >&2`},
 		&stdout,
 		&stderr,
@@ -63,7 +61,6 @@ func TestRunChildForwardsTerminationSignals(t *testing.T) {
 			responseChannel := make(chan response, 1)
 			go func() {
 				result, err := runChild(
-					context.Background(),
 					[]string{"sh", "-c", "printf 'READY\\n'; exec sleep 30"},
 					stdout,
 					&bytes.Buffer{},
@@ -98,7 +95,6 @@ func TestRunChildForwardsTerminationSignals(t *testing.T) {
 func TestRunChildCleansUpRemainingProcessGroup(t *testing.T) {
 	var stdout bytes.Buffer
 	result, err := runChild(
-		context.Background(),
 		[]string{"sh", "-c", "sleep 30 & echo $!; exit 0"},
 		&stdout,
 		&bytes.Buffer{},


### PR DESCRIPTION
## Summary
- Remove unused context cancellation threading while retaining SIGTERM and SIGINT forwarding.
- Reuse the shared first-error recorder for stream forwarding and remove the unreachable invalid-format envelope path.
- Document why unhyphenated result-format aliases remain accepted.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./runtimes/reporter/...`
- [x] `go test -race ./runtimes/reporter/...`
- [ ] `go test ./...` (local envtest cannot start because `/usr/local/kubebuilder/bin/etcd` is unavailable; all non-controller packages pass)