### PR TITLE
Share tool result and error types across runtime boundaries

### DIFF
--- a/runtimes/reference/internal/engine/engine.go
+++ b/runtimes/reference/internal/engine/engine.go
@@ -13,7 +13,6 @@ import (
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/events"
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/provider"
 	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
-	"github.com/MFS-code/Kontext/runtimes/reference/internal/tools"
 )
 
 // Emitter publishes best-effort observability events. The result envelope is
@@ -101,7 +100,7 @@ func (runner Runner) Run(ctx context.Context, runtimeConfig config.Config) Resul
 	execution.toolExecutor = toolExecutor
 	if err != nil {
 		code := "invalid_tool_configuration"
-		var toolError *tools.Error
+		var toolError *runtimeapi.CodedError
 		if errors.As(err, &toolError) && toolError.Code != "" {
 			code = toolError.Code
 		}

--- a/runtimes/reference/internal/engine/engine_test.go
+++ b/runtimes/reference/internal/engine/engine_test.go
@@ -67,6 +67,7 @@ func TestRunnerClosesEveryResolvedExecutorExactlyOnce(t *testing.T) {
 		resolverError  error
 		wantExitCode   int
 		wantCloseCalls int
+		wantErrorCode  string
 	}{
 		{
 			name:           "executor and error",
@@ -74,12 +75,17 @@ func TestRunnerClosesEveryResolvedExecutorExactlyOnce(t *testing.T) {
 			resolverError:  errors.New("resolve failed"),
 			wantExitCode:   1,
 			wantCloseCalls: 1,
+			wantErrorCode:  "invalid_tool_configuration",
 		},
 		{
-			name:           "nil and error",
-			resolverError:  errors.New("resolve failed"),
+			name: "nil and coded error",
+			resolverError: &runtimeapi.CodedError{
+				Code:    "unknown_tool",
+				Message: "resolve failed",
+			},
 			wantExitCode:   1,
 			wantCloseCalls: 0,
+			wantErrorCode:  "unknown_tool",
 		},
 		{
 			name:           "successful executor",
@@ -115,7 +121,7 @@ func TestRunnerClosesEveryResolvedExecutorExactlyOnce(t *testing.T) {
 			}
 			if test.resolverError != nil &&
 				(result.Envelope.Error == nil ||
-					result.Envelope.Error.Code != "invalid_tool_configuration" ||
+					result.Envelope.Error.Code != test.wantErrorCode ||
 					result.Envelope.Error.Message != test.resolverError.Error()) {
 				t.Fatalf("resolver error was not preserved: %#v", result.Envelope.Error)
 			}

--- a/runtimes/reference/internal/mcpclient/client.go
+++ b/runtimes/reference/internal/mcpclient/client.go
@@ -25,25 +25,6 @@ const (
 	processTerminationGrace = 500 * time.Millisecond
 )
 
-type Error struct {
-	Code    string
-	Message string
-}
-
-func (err *Error) Error() string {
-	if err.Code == "" {
-		return err.Message
-	}
-	return fmt.Sprintf("%s: %s", err.Code, err.Message)
-}
-
-type Result struct {
-	Content   string
-	IsError   bool
-	ErrorCode string
-	Truncated bool
-}
-
 type Manager struct {
 	servers         []*server
 	tools           map[string]*remoteTool
@@ -84,7 +65,7 @@ func New(ctx context.Context, mcpConfig config.MCPConfig, stderr io.Writer) (*Ma
 		}
 		if err := current.connect(ctx); err != nil {
 			manager.closeAfterStartupFailure()
-			var clientError *Error
+			var clientError *runtimeapi.CodedError
 			if errors.As(err, &clientError) {
 				return nil, clientError
 			}
@@ -98,7 +79,7 @@ func New(ctx context.Context, mcpConfig config.MCPConfig, stderr io.Writer) (*Ma
 		for _, discovered := range current.frozen {
 			if len(manager.definitions) >= maxDiscoveredTools {
 				manager.closeAfterStartupFailure()
-				return nil, &Error{
+				return nil, &runtimeapi.CodedError{
 					Code: "mcp_discovery_limit_exceeded",
 					Message: fmt.Sprintf(
 						"configured MCP servers expose more than %d tools in total",
@@ -108,7 +89,7 @@ func New(ctx context.Context, mcpConfig config.MCPConfig, stderr io.Writer) (*Ma
 			}
 			if _, collision := manager.tools[discovered.name]; collision {
 				manager.closeAfterStartupFailure()
-				return nil, &Error{
+				return nil, &runtimeapi.CodedError{
 					Code:    "mcp_invalid_tool_definition",
 					Message: fmt.Sprintf("MCP tool name %q is provided more than once", discovered.name),
 				}
@@ -123,7 +104,7 @@ func New(ctx context.Context, mcpConfig config.MCPConfig, stderr io.Writer) (*Ma
 				len(discovered.definition.InputSchema)
 			if manager.definitionBytes > maxTotalToolDefinitionBytes {
 				manager.closeAfterStartupFailure()
-				return nil, &Error{
+				return nil, &runtimeapi.CodedError{
 					Code: "mcp_discovery_limit_exceeded",
 					Message: fmt.Sprintf(
 						"configured MCP tool definitions exceed the %d-byte total limit",
@@ -148,9 +129,9 @@ func (manager *Manager) Execute(
 	ctx context.Context,
 	name string,
 	arguments json.RawMessage,
-) (Result, error) {
+) (runtimeapi.ToolResult, error) {
 	if manager == nil {
-		return Result{
+		return runtimeapi.ToolResult{
 			IsError:   true,
 			ErrorCode: "mcp_unavailable",
 			Content:   "MCP execution is unavailable",
@@ -158,14 +139,14 @@ func (manager *Manager) Execute(
 	}
 	selected, exists := manager.tools[name]
 	if !exists {
-		return Result{
+		return runtimeapi.ToolResult{
 			IsError:   true,
 			ErrorCode: "unknown_tool",
 			Content:   fmt.Sprintf("tool %q is not available", name),
 		}, nil
 	}
 	if err := validateArguments(selected.name, selected.schema, arguments); err != nil {
-		return Result{
+		return runtimeapi.ToolResult{
 			IsError:   true,
 			ErrorCode: "mcp_invalid_arguments",
 			Content:   err.Error(),
@@ -239,7 +220,7 @@ func (current *server) connect(ctx context.Context) error {
 	)
 	if err != nil {
 		_ = current.closeSession(ctx)
-		var clientError *Error
+		var clientError *runtimeapi.CodedError
 		if errors.As(err, &clientError) {
 			clientError.Message = current.redactor.clean(clientError.Message)
 			return clientError
@@ -252,7 +233,7 @@ func (current *server) connect(ctx context.Context) error {
 	}
 	if current.frozen != nil && !sameTools(current.frozen, discovered) {
 		_ = current.closeSession(ctx)
-		return &Error{
+		return &runtimeapi.CodedError{
 			Code:    "mcp_toolset_changed",
 			Message: fmt.Sprintf("MCP server %q tool definitions changed after reconnect", current.config.Name),
 		}
@@ -304,13 +285,13 @@ func (current *server) call(
 	ctx context.Context,
 	name string,
 	arguments json.RawMessage,
-) (Result, error) {
+) (runtimeapi.ToolResult, error) {
 	current.mu.Lock()
 	defer current.mu.Unlock()
 
 	if current.stale {
 		if err := current.closeSession(ctx); err != nil {
-			return Result{
+			return runtimeapi.ToolResult{
 				IsError:   true,
 				ErrorCode: "mcp_reconnect_failed",
 				Content:   fmt.Sprintf("MCP server %q could not close its stale session", current.config.Name),
@@ -318,7 +299,7 @@ func (current *server) call(
 		}
 		if err := current.connect(ctx); err != nil {
 			current.stale = true
-			return Result{
+			return runtimeapi.ToolResult{
 				IsError:   true,
 				ErrorCode: "mcp_reconnect_failed",
 				Content: current.safeMessage(
@@ -337,10 +318,10 @@ func (current *server) call(
 	if err != nil {
 		current.stale = true
 		if ctx.Err() != nil {
-			return Result{}, ctx.Err()
+			return runtimeapi.ToolResult{}, ctx.Err()
 		}
 		if errors.Is(callCtx.Err(), context.DeadlineExceeded) {
-			return Result{
+			return runtimeapi.ToolResult{
 				IsError:   true,
 				ErrorCode: "mcp_timeout",
 				Content:   fmt.Sprintf("MCP tool %q timed out", name),
@@ -350,7 +331,7 @@ func (current *server) call(
 		if errors.Is(err, mcp.ErrConnectionClosed) {
 			code = "mcp_transport_error"
 		}
-		return Result{
+		return runtimeapi.ToolResult{
 			IsError:   true,
 			ErrorCode: code,
 			Content: current.safeMessage(
@@ -361,13 +342,13 @@ func (current *server) call(
 
 	content, truncated, normalizeErr := normalizeResult(response, current.redactor)
 	if normalizeErr != nil {
-		return Result{
+		return runtimeapi.ToolResult{
 			IsError:   true,
 			ErrorCode: normalizeErr.Code,
 			Content:   normalizeErr.Message,
 		}, nil
 	}
-	return Result{
+	return runtimeapi.ToolResult{
 		Content:   content,
 		IsError:   response.IsError,
 		ErrorCode: errorCode(response.IsError),

--- a/runtimes/reference/internal/mcpclient/client_test.go
+++ b/runtimes/reference/internal/mcpclient/client_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/MFS-code/Kontext/runtimes/reference/internal/config"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 func TestHTTPDiscoveryExecutionAuthBoundingAndClose(t *testing.T) {
@@ -757,7 +758,7 @@ func TestDiscoveryLimitsAndToolNames(t *testing.T) {
 			_, err := New(context.Background(), config.MCPConfig{
 				Servers: []config.MCPServer{{Name: "limits", Transport: "http", Endpoint: httpServer.URL}},
 			}, nil)
-			var clientError *Error
+			var clientError *runtimeapi.CodedError
 			if !errors.As(err, &clientError) || clientError.Code != test.code {
 				t.Fatalf("expected %s, got %v", test.code, err)
 			}

--- a/runtimes/reference/internal/mcpclient/discovery.go
+++ b/runtimes/reference/internal/mcpclient/discovery.go
@@ -46,7 +46,7 @@ func discoverTools(
 			return nil, fmt.Errorf("discover tools: %w", err)
 		}
 		if len(discovered) >= maxDiscoveredTools {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code: "mcp_discovery_limit_exceeded",
 				Message: fmt.Sprintf(
 					"MCP server %q exposes more than %d tools",
@@ -56,7 +56,7 @@ func discoverTools(
 			}
 		}
 		if tool == nil || !mcpToolNamePattern.MatchString(tool.Name) {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code: "mcp_invalid_tool_definition",
 				Message: fmt.Sprintf(
 					"MCP server %q returned a tool name outside the 1..128 [A-Za-z0-9_.-]+ constraint",
@@ -65,13 +65,13 @@ func discoverTools(
 			}
 		}
 		if redactor.containsSensitive(tool.Name) {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code:    "mcp_invalid_tool_definition",
 				Message: fmt.Sprintf("MCP server %q returned a tool name containing a resolved sensitive value", serverName),
 			}
 		}
 		if _, duplicate := seen[tool.Name]; duplicate {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code:    "mcp_invalid_tool_definition",
 				Message: fmt.Sprintf("MCP server %q returned duplicate tool %q", serverName, tool.Name),
 			}
@@ -93,13 +93,13 @@ func discoverTools(
 		}
 		rawSchema, marshalErr := json.Marshal(tool.InputSchema)
 		if marshalErr != nil {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code:    "mcp_invalid_tool_definition",
 				Message: fmt.Sprintf("MCP server %q tool %q schema cannot be encoded", serverName, tool.Name),
 			}
 		}
 		if redactor.containsSensitive(string(rawSchema)) {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code: "mcp_invalid_tool_definition",
 				Message: fmt.Sprintf(
 					"MCP server %q tool %q schema contains a resolved sensitive value",
@@ -119,7 +119,7 @@ func discoverTools(
 		}
 		schema, resolvedSchema, err := normalizeSchema(tool.InputSchema)
 		if err != nil {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code:    "mcp_invalid_tool_definition",
 				Message: fmt.Sprintf("MCP server %q tool %q: %v", serverName, tool.Name, err),
 			}
@@ -145,7 +145,7 @@ func discoverTools(
 		}
 		totalDefinitionBytes += definitionBytes
 		if totalDefinitionBytes > maxTotalToolDefinitionBytes {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code: "mcp_discovery_limit_exceeded",
 				Message: fmt.Sprintf(
 					"MCP server %q tool definitions exceed the %d-byte total limit",
@@ -200,8 +200,8 @@ func discoveryLimitError(
 	part string,
 	actual int,
 	limit int,
-) *Error {
-	return &Error{
+) *runtimeapi.CodedError {
+	return &runtimeapi.CodedError{
 		Code: "mcp_discovery_limit_exceeded",
 		Message: fmt.Sprintf(
 			"MCP server %q tool %q %s is %d bytes; limit is %d bytes",

--- a/runtimes/reference/internal/mcpclient/redact.go
+++ b/runtimes/reference/internal/mcpclient/redact.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/MFS-code/Kontext/internal/tooloutput"
+	runtimeapi "github.com/MFS-code/Kontext/runtimes/reference/internal/runtimeapi"
 )
 
 const (
@@ -86,12 +87,12 @@ func (current *server) safeMessage(value string) string {
 	return current.redactor.clean(value)
 }
 
-func (current *server) safeError(code string, prefix string, err error) *Error {
+func (current *server) safeError(code string, prefix string, err error) *runtimeapi.CodedError {
 	message := prefix
 	if err != nil {
 		message += ": " + err.Error()
 	}
-	return &Error{Code: code, Message: current.safeMessage(message)}
+	return &runtimeapi.CodedError{Code: code, Message: current.safeMessage(message)}
 }
 
 type redactingLineWriter struct {

--- a/runtimes/reference/internal/runtimeapi/types.go
+++ b/runtimes/reference/internal/runtimeapi/types.go
@@ -91,6 +91,18 @@ type CompletionResponse struct {
 	RequestID  string
 }
 
+type CodedError struct {
+	Code    string
+	Message string
+}
+
+func (err *CodedError) Error() string {
+	if err.Code == "" {
+		return err.Message
+	}
+	return fmt.Sprintf("%s: %s", err.Code, err.Message)
+}
+
 type ProviderError struct {
 	Code       string
 	Message    string

--- a/runtimes/reference/internal/tools/knowledge.go
+++ b/runtimes/reference/internal/tools/knowledge.go
@@ -48,23 +48,23 @@ func (tool *knowledgeTool) Definition() runtimeapi.ToolDefinition {
 func (tool *knowledgeTool) Execute(
 	ctx context.Context,
 	rawArguments []byte,
-) (outcome, error) {
+) (runtimeapi.ToolResult, error) {
 	if err := ctx.Err(); err != nil {
-		return outcome{}, err
+		return runtimeapi.ToolResult{}, err
 	}
 	var arguments readKnowledgeArguments
 	if err := decodeArguments(rawArguments, &arguments); err != nil {
-		return outcome{}, err
+		return runtimeapi.ToolResult{}, err
 	}
 	requested := strings.TrimSpace(arguments.Path)
 	if requested == "" {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "invalid_tool_arguments",
 			Message: "path must be a non-empty file path",
 		}
 	}
 	if filepath.IsAbs(requested) {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_path_denied",
 			Message: "path must be relative to /kontext/knowledge",
 		}
@@ -72,7 +72,7 @@ func (tool *knowledgeTool) Execute(
 	cleaned := filepath.Clean(requested)
 	if cleaned == "." || cleaned == ".." ||
 		strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_path_denied",
 			Message: "path must remain inside /kontext/knowledge",
 		}
@@ -80,7 +80,7 @@ func (tool *knowledgeTool) Execute(
 
 	resolvedRoot, err := filepath.EvalSymlinks(tool.root)
 	if err != nil {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_unavailable",
 			Message: fmt.Sprintf("knowledge directory is unavailable: %v", err),
 		}
@@ -88,12 +88,12 @@ func (tool *knowledgeTool) Execute(
 	resolvedPath, err := filepath.EvalSymlinks(filepath.Join(resolvedRoot, cleaned))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return outcome{}, &Error{
+			return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 				Code:    "knowledge_not_found",
 				Message: fmt.Sprintf("knowledge file %q does not exist", requested),
 			}
 		}
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_read_failed",
 			Message: fmt.Sprintf("resolve knowledge file: %v", err),
 		}
@@ -101,7 +101,7 @@ func (tool *knowledgeTool) Execute(
 	relative, err := filepath.Rel(resolvedRoot, resolvedPath)
 	if err != nil || relative == ".." ||
 		strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_path_denied",
 			Message: "resolved path leaves /kontext/knowledge",
 		}
@@ -109,7 +109,7 @@ func (tool *knowledgeTool) Execute(
 
 	file, err := os.Open(resolvedPath)
 	if err != nil {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_read_failed",
 			Message: fmt.Sprintf("open knowledge file: %v", err),
 		}
@@ -117,13 +117,13 @@ func (tool *knowledgeTool) Execute(
 	defer file.Close()
 	info, err := file.Stat()
 	if err != nil {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_read_failed",
 			Message: fmt.Sprintf("inspect knowledge file: %v", err),
 		}
 	}
 	if !info.Mode().IsRegular() {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_path_denied",
 			Message: "path must identify a regular file",
 		}
@@ -131,14 +131,14 @@ func (tool *knowledgeTool) Execute(
 
 	data, err := io.ReadAll(io.LimitReader(file, tool.maxBytes+utf8.UTFMax))
 	if err != nil {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_read_failed",
 			Message: fmt.Sprintf("read knowledge file: %v", err),
 		}
 	}
 	oversized := int64(len(data)) > tool.maxBytes
 	if !oversized && !utf8.Valid(data) {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "knowledge_invalid_encoding",
 			Message: "knowledge file must contain UTF-8 text",
 		}
@@ -150,14 +150,14 @@ func (tool *knowledgeTool) Execute(
 			minimum = 0
 		}
 		if int64(len(prefix)) < minimum {
-			return outcome{}, &Error{
+			return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 				Code:    "knowledge_invalid_encoding",
 				Message: "knowledge file must contain UTF-8 text",
 			}
 		}
 	}
 	content, truncated := tooloutput.Bound(string(data), tool.maxBytes)
-	return outcome{
+	return runtimeapi.ToolResult{
 		Content:   content,
 		Truncated: truncated,
 	}, nil
@@ -167,14 +167,14 @@ func decodeArguments(raw []byte, destination any) error {
 	decoder := json.NewDecoder(strings.NewReader(string(raw)))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(destination); err != nil {
-		return &Error{
+		return &runtimeapi.CodedError{
 			Code:    "invalid_tool_arguments",
 			Message: fmt.Sprintf("invalid tool arguments: %v", err),
 		}
 	}
 	var trailing any
 	if err := decoder.Decode(&trailing); err != io.EOF {
-		return &Error{
+		return &runtimeapi.CodedError{
 			Code:    "invalid_tool_arguments",
 			Message: "tool arguments contain trailing data",
 		}

--- a/runtimes/reference/internal/tools/kubernetes.go
+++ b/runtimes/reference/internal/tools/kubernetes.go
@@ -139,15 +139,15 @@ func kubernetesReadInputSchema() json.RawMessage {
 func (tool *kubernetesTool) Execute(
 	ctx context.Context,
 	rawArguments []byte,
-) (outcome, error) {
+) (runtimeapi.ToolResult, error) {
 	var arguments kubernetesReadArguments
 	if err := decodeArguments(rawArguments, &arguments); err != nil {
-		return outcome{}, err
+		return runtimeapi.ToolResult{}, err
 	}
 	resourceName := strings.ToLower(strings.TrimSpace(arguments.Resource))
 	resource, allowed := kubernetesResources[resourceName]
 	if !allowed {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "kubernetes_resource_denied",
 			Message: fmt.Sprintf("Kubernetes resource %q is not allowlisted", arguments.Resource),
 		}
@@ -157,13 +157,13 @@ func (tool *kubernetesTool) Execute(
 	case "get":
 		name := strings.TrimSpace(arguments.Name)
 		if name == "" {
-			return outcome{}, &Error{
+			return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 				Code:    "invalid_tool_arguments",
 				Message: "name is required for Kubernetes get",
 			}
 		}
 		if len(name) > 253 || !kubernetesNamePattern.MatchString(name) {
-			return outcome{}, &Error{
+			return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 				Code:    "invalid_tool_arguments",
 				Message: "name must be a valid Kubernetes DNS subdomain",
 			}
@@ -171,13 +171,13 @@ func (tool *kubernetesTool) Execute(
 		arguments.Name = name
 	case "list":
 		if strings.TrimSpace(arguments.Name) != "" {
-			return outcome{}, &Error{
+			return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 				Code:    "invalid_tool_arguments",
 				Message: "name must be omitted for Kubernetes list",
 			}
 		}
 	default:
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "kubernetes_operation_denied",
 			Message: "operation must be get or list",
 		}
@@ -185,7 +185,7 @@ func (tool *kubernetesTool) Execute(
 
 	config, err := tool.resolveConfig()
 	if err != nil {
-		return outcome{}, err
+		return runtimeapi.ToolResult{}, err
 	}
 	requestPath := path.Join(
 		resource.apiPrefix,
@@ -199,7 +199,7 @@ func (tool *kubernetesTool) Execute(
 	endpoint := strings.TrimRight(config.BaseURL, "/") + requestPath
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "kubernetes_request_failed",
 			Message: fmt.Sprintf("create Kubernetes request: %v", err),
 		}
@@ -215,9 +215,9 @@ func (tool *kubernetesTool) Execute(
 	response, err := config.Client.Do(request)
 	if err != nil {
 		if ctx.Err() != nil {
-			return outcome{}, ctx.Err()
+			return runtimeapi.ToolResult{}, ctx.Err()
 		}
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "kubernetes_request_failed",
 			Message: fmt.Sprintf("Kubernetes API request failed: %v", err),
 		}
@@ -225,7 +225,7 @@ func (tool *kubernetesTool) Execute(
 	defer response.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(response.Body, tool.maxBytes+1))
 	if err != nil {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "kubernetes_response_failed",
 			Message: fmt.Sprintf("read Kubernetes API response: %v", err),
 		}
@@ -246,7 +246,7 @@ func (tool *kubernetesTool) Execute(
 		if message == "" {
 			message = fmt.Sprintf("Kubernetes API returned HTTP %d", response.StatusCode)
 		}
-		return outcome{
+		return runtimeapi.ToolResult{
 			Content:   message,
 			IsError:   true,
 			ErrorCode: code,
@@ -254,12 +254,12 @@ func (tool *kubernetesTool) Execute(
 		}, nil
 	}
 	if !truncated && !json.Valid(body) {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "kubernetes_invalid_response",
 			Message: "Kubernetes API returned invalid JSON",
 		}
 	}
-	return outcome{
+	return runtimeapi.ToolResult{
 		Content:   string(body),
 		Truncated: truncated,
 	}, nil
@@ -283,7 +283,7 @@ func resolveKubernetesConfig(config KubernetesConfig) (KubernetesConfig, error) 
 	if config.Namespace == "" {
 		namespace, err := os.ReadFile(serviceAccountNSPath)
 		if err != nil {
-			return KubernetesConfig{}, &Error{
+			return KubernetesConfig{}, &runtimeapi.CodedError{
 				Code:    "kubernetes_unavailable",
 				Message: fmt.Sprintf("read current namespace: %v", err),
 			}
@@ -293,7 +293,7 @@ func resolveKubernetesConfig(config KubernetesConfig) (KubernetesConfig, error) 
 	if config.Token == "" {
 		token, err := os.ReadFile(serviceAccountTokenPath)
 		if err != nil {
-			return KubernetesConfig{}, &Error{
+			return KubernetesConfig{}, &runtimeapi.CodedError{
 				Code:    "kubernetes_unavailable",
 				Message: fmt.Sprintf("read service-account token: %v", err),
 			}
@@ -307,7 +307,7 @@ func resolveKubernetesConfig(config KubernetesConfig) (KubernetesConfig, error) 
 			port = strings.TrimSpace(os.Getenv("KUBERNETES_SERVICE_PORT"))
 		}
 		if host == "" || port == "" {
-			return KubernetesConfig{}, &Error{
+			return KubernetesConfig{}, &runtimeapi.CodedError{
 				Code:    "kubernetes_unavailable",
 				Message: "Kubernetes service host and port are unavailable",
 			}
@@ -322,7 +322,7 @@ func resolveKubernetesConfig(config KubernetesConfig) (KubernetesConfig, error) 
 		}
 	}
 	if config.Namespace == "" || config.Token == "" {
-		return KubernetesConfig{}, &Error{
+		return KubernetesConfig{}, &runtimeapi.CodedError{
 			Code:    "kubernetes_unavailable",
 			Message: "Kubernetes namespace and service-account token are required",
 		}
@@ -333,14 +333,14 @@ func resolveKubernetesConfig(config KubernetesConfig) (KubernetesConfig, error) 
 func newKubernetesClient() (*http.Client, error) {
 	certificate, err := os.ReadFile(serviceAccountCAPath)
 	if err != nil {
-		return nil, &Error{
+		return nil, &runtimeapi.CodedError{
 			Code:    "kubernetes_unavailable",
 			Message: fmt.Sprintf("read Kubernetes CA certificate: %v", err),
 		}
 	}
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(certificate) {
-		return nil, &Error{
+		return nil, &runtimeapi.CodedError{
 			Code:    "kubernetes_unavailable",
 			Message: "Kubernetes CA certificate is invalid",
 		}

--- a/runtimes/reference/internal/tools/shell.go
+++ b/runtimes/reference/internal/tools/shell.go
@@ -70,40 +70,40 @@ func (tool *shellTool) Definition() runtimeapi.ToolDefinition {
 func (tool *shellTool) Execute(
 	ctx context.Context,
 	rawArguments []byte,
-) (outcome, error) {
+) (runtimeapi.ToolResult, error) {
 	var arguments shellArguments
 	if err := decodeArguments(rawArguments, &arguments); err != nil {
-		return outcome{}, err
+		return runtimeapi.ToolResult{}, err
 	}
 	if strings.TrimSpace(arguments.Command) == "" ||
 		strings.ContainsRune(arguments.Command, '\x00') {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "invalid_tool_arguments",
 			Message: "command must be a non-empty string without NUL bytes",
 		}
 	}
 	if !filepath.IsAbs(arguments.WorkingDirectory) {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "invalid_tool_arguments",
 			Message: "working_directory must be absolute",
 		}
 	}
 	info, err := os.Stat(arguments.WorkingDirectory)
 	if err != nil {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "shell_working_directory_invalid",
 			Message: fmt.Sprintf("inspect working directory: %v", err),
 		}
 	}
 	if !info.IsDir() {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "shell_working_directory_invalid",
 			Message: "working_directory must identify a directory",
 		}
 	}
 	environment, err := filteredEnvironment(arguments.Environment)
 	if err != nil {
-		return outcome{}, err
+		return runtimeapi.ToolResult{}, err
 	}
 
 	captureBudget := &captureBudget{remaining: tool.maxBytes}
@@ -120,7 +120,7 @@ func (tool *shellTool) Execute(
 	command.Stderr = io.MultiWriter(stderrStream, stderrCapture)
 	procgroup.Prepare(command)
 	if err := command.Start(); err != nil {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "shell_start_failed",
 			Message: fmt.Sprintf("start shell command: %v", err),
 		}
@@ -140,7 +140,7 @@ func (tool *shellTool) Execute(
 			done,
 			shellTerminationGrace,
 		)
-		return outcome{}, ctx.Err()
+		return runtimeapi.ToolResult{}, ctx.Err()
 	}
 	_ = procgroup.Kill(command.Process.Pid)
 
@@ -148,7 +148,7 @@ func (tool *shellTool) Execute(
 	if waitErr != nil {
 		var exitError *exec.ExitError
 		if !errors.As(waitErr, &exitError) {
-			return outcome{}, &Error{
+			return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 				Code:    "shell_wait_failed",
 				Message: fmt.Sprintf("wait for shell command: %v", waitErr),
 			}
@@ -161,12 +161,12 @@ func (tool *shellTool) Execute(
 		Stderr:   stderrCapture.String(),
 	})
 	if err != nil {
-		return outcome{}, &Error{
+		return runtimeapi.ToolResult{}, &runtimeapi.CodedError{
 			Code:    "shell_output_failed",
 			Message: fmt.Sprintf("encode shell output: %v", err),
 		}
 	}
-	result := outcome{
+	result := runtimeapi.ToolResult{
 		Content:   string(encoded),
 		Truncated: stdoutCapture.Truncated() || stderrCapture.Truncated(),
 	}
@@ -186,19 +186,19 @@ func filteredEnvironment(requested map[string]string) ([]string, error) {
 	}
 	for name, value := range requested {
 		if !environmentNamePattern.MatchString(name) {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code:    "shell_environment_denied",
 				Message: fmt.Sprintf("environment variable name %q is invalid", name),
 			}
 		}
 		if sensitiveEnvironmentName(name) {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code:    "shell_environment_denied",
 				Message: fmt.Sprintf("environment variable %q is reserved or sensitive", name),
 			}
 		}
 		if strings.ContainsRune(value, '\x00') {
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code:    "shell_environment_denied",
 				Message: fmt.Sprintf("environment variable %q contains a NUL byte", name),
 			}

--- a/runtimes/reference/internal/tools/tools.go
+++ b/runtimes/reference/internal/tools/tools.go
@@ -43,26 +43,7 @@ type Registry struct {
 
 type implementation interface {
 	Definition() runtimeapi.ToolDefinition
-	Execute(context.Context, []byte) (outcome, error)
-}
-
-type outcome struct {
-	Content   string
-	IsError   bool
-	ErrorCode string
-	Truncated bool
-}
-
-type Error struct {
-	Code    string
-	Message string
-}
-
-func (err *Error) Error() string {
-	if err.Code == "" {
-		return err.Message
-	}
-	return fmt.Sprintf("%s: %s", err.Code, err.Message)
+	Execute(context.Context, []byte) (runtimeapi.ToolResult, error)
 }
 
 func NewWithContext(ctx context.Context, toolConfig Config) (*Registry, error) {
@@ -71,7 +52,7 @@ func NewWithContext(ctx context.Context, toolConfig Config) (*Registry, error) {
 		config.MaxCapturedBytes = maxSafeCapturedBytes
 	}
 	if config.MaxCapturedBytes > maxSafeCapturedBytes {
-		return nil, &Error{
+		return nil, &runtimeapi.CodedError{
 			Code: "invalid_tool_configuration",
 			Message: fmt.Sprintf(
 				"captured tool output cannot exceed %d bytes",
@@ -88,16 +69,13 @@ func NewWithContext(ctx context.Context, toolConfig Config) (*Registry, error) {
 
 	mcpManager, err := mcpclient.New(ctx, config.MCP, config.Stderr)
 	if err != nil {
-		code := "invalid_tool_configuration"
-		message := err.Error()
-		var mcpError *mcpclient.Error
-		if errors.As(err, &mcpError) && mcpError.Code != "" {
-			code = mcpError.Code
-			message = mcpError.Message
+		var codedError *runtimeapi.CodedError
+		if errors.As(err, &codedError) && codedError.Code != "" {
+			return nil, codedError
 		}
-		return nil, &Error{
-			Code:    code,
-			Message: message,
+		return nil, &runtimeapi.CodedError{
+			Code:    "invalid_tool_configuration",
+			Message: err.Error(),
 		}
 	}
 	implementations := map[string]implementation{
@@ -115,7 +93,7 @@ func NewWithContext(ctx context.Context, toolConfig Config) (*Registry, error) {
 	for _, definition := range mcpManager.Definitions() {
 		if _, collision := implementations[definition.Name]; collision {
 			closeMCPManagerAfterStartupFailure(mcpManager)
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code:    "tool_name_collision",
 				Message: fmt.Sprintf("MCP tool %q collides with another available tool", definition.Name),
 			}
@@ -138,7 +116,7 @@ func NewWithContext(ctx context.Context, toolConfig Config) (*Registry, error) {
 		selected, exists := implementations[name]
 		if !exists {
 			closeMCPManagerAfterStartupFailure(mcpManager)
-			return nil, &Error{
+			return nil, &runtimeapi.CodedError{
 				Code:    "unknown_tool",
 				Message: fmt.Sprintf("configured tool %q is not available in the reference runtime", name),
 			}
@@ -170,14 +148,8 @@ func (tool *mcpImplementation) Definition() runtimeapi.ToolDefinition {
 func (tool *mcpImplementation) Execute(
 	ctx context.Context,
 	arguments []byte,
-) (outcome, error) {
-	result, err := tool.manager.Execute(ctx, tool.definition.Name, arguments)
-	return outcome{
-		Content:   result.Content,
-		IsError:   result.IsError,
-		ErrorCode: result.ErrorCode,
-		Truncated: result.Truncated,
-	}, err
+) (runtimeapi.ToolResult, error) {
+	return tool.manager.Execute(ctx, tool.definition.Name, arguments)
 }
 
 func (registry *Registry) Close(ctx context.Context) error {
@@ -220,12 +192,12 @@ func (registry *Registry) Execute(
 		}
 		return result, nil
 	}
-	toolOutcome, err := selected.Execute(ctx, call.Arguments)
+	toolResult, err := selected.Execute(ctx, call.Arguments)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return runtimeapi.ToolResult{}, err
 		}
-		var toolError *Error
+		var toolError *runtimeapi.CodedError
 		if errors.As(err, &toolError) {
 			result.IsError = true
 			result.ErrorCode = toolError.Code
@@ -237,9 +209,7 @@ func (registry *Registry) Execute(
 		result.Content = err.Error()
 		return result, nil
 	}
-	result.Content = toolOutcome.Content
-	result.IsError = toolOutcome.IsError
-	result.ErrorCode = toolOutcome.ErrorCode
-	result.Truncated = toolOutcome.Truncated
-	return result, nil
+	toolResult.CallID = call.ID
+	toolResult.Name = call.Name
+	return toolResult, nil
 }

--- a/runtimes/reference/internal/tools/tools_test.go
+++ b/runtimes/reference/internal/tools/tools_test.go
@@ -34,7 +34,7 @@ func TestRegistryRejectsUnknownConfiguredTool(t *testing.T) {
 		context.Background(),
 		tools.Config{Allowed: []string{"not-built-in"}},
 	)
-	var toolError *tools.Error
+	var toolError *runtimeapi.CodedError
 	if !errors.As(err, &toolError) || toolError.Code != "unknown_tool" {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -149,7 +149,7 @@ func TestRegistryRejectsMCPBuiltInNameCollision(t *testing.T) {
 			Name: "remote", Transport: "http", Endpoint: httpServer.URL,
 		}}},
 	})
-	var toolError *tools.Error
+	var toolError *runtimeapi.CodedError
 	if !errors.As(err, &toolError) || toolError.Code != "tool_name_collision" {
 		t.Fatalf("unexpected collision error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add a shared `runtimeapi.CodedError` for MCP, tools, and engine error propagation
- return `runtimeapi.ToolResult` directly across MCP and built-in tool boundaries
- remove redundant field-by-field result copies while preserving call identity and error behavior

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./runtimes/reference/...`
- [ ] `go test ./...` (local envtest cannot start because `/usr/local/kubebuilder/bin/etcd` is unavailable; all other packages passed)