### PR TITLE
Consolidate kind CI setup behind composite actions

### DIFF
--- a/.github/actions/build-core-images/action.yml
+++ b/.github/actions/build-core-images/action.yml
@@ -1,0 +1,73 @@
+name: Build core images
+description: Build the local images used by Kontext kind jobs
+
+inputs:
+  image-set:
+    description: Image set to build (full or network-policy)
+    required: true
+  cache-scope:
+    description: Prefix prepended to each image's GitHub Actions cache scope
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Validate image set
+      shell: bash
+      env:
+        IMAGE_SET: ${{ inputs.image-set }}
+      run: |
+        case "${IMAGE_SET}" in
+          full|network-policy) ;;
+          *)
+            echo "unsupported image set: ${IMAGE_SET}" >&2
+            exit 1
+            ;;
+        esac
+
+    - name: Build operator image
+      uses: ./.github/actions/build-image
+      with:
+        context: .
+        tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
+        cache-scope: ${{ inputs.cache-scope }}operator
+        load: "true"
+
+    - name: Build echo runtime image
+      if: inputs.image-set == 'full'
+      uses: ./.github/actions/build-image
+      with:
+        context: runtimes/echo
+        dockerfile: runtimes/echo/Dockerfile
+        tags: ${{ env.KONTEXT_ECHO_IMAGE }}
+        cache-scope: ${{ inputs.cache-scope }}echo
+        load: "true"
+
+    - name: Build reusable reporter image
+      uses: ./.github/actions/build-image
+      with:
+        context: .
+        dockerfile: runtimes/reporter/Dockerfile
+        tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
+        cache-scope: ${{ inputs.cache-scope }}reporter
+        load: "true"
+
+    - name: Build model-agnostic reference runtime image
+      uses: ./.github/actions/build-image
+      with:
+        context: .
+        dockerfile: runtimes/reference/Dockerfile
+        tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
+        cache-scope: ${{ inputs.cache-scope }}reference
+        load: "true"
+
+    - name: Build stdout-capture fixture image
+      if: inputs.image-set == 'full'
+      uses: ./.github/actions/build-image
+      with:
+        context: runtimes/stdout-fixture
+        dockerfile: runtimes/stdout-fixture/Dockerfile
+        tags: ${{ env.KONTEXT_STDOUT_FIXTURE_IMAGE }}
+        cache-scope: ${{ inputs.cache-scope }}stdout-fixture
+        load: "true"

--- a/.github/actions/kind-diagnostics/action.yml
+++ b/.github/actions/kind-diagnostics/action.yml
@@ -1,0 +1,52 @@
+name: Preserve kind diagnostics
+description: Collect and upload diagnostics from a failed kind job
+
+inputs:
+  diagnostics-dir:
+    description: Directory containing the diagnostics artifact
+    required: true
+  artifact-name:
+    description: Name of the uploaded diagnostics artifact
+    required: true
+  collect:
+    description: Collect standard diagnostics before uploading
+    required: false
+    default: "true"
+  redact-workloads:
+    description: Remove workload details that may contain provider data
+    required: false
+    default: "false"
+  retention-days:
+    description: Number of days to retain the artifact (0 uses the repository default)
+    required: false
+    default: "0"
+
+runs:
+  using: composite
+  steps:
+    - name: Collect kind diagnostics
+      if: ${{ always() && inputs.collect == 'true' }}
+      shell: bash
+      env:
+        DIAGNOSTICS_DIR: ${{ inputs.diagnostics-dir }}
+      run: ./scripts/collect-kind-diagnostics.sh "${DIAGNOSTICS_DIR}"
+
+    - name: Redact workload diagnostics
+      if: ${{ always() && inputs.redact-workloads == 'true' }}
+      shell: bash
+      env:
+        DIAGNOSTICS_DIR: ${{ inputs.diagnostics-dir }}
+      run: |
+        rm -f \
+          "${DIAGNOSTICS_DIR}/agent-workloads.txt" \
+          "${DIAGNOSTICS_DIR}/kontext-resources.txt" \
+          "${DIAGNOSTICS_DIR}/workload-overview.txt"
+
+    - name: Upload kind diagnostics
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.diagnostics-dir }}
+        if-no-files-found: ignore
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -176,49 +175,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build operator image
-        uses: ./.github/actions/build-image
+      - name: Build kind images
+        uses: ./.github/actions/build-core-images
         with:
-          context: .
-          tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
-          cache-scope: operator
-          load: "true"
-
-      - name: Build echo runtime image
-        uses: ./.github/actions/build-image
-        with:
-          context: runtimes/echo
-          dockerfile: runtimes/echo/Dockerfile
-          tags: ${{ env.KONTEXT_ECHO_IMAGE }}
-          cache-scope: echo
-          load: "true"
-
-      - name: Build reusable reporter image
-        uses: ./.github/actions/build-image
-        with:
-          context: .
-          dockerfile: runtimes/reporter/Dockerfile
-          tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
-          cache-scope: reporter
-          load: "true"
-
-      - name: Build model-agnostic reference runtime image
-        uses: ./.github/actions/build-image
-        with:
-          context: .
-          dockerfile: runtimes/reference/Dockerfile
-          tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
-          cache-scope: reference
-          load: "true"
-
-      - name: Build stdout-capture fixture image
-        uses: ./.github/actions/build-image
-        with:
-          context: runtimes/stdout-fixture
-          dockerfile: runtimes/stdout-fixture/Dockerfile
-          tags: ${{ env.KONTEXT_STDOUT_FIXTURE_IMAGE }}
-          cache-scope: stdout-fixture
-          load: "true"
+          image-set: full
+          cache-scope: ""
 
       - name: Create kind cluster
         uses: helm/kind-action@v1
@@ -245,17 +206,12 @@ jobs:
           include-hidden-files: true
           retention-days: 5
 
-      - name: Collect diagnostics on failure
+      - name: Preserve diagnostics
         if: failure()
-        run: ./scripts/collect-kind-diagnostics.sh "${KONTEXT_DIAG_DIR}"
-
-      - name: Upload diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/kind-diagnostics
         with:
-          name: kind-diagnostics-${{ github.run_id }}
-          path: ${{ env.KONTEXT_DIAG_DIR }}
-          if-no-files-found: ignore
+          diagnostics-dir: ${{ env.KONTEXT_DIAG_DIR }}
+          artifact-name: kind-diagnostics-${{ github.run_id }}
 
       - name: Delete kind cluster
         if: always()
@@ -282,42 +238,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build operator image
-        uses: ./.github/actions/build-image
+      - name: Build NetworkPolicy images
+        uses: ./.github/actions/build-core-images
         with:
-          context: .
-          tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
-          cache-scope: network-policy-operator
-          load: "true"
-
-      - name: Build reusable reporter image
-        uses: ./.github/actions/build-image
-        with:
-          context: .
-          dockerfile: runtimes/reporter/Dockerfile
-          tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
-          cache-scope: network-policy-reporter
-          load: "true"
-
-      - name: Build model-agnostic reference runtime image
-        uses: ./.github/actions/build-image
-        with:
-          context: .
-          dockerfile: runtimes/reference/Dockerfile
-          tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
-          cache-scope: network-policy-reference
-          load: "true"
+          image-set: network-policy
+          cache-scope: network-policy-
 
       - name: Run Calico NetworkPolicy acceptance
         run: ./scripts/e2e-kind-network-policy.sh
 
-      - name: Upload diagnostics
+      - name: Preserve diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/kind-diagnostics
         with:
-          name: network-policy-diagnostics-${{ github.run_id }}
-          path: ${{ env.KONTEXT_DIAG_DIR }}
-          if-no-files-found: ignore
+          diagnostics-dir: ${{ env.KONTEXT_DIAG_DIR }}
+          artifact-name: network-policy-diagnostics-${{ github.run_id }}
+          collect: "false"
 
       - name: Delete kind cluster
         if: always()

--- a/.github/workflows/provider-acceptance.yml
+++ b/.github/workflows/provider-acceptance.yml
@@ -41,6 +41,7 @@ jobs:
       KIND_CLUSTER_NAME: provider-acceptance
       KONTEXT_ACCEPTANCE_NAMESPACE: provider-acceptance
       KONTEXT_ACCEPTANCE_SCENARIO: ${{ inputs.scenario }}
+      # The NetworkPolicy e2e job exercises this focused install path without provider credentials.
       KONTEXT_KIND_IMAGE_SET: network-policy
       KONTEXT_OPERATOR_IMAGE: kontext-operator:dev
       KONTEXT_REPORTER_IMAGE: kontext-reporter:dev

--- a/.github/workflows/provider-acceptance.yml
+++ b/.github/workflows/provider-acceptance.yml
@@ -41,6 +41,7 @@ jobs:
       KIND_CLUSTER_NAME: provider-acceptance
       KONTEXT_ACCEPTANCE_NAMESPACE: provider-acceptance
       KONTEXT_ACCEPTANCE_SCENARIO: ${{ inputs.scenario }}
+      KONTEXT_KIND_IMAGE_SET: network-policy
       KONTEXT_OPERATOR_IMAGE: kontext-operator:dev
       KONTEXT_REPORTER_IMAGE: kontext-reporter:dev
       KONTEXT_REFERENCE_IMAGE: kontext-reference:dev
@@ -71,31 +72,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build maintained operator image
-        uses: ./.github/actions/build-image
+      - name: Build maintained images
+        uses: ./.github/actions/build-core-images
         with:
-          context: .
-          tags: ${{ env.KONTEXT_OPERATOR_IMAGE }}
-          cache-scope: provider-acceptance-operator
-          load: "true"
-
-      - name: Build reusable reporter image
-        uses: ./.github/actions/build-image
-        with:
-          context: .
-          dockerfile: runtimes/reporter/Dockerfile
-          tags: ${{ env.KONTEXT_REPORTER_IMAGE }}
-          cache-scope: provider-acceptance-reporter
-          load: "true"
-
-      - name: Build maintained reference runtime image
-        uses: ./.github/actions/build-image
-        with:
-          context: .
-          dockerfile: runtimes/reference/Dockerfile
-          tags: ${{ env.KONTEXT_REFERENCE_IMAGE }}
-          cache-scope: provider-acceptance-reference
-          load: "true"
+          image-set: network-policy
+          cache-scope: provider-acceptance-
 
       - name: Create ephemeral kind cluster
         uses: helm/kind-action@v1
@@ -103,18 +84,8 @@ jobs:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s
 
-      - name: Load maintained images
-        run: |
-          kind load docker-image "${KONTEXT_OPERATOR_IMAGE}" --name "${KIND_CLUSTER_NAME}"
-          kind load docker-image "${KONTEXT_REPORTER_IMAGE}" --name "${KIND_CLUSTER_NAME}"
-          kind load docker-image "${KONTEXT_REFERENCE_IMAGE}" --name "${KIND_CLUSTER_NAME}"
-
-      - name: Install maintained operator
-        run: |
-          kubectl apply -k config/overlays/dev
-          kubectl rollout status deployment/controller-manager \
-            --namespace kontext-system \
-            --timeout=120s
+      - name: Install Kontext with maintained images
+        run: ./scripts/install-go-kind.sh
 
       - name: Run Anthropic acceptance
         if: inputs.provider == 'anthropic'
@@ -137,22 +108,13 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
-      - name: Collect redacted failure diagnostics
+      - name: Preserve redacted failure diagnostics
         if: failure()
-        run: |
-          ./scripts/collect-kind-diagnostics.sh "${RUNNER_TEMP}/provider-diagnostics"
-          rm -f \
-            "${RUNNER_TEMP}/provider-diagnostics/agent-workloads.txt" \
-            "${RUNNER_TEMP}/provider-diagnostics/kontext-resources.txt" \
-            "${RUNNER_TEMP}/provider-diagnostics/workload-overview.txt"
-
-      - name: Upload failure diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/kind-diagnostics
         with:
-          name: provider-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/provider-diagnostics
-          if-no-files-found: ignore
+          diagnostics-dir: ${{ runner.temp }}/provider-diagnostics
+          artifact-name: provider-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          redact-workloads: "true"
           retention-days: 3
 
       - name: Delete kind cluster

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,17 +379,12 @@ jobs:
           fi
           ./scripts/verify-release-install.sh "${args[@]}"
 
-      - name: Collect diagnostics on failure
+      - name: Preserve diagnostics
         if: failure()
-        run: ./scripts/collect-kind-diagnostics.sh "${KONTEXT_DIAG_DIR}"
-
-      - name: Upload diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/kind-diagnostics
         with:
-          name: release-install-diagnostics-${{ github.run_id }}
-          path: ${{ env.KONTEXT_DIAG_DIR }}
-          if-no-files-found: ignore
+          diagnostics-dir: ${{ env.KONTEXT_DIAG_DIR }}
+          artifact-name: release-install-diagnostics-${{ github.run_id }}
 
       - name: Delete kind cluster
         if: always()


### PR DESCRIPTION
## Summary
- centralize the full and focused kind image sets while preserving every existing Buildx cache scope
- collect and upload kind diagnostics through one composite action; cluster creation and deletion stay inline because composite actions have no post hook and the NetworkPolicy script owns its custom CNI lifecycle
- route provider acceptance installation through `scripts/install-go-kind.sh` and remove the unused workflow-level `actions: write` permission

## Test plan
- [x] `make verify`
- [x] parse the changed workflow and composite-action YAML files locally
- [x] pass all pull-request CI jobs on the latest head
- [x] exercise `install-go-kind.sh` with `KONTEXT_KIND_IMAGE_SET=network-policy` in the passing NetworkPolicy e2e job, covering the same focused image-loading and dynamic-overlay path used by provider acceptance
- [x] inspect the credentialed provider scenario separately; it was not dispatched because it requires protected provider credentials and a real model selection