### PR TITLE
Define Task mode API and strict resolver contract

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -92,9 +92,9 @@ One bounded execution. Maps to exactly one Pod. **Spec is immutable after creati
 
 | Field                | Type     | Req | Notes                                            |
 | -------------------- | -------- | --- | ------------------------------------------------ |
-| `agentRef.name`      | string   | no  | Owning `Agent`. A user-created reference to a Task Agent is an explicit execution trigger. Omitted = standalone ad-hoc run. |
+| `agentRef.name`      | string   | no  | Owning `Agent`. With Task CREATE admission installed, a user-created reference is an explicit execution trigger. Omitted = standalone ad-hoc run. |
 | `parameters`         | map[string]string | no | Immutable Task invocation parameters retained with the resolved snapshot. Requires `agentRef`. |
-| `goal`               | string   | yes* | Concrete, fully-resolved goal. Omitted only in a sparse Task invocation before CREATE admission. |
+| `goal`               | string   | yes | Concrete, fully-resolved goal.                   |
 | `provider`           | string   | no  | Resolved from Agent at creation.                 |
 | `model`              | string   | yes |                                                  |
 | `tools`              | []string | no  |                                                  |
@@ -103,7 +103,7 @@ One bounded execution. Maps to exactly one Pod. **Spec is immutable after creati
 | `knowledgeConfigMapRef.name` | string | no | Static ConfigMap context mounted read-only at `/kontext/knowledge`. |
 | `serviceAccountName` | string   | no  |                                                  |
 | `env`                | []EnvVar | no  | Resolved literal or Secret-backed env snapshot.  |
-| `runtime.image`      | string   | yes* | Resolved from Agent. Omitted only in a sparse Task invocation before CREATE admission. |
+| `runtime.image`      | string   | yes | Resolved from Agent.                             |
 | `runtime.command`    | []string | no  | Required when stdout capture is configured.      |
 | `runtime.args`       | []string | no  | Appended to the declared command.                |
 | `runtime.result`     | object   | no  | Optional stdout result capture policy.           |
@@ -117,20 +117,30 @@ to provide a complete execution spec directly.
 
 ### Task invocation and resolution
 
-Creating a Task `Agent` never starts work. A user explicitly triggers it by
-creating a user-named `AgentRun` whose `spec.agentRef.name` names that Task
-Agent. Runs may be created concurrently; there is no generated-name or
-single-active-run restriction.
+Creating a Task `Agent` never starts work. Once Task CREATE admission is
+installed, a user explicitly triggers it by submitting a user-named
+`AgentRun` whose `spec.agentRef.name` names that Task Agent. Runs may be
+submitted concurrently; there is no generated-name or single-active-run
+restriction.
 
-A Task invocation is sparse: before CREATE admission it may contain only
-`agentRef` and optional `parameters`. Future CREATE admission resolves it into
-the complete immutable execution snapshot stored by the API server. It copies
-runtime, provider, model, tools, budget, service account, Secret reference,
-knowledge ConfigMap reference, and environment from the Agent. The concrete
-goal is copied from `goal` or rendered from `goalTemplate`. These execution
-fields are locked: an invocation that supplies any of them is rejected, even
-when the supplied value would match the template. Users needing execution
-overrides create a standalone `AgentRun` or a separate Agent definition.
+A Task invocation request is sparse: it may contain only `agentRef` and
+optional `parameters`. Kubernetes
+[invokes mutating admission first](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
+and then validates the final object against the CRD. Future CREATE admission
+therefore receives the sparse request, resolves it in memory, and returns the
+complete immutable execution snapshot that the API server validates and
+stores. The persisted `AgentRun.spec` always includes `goal`, `model`, and
+`runtime.image`; an unresolved sparse object is never valid stored state.
+Without the Task webhook infrastructure and mutator from #83/#84, the API
+server rejects the sparse request as missing required fields.
+
+Resolution copies runtime, provider, model, tools, budget, service account,
+Secret reference, knowledge ConfigMap reference, and environment from the
+Agent. The concrete goal is copied from `goal` or rendered from
+`goalTemplate`. These execution fields are locked: an invocation request that
+supplies any of them is rejected, even when the supplied value would match the
+template. Users needing execution overrides create a standalone `AgentRun` or
+a separate Agent definition.
 
 A Task Agent configures exactly one of `goal` or `goalTemplate`. A static
 `goal` accepts no parameters. A template uses only ASCII identifier
@@ -153,7 +163,8 @@ built, once at this boundary.
 
 The pure resolver in `internal/runfactory` defines these semantics for future
 admission code. This version does not register a webhook, so sparse Task
-objects are schema-valid but are not yet resolved end to end.
+CREATE requests remain schema-invalid and cannot reach the AgentRun
+controller.
 
 ### `status`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -26,7 +26,7 @@ API group/version: `kontext.dev/v1alpha1` (alpha on purpose — the shape is all
 | Kontext                  | Core Kubernetes analogue | Behavior                                                                               |
 | ------------------------ | ------------------------ | -------------------------------------------------------------------------------------- |
 | `Agent` mode `Service`   | `Deployment`             | Always-on. Controller keeps one live `AgentRun`; re-casts on exit/failure.             |
-| `Agent` mode `Task`      | reusable template        | Reserved in the schema. The controller reports `UnsupportedMode`; create a standalone `AgentRun` for one-shot work. |
+| `Agent` mode `Task`      | reusable task template   | Creating the Agent does not execute it. A user creates a named, sparse `AgentRun` referencing it to trigger work. |
 | `Agent` mode `Scheduled` | `CronJob`                | Reserved in the schema. The controller reports `UnsupportedMode` and does not schedule runs. |
 | `AgentRun`               | `Pod` / `Job`            | The single execution unit. Owns one Pod. Holds `status.result`, usage, immutable spec. |
 
@@ -50,8 +50,8 @@ The reusable definition. Cluster-namespaced. Has a status subresource.
 | `runtime.args`       | []string                              | no  |                                                                |
 | `runtime.result`     | object                                | no  | Optional stdout result capture policy.                         |
 | `runtime.securityContext` | restricted security context     | no  | Portable non-root, capability-drop, filesystem, and seccomp settings. |
-| `goal`               | string                                | no* | Default/persistent goal. Required for `Service`/`Scheduled`.   |
-| `goalTemplate`       | string                                | no  | Parameterized goal for templated runs (`Task`).                |
+| `goal`               | string                                | no* | Concrete goal. Required for `Service`/`Scheduled`; exactly one of `goal` or `goalTemplate` is required for `Task`. |
+| `goalTemplate`       | string                                | no  | Parameterized goal for `Task`; forbidden in other modes.       |
 | `provider`           | string                                | no  | Default `anthropic`.                                           |
 | `model`              | string                                | yes |                                                                |
 | `tools`              | []string                              | no  | Declared tool allowlist (semantics live in the runtime image). |
@@ -76,7 +76,7 @@ The reusable definition. Cluster-namespaced. Has a status subresource.
 | `conditions`         | []Condition | `Ready`, `Progressing`.              |
 | `currentRunName`     | string      | `Service`: the live run.             |
 | `lastRunName`        | string      | `Task`/`Scheduled`: most recent run. |
-| `runsCreated`        | int         | Counter.                             |
+| `runsCreated`        | int         | Mode-specific observed run count.   |
 | `restarts`           | int         | `Service`: re-cast count.            |
 | `observedGeneration` | int         |                                      |
 
@@ -92,8 +92,9 @@ One bounded execution. Maps to exactly one Pod. **Spec is immutable after creati
 
 | Field                | Type     | Req | Notes                                            |
 | -------------------- | -------- | --- | ------------------------------------------------ |
-| `agentRef.name`      | string   | no  | Owning `Agent`. Omitted = standalone ad-hoc run. |
-| `goal`               | string   | yes | Concrete, fully-resolved goal.                   |
+| `agentRef.name`      | string   | no  | Owning `Agent`. A user-created reference to a Task Agent is an explicit execution trigger. Omitted = standalone ad-hoc run. |
+| `parameters`         | map[string]string | no | Immutable Task invocation parameters retained with the resolved snapshot. Requires `agentRef`. |
+| `goal`               | string   | yes* | Concrete, fully-resolved goal. Omitted only in a sparse Task invocation before CREATE admission. |
 | `provider`           | string   | no  | Resolved from Agent at creation.                 |
 | `model`              | string   | yes |                                                  |
 | `tools`              | []string | no  |                                                  |
@@ -102,14 +103,57 @@ One bounded execution. Maps to exactly one Pod. **Spec is immutable after creati
 | `knowledgeConfigMapRef.name` | string | no | Static ConfigMap context mounted read-only at `/kontext/knowledge`. |
 | `serviceAccountName` | string   | no  |                                                  |
 | `env`                | []EnvVar | no  | Resolved literal or Secret-backed env snapshot.  |
-| `runtime.image`      | string   | yes | Resolved from Agent.                             |
+| `runtime.image`      | string   | yes* | Resolved from Agent. Omitted only in a sparse Task invocation before CREATE admission. |
 | `runtime.command`    | []string | no  | Required when stdout capture is configured.      |
 | `runtime.args`       | []string | no  | Appended to the declared command.                |
 | `runtime.result`     | object   | no  | Optional stdout result capture policy.           |
 | `runtime.securityContext` | restricted security context | no | Portable non-root, capability-drop, filesystem, and seccomp settings. |
 
 
-When created from an `Agent`, the controller snapshots/resolves these fields so the run does not drift if the `Agent` changes later.
+When created from an `Agent`, execution fields are snapshotted so the run does
+not drift if the `Agent` changes later. Service and future Scheduled
+controllers continue to create fully resolved runs. Standalone runs continue
+to provide a complete execution spec directly.
+
+### Task invocation and resolution
+
+Creating a Task `Agent` never starts work. A user explicitly triggers it by
+creating a user-named `AgentRun` whose `spec.agentRef.name` names that Task
+Agent. Runs may be created concurrently; there is no generated-name or
+single-active-run restriction.
+
+A Task invocation is sparse: before CREATE admission it may contain only
+`agentRef` and optional `parameters`. Future CREATE admission resolves it into
+the complete immutable execution snapshot stored by the API server. It copies
+runtime, provider, model, tools, budget, service account, Secret reference,
+knowledge ConfigMap reference, and environment from the Agent. The concrete
+goal is copied from `goal` or rendered from `goalTemplate`. These execution
+fields are locked: an invocation that supplies any of them is rejected, even
+when the supplied value would match the template. Users needing execution
+overrides create a standalone `AgentRun` or a separate Agent definition.
+
+A Task Agent configures exactly one of `goal` or `goalTemplate`. A static
+`goal` accepts no parameters. A template uses only ASCII identifier
+placeholders matching `[A-Za-z_][A-Za-z0-9_]*`:
+
+- `${name}` inserts the exact string value of parameter `name`.
+- `$${name}` emits the literal text `${name}` and does not consume a parameter.
+- Substitution is one pass: parameter values are never interpreted as
+  templates.
+- Repeated placeholders reuse the same parameter. Empty, Unicode, and
+  multiline values are valid.
+- Malformed placeholders, missing parameters, and supplied-but-unused
+  parameters reject the invocation. Missing and unused names are reported in
+  sorted order.
+
+Resolution is all-or-nothing and does not mutate either input object. Copied
+maps, slices, pointers, and nested values are isolated from later mutation.
+Provider defaults and aliases are normalized while the execution snapshot is
+built, once at this boundary.
+
+The pure resolver in `internal/runfactory` defines these semantics for future
+admission code. This version does not register a webhook, so sparse Task
+objects are schema-valid but are not yet resolved end to end.
 
 ### `status`
 
@@ -136,7 +180,17 @@ provider did not measure it; a present zero means it measured zero.
 
 ### Ownership
 
-`AgentRun` created from an `Agent` carries an owner reference to it → standard GC cascade. Standalone `AgentRun`s are allowed for ad-hoc execution, demos, and direct task dispatch.
+`AgentRun` created from or resolved against an `Agent` carries an owner
+reference to it → standard GC cascade. Standalone `AgentRun`s are allowed for
+ad-hoc execution, demos, and direct task dispatch.
+
+For Task Agents, `status.lastRunName` is the newest retained owned Task run by
+creation time. `status.runsCreated` is the exact number of currently retained
+owned Task runs, not a lifetime counter. Deleting an owned run can therefore
+decrease `runsCreated` and can move or clear `lastRunName`. These Task meanings
+do not change the existing Service status semantics. Task status
+reconciliation is intentionally deferred; this section defines the contract
+it must implement.
 
 ### Contract evolution policy
 

--- a/api/v1alpha1/agent_types.go
+++ b/api/v1alpha1/agent_types.go
@@ -15,12 +15,17 @@ const (
 )
 
 // AgentSpec defines the desired state of Agent.
+// +kubebuilder:validation:XValidation:rule="self.mode == 'Task' ? has(self.goal) != has(self.goalTemplate) : has(self.goal) && !has(self.goalTemplate)",message="Task agents require exactly one of goal or goalTemplate; Service and Scheduled agents require goal and forbid goalTemplate"
+// +kubebuilder:validation:XValidation:rule="self.mode == 'Scheduled' || !has(self.schedule)",message="schedule is only valid for Scheduled agents"
+// +kubebuilder:validation:XValidation:rule="self.mode == 'Service' || !has(self.backoff)",message="backoff is only valid for Service agents"
 type AgentSpec struct {
 	Mode AgentMode `json:"mode"`
 
 	Runtime RuntimeSpec `json:"runtime"`
 
-	Goal         string `json:"goal,omitempty"`
+	// +kubebuilder:validation:MinLength=1
+	Goal string `json:"goal,omitempty"`
+	// +kubebuilder:validation:MinLength=1
 	GoalTemplate string `json:"goalTemplate,omitempty"`
 
 	Provider string `json:"provider,omitempty"`

--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -19,10 +19,13 @@ type AgentRef struct {
 	Name string `json:"name"`
 }
 
-// AgentRunSpec defines the desired state of AgentRun.
+// AgentRunSpec defines the desired state of AgentRun. Persisted specs are
+// always complete. A future CREATE mutating webhook may decode a sparse Task
+// request into this type, but it must resolve the required execution fields
+// before API-server schema validation and persistence.
 // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="AgentRun spec is immutable"
 // +kubebuilder:validation:XValidation:rule="has(self.agentRef) || !has(self.parameters)",message="parameters require agentRef"
-// +kubebuilder:validation:XValidation:rule="(has(self.goal) && has(self.model) && has(self.runtime)) || (has(self.agentRef) && !has(self.goal) && !has(self.provider) && !has(self.model) && !has(self.tools) && !has(self.budget) && !has(self.secretRef) && !has(self.knowledgeConfigMapRef) && !has(self.serviceAccountName) && !has(self.runtime) && !has(self.env))",message="AgentRun must be a complete execution spec or a sparse invocation containing only agentRef and parameters"
+// +kubebuilder:validation:XValidation:rule="has(self.goal) && has(self.model) && has(self.runtime)",message="persisted AgentRun spec must contain a complete execution snapshot"
 type AgentRunSpec struct {
 	AgentRef *AgentRef `json:"agentRef,omitempty"`
 
@@ -30,11 +33,11 @@ type AgentRunSpec struct {
 	Parameters map[string]string `json:"parameters,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
-	Goal string `json:"goal,omitempty"`
+	Goal string `json:"goal"`
 
 	Provider string `json:"provider,omitempty"`
 	// +kubebuilder:validation:MinLength=1
-	Model string   `json:"model,omitempty"`
+	Model string   `json:"model"`
 	Tools []string `json:"tools,omitempty"`
 
 	Budget *BudgetSpec `json:"budget,omitempty"`
@@ -45,7 +48,7 @@ type AgentRunSpec struct {
 
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	Runtime RuntimeSpec `json:"runtime,omitempty,omitzero"`
+	Runtime RuntimeSpec `json:"runtime"`
 
 	Env []EnvVar `json:"env,omitempty"`
 }

--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -15,20 +15,26 @@ const (
 
 // AgentRef links an AgentRun to its owning Agent.
 type AgentRef struct {
+	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 }
 
 // AgentRunSpec defines the desired state of AgentRun.
 // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="AgentRun spec is immutable"
+// +kubebuilder:validation:XValidation:rule="has(self.agentRef) || !has(self.parameters)",message="parameters require agentRef"
+// +kubebuilder:validation:XValidation:rule="(has(self.goal) && has(self.model) && has(self.runtime)) || (has(self.agentRef) && !has(self.goal) && !has(self.provider) && !has(self.model) && !has(self.tools) && !has(self.budget) && !has(self.secretRef) && !has(self.knowledgeConfigMapRef) && !has(self.serviceAccountName) && !has(self.runtime) && !has(self.env))",message="AgentRun must be a complete execution spec or a sparse invocation containing only agentRef and parameters"
 type AgentRunSpec struct {
 	AgentRef *AgentRef `json:"agentRef,omitempty"`
 
+	// Parameters are retained with a resolved Task snapshot for auditability.
+	Parameters map[string]string `json:"parameters,omitempty"`
+
 	// +kubebuilder:validation:MinLength=1
-	Goal string `json:"goal"`
+	Goal string `json:"goal,omitempty"`
 
 	Provider string `json:"provider,omitempty"`
 	// +kubebuilder:validation:MinLength=1
-	Model string   `json:"model"`
+	Model string   `json:"model,omitempty"`
 	Tools []string `json:"tools,omitempty"`
 
 	Budget *BudgetSpec `json:"budget,omitempty"`
@@ -39,7 +45,7 @@ type AgentRunSpec struct {
 
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	Runtime RuntimeSpec `json:"runtime"`
+	Runtime RuntimeSpec `json:"runtime,omitempty,omitzero"`
 
 	Env []EnvVar `json:"env,omitempty"`
 }

--- a/api/v1alpha1/task_contract_test.go
+++ b/api/v1alpha1/task_contract_test.go
@@ -2,44 +2,29 @@ package v1alpha1_test
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 )
 
-func TestSparseTaskInvocationJSONOmitsExecutionFields(t *testing.T) {
-	invocation := kontextv1alpha1.AgentRunSpec{
-		AgentRef: &kontextv1alpha1.AgentRef{Name: "task"},
-		Parameters: map[string]string{
-			"input": "value",
-		},
+func TestSparseTaskCreateRequestDecodesForFutureMutation(t *testing.T) {
+	// Kubernetes invokes mutating admission before it validates the final
+	// object against the CRD. The future Task webhook can therefore decode this
+	// request shape, resolve it in memory, and return a complete object. It must
+	// never marshal or persist this unresolved value.
+	data := []byte(`{"agentRef":{"name":"task"},"parameters":{"input":"value"}}`)
+	var invocation kontextv1alpha1.AgentRunSpec
+	if err := json.Unmarshal(data, &invocation); err != nil {
+		t.Fatalf("decode sparse CREATE request: %v", err)
 	}
-
-	data, err := json.Marshal(invocation)
-	if err != nil {
-		t.Fatalf("marshal sparse invocation: %v", err)
+	if invocation.AgentRef == nil || invocation.AgentRef.Name != "task" {
+		t.Fatalf("decoded agentRef = %#v", invocation.AgentRef)
 	}
-	encoded := string(data)
-	for _, field := range []string{
-		`"goal"`,
-		`"provider"`,
-		`"model"`,
-		`"tools"`,
-		`"budget"`,
-		`"secretRef"`,
-		`"knowledgeConfigMapRef"`,
-		`"serviceAccountName"`,
-		`"runtime"`,
-		`"env"`,
-	} {
-		if strings.Contains(encoded, field) {
-			t.Fatalf("sparse invocation unexpectedly serialized %s: %s", field, encoded)
-		}
+	if invocation.Parameters["input"] != "value" {
+		t.Fatalf("decoded parameters = %#v", invocation.Parameters)
 	}
-	if !strings.Contains(encoded, `"agentRef":{"name":"task"}`) ||
-		!strings.Contains(encoded, `"parameters":{"input":"value"}`) {
-		t.Fatalf("sparse invocation omitted allowed fields: %s", encoded)
+	if invocation.Goal != "" || invocation.Model != "" || invocation.Runtime.Image != "" {
+		t.Fatalf("sparse request unexpectedly contains execution fields: %#v", invocation)
 	}
 }
 

--- a/api/v1alpha1/task_contract_test.go
+++ b/api/v1alpha1/task_contract_test.go
@@ -1,0 +1,58 @@
+package v1alpha1_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+)
+
+func TestSparseTaskInvocationJSONOmitsExecutionFields(t *testing.T) {
+	invocation := kontextv1alpha1.AgentRunSpec{
+		AgentRef: &kontextv1alpha1.AgentRef{Name: "task"},
+		Parameters: map[string]string{
+			"input": "value",
+		},
+	}
+
+	data, err := json.Marshal(invocation)
+	if err != nil {
+		t.Fatalf("marshal sparse invocation: %v", err)
+	}
+	encoded := string(data)
+	for _, field := range []string{
+		`"goal"`,
+		`"provider"`,
+		`"model"`,
+		`"tools"`,
+		`"budget"`,
+		`"secretRef"`,
+		`"knowledgeConfigMapRef"`,
+		`"serviceAccountName"`,
+		`"runtime"`,
+		`"env"`,
+	} {
+		if strings.Contains(encoded, field) {
+			t.Fatalf("sparse invocation unexpectedly serialized %s: %s", field, encoded)
+		}
+	}
+	if !strings.Contains(encoded, `"agentRef":{"name":"task"}`) ||
+		!strings.Contains(encoded, `"parameters":{"input":"value"}`) {
+		t.Fatalf("sparse invocation omitted allowed fields: %s", encoded)
+	}
+}
+
+func TestAgentRunParametersDeepCopy(t *testing.T) {
+	source := &kontextv1alpha1.AgentRun{
+		Spec: kontextv1alpha1.AgentRunSpec{
+			Parameters: map[string]string{"input": "original"},
+		},
+	}
+	copy := source.DeepCopy()
+	source.Spec.Parameters["input"] = "changed"
+
+	if copy.Spec.Parameters["input"] != "original" {
+		t.Fatalf("deep copy shares parameters map: %#v", copy.Spec.Parameters)
+	}
+}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -166,6 +166,13 @@ func (in *AgentRunSpec) DeepCopyInto(out *AgentRunSpec) {
 		*out = new(AgentRef)
 		**out = **in
 	}
+	if in.Parameters != nil {
+		in, out := &in.Parameters, &out.Parameters
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Tools != nil {
 		in, out := &in.Tools, &out.Tools
 		*out = make([]string, len(*in))

--- a/config/crd/bases/kontext.dev_agentruns.yaml
+++ b/config/crd/bases/kontext.dev_agentruns.yaml
@@ -49,7 +49,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: AgentRunSpec defines the desired state of AgentRun.
+            description: |-
+              AgentRunSpec defines the desired state of AgentRun. Persisted specs are
+              always complete. A future CREATE mutating webhook may decode a sparse Task
+              request into this type, but it must resolve the required execution fields
+              before API-server schema validation and persistence.
             properties:
               agentRef:
                 description: AgentRef links an AgentRun to its owning Agent.
@@ -234,18 +238,18 @@ spec:
                 items:
                   type: string
                 type: array
+            required:
+            - goal
+            - model
+            - runtime
             type: object
             x-kubernetes-validations:
             - message: AgentRun spec is immutable
               rule: self == oldSelf
             - message: parameters require agentRef
               rule: has(self.agentRef) || !has(self.parameters)
-            - message: AgentRun must be a complete execution spec or a sparse invocation
-                containing only agentRef and parameters
-              rule: (has(self.goal) && has(self.model) && has(self.runtime)) || (has(self.agentRef)
-                && !has(self.goal) && !has(self.provider) && !has(self.model) && !has(self.tools)
-                && !has(self.budget) && !has(self.secretRef) && !has(self.knowledgeConfigMapRef)
-                && !has(self.serviceAccountName) && !has(self.runtime) && !has(self.env))
+            - message: persisted AgentRun spec must contain a complete execution snapshot
+              rule: has(self.goal) && has(self.model) && has(self.runtime)
           status:
             description: AgentRunStatus defines the observed state of AgentRun.
             properties:

--- a/config/crd/bases/kontext.dev_agentruns.yaml
+++ b/config/crd/bases/kontext.dev_agentruns.yaml
@@ -55,6 +55,7 @@ spec:
                 description: AgentRef links an AgentRun to its owning Agent.
                 properties:
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - name
@@ -123,6 +124,12 @@ spec:
               model:
                 minLength: 1
                 type: string
+              parameters:
+                additionalProperties:
+                  type: string
+                description: Parameters are retained with a resolved Task snapshot
+                  for auditability.
+                type: object
               provider:
                 type: string
               runtime:
@@ -227,14 +234,18 @@ spec:
                 items:
                   type: string
                 type: array
-            required:
-            - goal
-            - model
-            - runtime
             type: object
             x-kubernetes-validations:
             - message: AgentRun spec is immutable
               rule: self == oldSelf
+            - message: parameters require agentRef
+              rule: has(self.agentRef) || !has(self.parameters)
+            - message: AgentRun must be a complete execution spec or a sparse invocation
+                containing only agentRef and parameters
+              rule: (has(self.goal) && has(self.model) && has(self.runtime)) || (has(self.agentRef)
+                && !has(self.goal) && !has(self.provider) && !has(self.model) && !has(self.tools)
+                && !has(self.budget) && !has(self.secretRef) && !has(self.knowledgeConfigMapRef)
+                && !has(self.serviceAccountName) && !has(self.runtime) && !has(self.env))
           status:
             description: AgentRunStatus defines the observed state of AgentRun.
             properties:

--- a/config/crd/bases/kontext.dev_agents.yaml
+++ b/config/crd/bases/kontext.dev_agents.yaml
@@ -113,8 +113,10 @@ spec:
                     rule: has(self.value) != has(self.valueFrom)
                 type: array
               goal:
+                minLength: 1
                 type: string
               goalTemplate:
+                minLength: 1
                 type: string
               knowledgeConfigMapRef:
                 description: ConfigMapRef references a Kubernetes ConfigMap mounted
@@ -247,6 +249,15 @@ spec:
             - model
             - runtime
             type: object
+            x-kubernetes-validations:
+            - message: Task agents require exactly one of goal or goalTemplate; Service
+                and Scheduled agents require goal and forbid goalTemplate
+              rule: 'self.mode == ''Task'' ? has(self.goal) != has(self.goalTemplate)
+                : has(self.goal) && !has(self.goalTemplate)'
+            - message: schedule is only valid for Scheduled agents
+              rule: self.mode == 'Scheduled' || !has(self.schedule)
+            - message: backoff is only valid for Service agents
+              rule: self.mode == 'Service' || !has(self.backoff)
           status:
             description: AgentStatus defines the observed state of Agent.
             properties:

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -17,9 +17,9 @@ model, budgets, and related fields.
 - **Service** — always-on. The controller keeps one live child `AgentRun` and
   re-casts it with backoff after exit or failure. In-memory conversation is not
   restored across recasts.
-- **Task** — reserved reusable template. The schema is available, but the
-  controller reports `UnsupportedMode`. Create a standalone `AgentRun` for
-  one-shot work.
+- **Task** — reusable one-shot template. Creating the Agent does not execute
+  it. A user explicitly triggers work by creating a named `AgentRun` that
+  references it. Task controller status reconciliation remains reserved.
 - **Scheduled** — reserved for cron-style minting. The schema is available,
   but the controller reports `UnsupportedMode` and does not schedule runs.
 
@@ -31,6 +31,40 @@ fields when available.
 
 You can create an `AgentRun` standalone, without an owning `Agent`. That path
 is the fastest way to prove install health with the echo runtime.
+
+### Task invocations
+
+A Task Agent configures exactly one static `goal` or parameterized
+`goalTemplate`. A sparse invocation contains only `agentRef` and optional
+string `parameters`:
+
+```yaml
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: summarize-frontend
+spec:
+  agentRef:
+    name: summarizer
+  parameters:
+    area: frontend
+```
+
+Templates use strict `${area}` placeholders. `$${area}` produces the literal
+text `${area}`. Missing and unused parameters are rejected, and static goals
+accept no parameters. Runtime, provider, model, tools, budget, identity,
+references, environment, and the concrete goal are locked to the Agent
+template. Use a standalone run or another Agent definition when those fields
+must differ.
+
+The pure resolution contract is present in this release, but sparse CREATE
+admission is not registered yet. Until that follow-up lands, use fully resolved
+or standalone runs for end-to-end execution.
+
+Task runs are user-named and can execute concurrently. For Task status,
+`lastRunName` means the newest retained owned run by creation time, while
+`runsCreated` is the number of currently retained owned runs. It is not a
+lifetime counter.
 
 ## Status and logs
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -32,11 +32,11 @@ fields when available.
 You can create an `AgentRun` standalone, without an owning `Agent`. That path
 is the fastest way to prove install health with the echo runtime.
 
-### Task invocations
+### Future Task invocation requests
 
 A Task Agent configures exactly one static `goal` or parameterized
-`goalTemplate`. A sparse invocation contains only `agentRef` and optional
-string `parameters`:
+`goalTemplate`. Once the Task CREATE webhook is installed, its sparse request
+shape contains only `agentRef` and optional string `parameters`:
 
 ```yaml
 apiVersion: kontext.dev/v1alpha1
@@ -57,9 +57,13 @@ references, environment, and the concrete goal are locked to the Agent
 template. Use a standalone run or another Agent definition when those fields
 must differ.
 
-The pure resolution contract is present in this release, but sparse CREATE
-admission is not registered yet. Until that follow-up lands, use fully resolved
-or standalone runs for end-to-end execution.
+This YAML is an admission request shape, not a valid persisted AgentRun in the
+current release. Kubernetes runs mutating admission before final CRD
+validation, so #84 will resolve the request before the API server validates and
+stores it. Persisted AgentRuns always contain `goal`, `model`, and
+`runtime.image`. Until the webhook infrastructure and mutator from #83/#84 are
+installed, the API server rejects sparse CREATE requests; use standalone runs
+for end-to-end execution.
 
 Task runs are user-named and can execute concurrently. For Task status,
 `lastRunName` means the newest retained owned run by creation time, while

--- a/internal/controller/task_api_validation_test.go
+++ b/internal/controller/task_api_validation_test.go
@@ -1,0 +1,228 @@
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+)
+
+func TestTaskAgentAPIValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         kontextv1alpha1.AgentMode
+		goal         string
+		goalTemplate string
+		schedule     string
+		backoff      *kontextv1alpha1.BackoffSpec
+		wantValid    bool
+	}{
+		{name: "Task static goal", mode: kontextv1alpha1.AgentModeTask, goal: "static", wantValid: true},
+		{name: "Task goal template", mode: kontextv1alpha1.AgentModeTask, goalTemplate: "${input}", wantValid: true},
+		{name: "Task neither goal", mode: kontextv1alpha1.AgentModeTask},
+		{name: "Task both goals", mode: kontextv1alpha1.AgentModeTask, goal: "static", goalTemplate: "${input}"},
+		{name: "Task rejects schedule", mode: kontextv1alpha1.AgentModeTask, goal: "static", schedule: "* * * * *"},
+		{name: "Task rejects backoff", mode: kontextv1alpha1.AgentModeTask, goal: "static", backoff: &kontextv1alpha1.BackoffSpec{}},
+		{name: "Service static goal", mode: kontextv1alpha1.AgentModeService, goal: "serve", backoff: &kontextv1alpha1.BackoffSpec{}, wantValid: true},
+		{name: "Service missing goal", mode: kontextv1alpha1.AgentModeService},
+		{name: "Service rejects template", mode: kontextv1alpha1.AgentModeService, goalTemplate: "${input}"},
+		{name: "Service rejects schedule", mode: kontextv1alpha1.AgentModeService, goal: "serve", schedule: "* * * * *"},
+		{name: "Scheduled static goal", mode: kontextv1alpha1.AgentModeScheduled, goal: "scheduled", schedule: "* * * * *", wantValid: true},
+		{name: "Scheduled missing goal", mode: kontextv1alpha1.AgentModeScheduled, schedule: "* * * * *"},
+		{name: "Scheduled rejects template", mode: kontextv1alpha1.AgentModeScheduled, goalTemplate: "${input}", schedule: "* * * * *"},
+		{name: "Scheduled rejects backoff", mode: kontextv1alpha1.AgentModeScheduled, goal: "scheduled", backoff: &kontextv1alpha1.BackoffSpec{}},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			agent := &kontextv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("task-agent-validation-%d", index),
+					Namespace: "default",
+				},
+				Spec: kontextv1alpha1.AgentSpec{
+					Mode:         test.mode,
+					Goal:         test.goal,
+					GoalTemplate: test.goalTemplate,
+					Model:        "test/model",
+					Runtime:      echoRuntimeSpec(),
+					Schedule:     test.schedule,
+					Backoff:      test.backoff,
+				},
+			}
+			err := k8sClient.Create(context.Background(), agent)
+			if test.wantValid {
+				if err != nil {
+					t.Fatalf("expected valid Agent: %v", err)
+				}
+				deleteObject(t, agent)
+				return
+			}
+			if !apierrors.IsInvalid(err) {
+				t.Fatalf("expected API validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAgentRunInvocationAPIValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      map[string]any
+		wantValid bool
+	}{
+		{
+			name:      "sparse reference only",
+			spec:      map[string]any{"agentRef": map[string]any{"name": "task"}},
+			wantValid: true,
+		},
+		{
+			name: "sparse parameters",
+			spec: map[string]any{
+				"agentRef":   map[string]any{"name": "task"},
+				"parameters": map[string]any{"input": "value"},
+			},
+			wantValid: true,
+		},
+		{
+			name: "parameters require reference",
+			spec: map[string]any{
+				"parameters": map[string]any{"input": "value"},
+			},
+		},
+		{
+			name:      "standalone complete execution",
+			spec:      completeAgentRunSpec(nil),
+			wantValid: true,
+		},
+		{
+			name:      "fully resolved Service or Scheduled controller run",
+			spec:      completeAgentRunSpec(map[string]any{"name": "controller-agent"}),
+			wantValid: true,
+		},
+		{
+			name: "fully resolved Task snapshot retains parameters",
+			spec: mergeSpec(
+				completeAgentRunSpec(map[string]any{"name": "task"}),
+				map[string]any{"parameters": map[string]any{"input": "value"}},
+			),
+			wantValid: true,
+		},
+		{
+			name: "standalone cannot be sparse",
+			spec: map[string]any{},
+		},
+		{
+			name: "referenced partial execution is rejected",
+			spec: map[string]any{
+				"agentRef": map[string]any{"name": "task"},
+				"goal":     "partial",
+			},
+		},
+		{
+			name: "sparse invocation rejects locked provider",
+			spec: map[string]any{
+				"agentRef": map[string]any{"name": "task"},
+				"provider": "fake",
+			},
+		},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			run := unstructuredAgentRun(fmt.Sprintf("task-run-validation-%d", index), test.spec)
+			err := k8sClient.Create(context.Background(), run)
+			if test.wantValid {
+				if err != nil {
+					t.Fatalf("expected valid AgentRun: %v", err)
+				}
+				deleteObject(t, run)
+				return
+			}
+			if !apierrors.IsInvalid(err) {
+				t.Fatalf("expected API validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAgentRunParametersAndSpecAreImmutable(t *testing.T) {
+	ctx := context.Background()
+	run := unstructuredAgentRun("task-run-parameters-immutable", map[string]any{
+		"agentRef":   map[string]any{"name": "task"},
+		"parameters": map[string]any{"input": "original"},
+	})
+	if err := k8sClient.Create(ctx, run); err != nil {
+		t.Fatalf("create sparse AgentRun: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(context.Background(), run)
+	})
+
+	if err := unstructured.SetNestedField(run.Object, "changed", "spec", "parameters", "input"); err != nil {
+		t.Fatalf("change parameters: %v", err)
+	}
+	err := k8sClient.Update(ctx, run)
+	if !apierrors.IsInvalid(err) {
+		t.Fatalf("expected immutable spec validation error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "AgentRun spec is immutable") {
+		t.Fatalf("immutability error is not actionable: %v", err)
+	}
+}
+
+func completeAgentRunSpec(agentRef map[string]any) map[string]any {
+	spec := map[string]any{
+		"goal":  "complete execution",
+		"model": "test/model",
+		"runtime": map[string]any{
+			"image": "kontext-echo:dev",
+		},
+	}
+	if agentRef != nil {
+		spec["agentRef"] = agentRef
+	}
+	return spec
+}
+
+func mergeSpec(base, fields map[string]any) map[string]any {
+	for key, value := range fields {
+		base[key] = value
+	}
+	return base
+}
+
+func unstructuredAgentRun(name string, spec map[string]any) *unstructured.Unstructured {
+	run := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kontext.dev/v1alpha1",
+			"kind":       "AgentRun",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "default",
+			},
+			"spec": spec,
+		},
+	}
+	run.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kontext.dev",
+		Version: "v1alpha1",
+		Kind:    "AgentRun",
+	})
+	return run
+}
+
+func deleteObject(t *testing.T, object client.Object) {
+	t.Helper()
+	if err := k8sClient.Delete(context.Background(), object); err != nil {
+		t.Fatalf("delete valid object: %v", err)
+	}
+}

--- a/internal/controller/task_api_validation_test.go
+++ b/internal/controller/task_api_validation_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
@@ -73,30 +74,33 @@ func TestTaskAgentAPIValidation(t *testing.T) {
 	}
 }
 
-func TestAgentRunInvocationAPIValidation(t *testing.T) {
+func TestAgentRunPersistenceAPIValidation(t *testing.T) {
 	tests := []struct {
-		name      string
-		spec      map[string]any
-		wantValid bool
+		name        string
+		spec        map[string]any
+		wantValid   bool
+		wantMessage string
 	}{
 		{
-			name:      "sparse reference only",
-			spec:      map[string]any{"agentRef": map[string]any{"name": "task"}},
-			wantValid: true,
+			name:        "sparse reference only is not persisted",
+			spec:        map[string]any{"agentRef": map[string]any{"name": "task"}},
+			wantMessage: "Required value",
 		},
 		{
-			name: "sparse parameters",
+			name: "sparse parameters are not persisted",
 			spec: map[string]any{
 				"agentRef":   map[string]any{"name": "task"},
 				"parameters": map[string]any{"input": "value"},
 			},
-			wantValid: true,
+			wantMessage: "Required value",
 		},
 		{
 			name: "parameters require reference",
-			spec: map[string]any{
-				"parameters": map[string]any{"input": "value"},
-			},
+			spec: mergeSpec(
+				completeAgentRunSpec(nil),
+				map[string]any{"parameters": map[string]any{"input": "value"}},
+			),
+			wantMessage: "parameters require agentRef",
 		},
 		{
 			name:      "standalone complete execution",
@@ -117,8 +121,9 @@ func TestAgentRunInvocationAPIValidation(t *testing.T) {
 			wantValid: true,
 		},
 		{
-			name: "standalone cannot be sparse",
-			spec: map[string]any{},
+			name:        "standalone cannot be sparse",
+			spec:        map[string]any{},
+			wantMessage: "Required value",
 		},
 		{
 			name: "referenced partial execution is rejected",
@@ -126,13 +131,17 @@ func TestAgentRunInvocationAPIValidation(t *testing.T) {
 				"agentRef": map[string]any{"name": "task"},
 				"goal":     "partial",
 			},
+			wantMessage: "Required value",
 		},
 		{
-			name: "sparse invocation rejects locked provider",
+			name: "runtime image remains required",
 			spec: map[string]any{
 				"agentRef": map[string]any{"name": "task"},
-				"provider": "fake",
+				"goal":     "resolved",
+				"model":    "test/model",
+				"runtime":  map[string]any{},
 			},
+			wantMessage: "image: Required value",
 		},
 	}
 
@@ -150,18 +159,24 @@ func TestAgentRunInvocationAPIValidation(t *testing.T) {
 			if !apierrors.IsInvalid(err) {
 				t.Fatalf("expected API validation error, got %v", err)
 			}
+			if test.wantMessage != "" && !strings.Contains(err.Error(), test.wantMessage) {
+				t.Fatalf("validation error does not contain %q: %v", test.wantMessage, err)
+			}
 		})
 	}
 }
 
 func TestAgentRunParametersAndSpecAreImmutable(t *testing.T) {
 	ctx := context.Background()
-	run := unstructuredAgentRun("task-run-parameters-immutable", map[string]any{
-		"agentRef":   map[string]any{"name": "task"},
-		"parameters": map[string]any{"input": "original"},
-	})
+	run := unstructuredAgentRun(
+		"task-run-parameters-immutable",
+		mergeSpec(
+			completeAgentRunSpec(map[string]any{"name": "task"}),
+			map[string]any{"parameters": map[string]any{"input": "original"}},
+		),
+	)
 	if err := k8sClient.Create(ctx, run); err != nil {
-		t.Fatalf("create sparse AgentRun: %v", err)
+		t.Fatalf("create complete resolved AgentRun: %v", err)
 	}
 	t.Cleanup(func() {
 		_ = k8sClient.Delete(context.Background(), run)
@@ -176,6 +191,29 @@ func TestAgentRunParametersAndSpecAreImmutable(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "AgentRun spec is immutable") {
 		t.Fatalf("immutability error is not actionable: %v", err)
+	}
+}
+
+func TestAgentRunReconcilerCannotObserveAdmittedSparseSpec(t *testing.T) {
+	// Kubernetes mutating admission runs before final CRD validation. Until the
+	// future Task mutator is installed, this sparse CREATE must fail validation,
+	// leaving no object for the AgentRun controller to reconcile.
+	ctx := context.Background()
+	name := "sparse-run-never-admitted"
+	run := unstructuredAgentRun(name, map[string]any{
+		"agentRef":   map[string]any{"name": "task"},
+		"parameters": map[string]any{"input": "value"},
+	})
+	if err := k8sClient.Create(ctx, run); !apierrors.IsInvalid(err) {
+		t.Fatalf("expected sparse CREATE to be rejected, got %v", err)
+	}
+
+	key := types.NamespacedName{Name: name, Namespace: "default"}
+	reconcileAgentRun(ctx, t, key)
+
+	var observed kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, key, &observed); !apierrors.IsNotFound(err) {
+		t.Fatalf("controller could observe sparse AgentRun: object=%#v error=%v", observed, err)
 	}
 }
 

--- a/internal/runfactory/runfactory.go
+++ b/internal/runfactory/runfactory.go
@@ -2,6 +2,12 @@
 package runfactory
 
 import (
+	"fmt"
+	"maps"
+	"reflect"
+	"sort"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -10,6 +16,49 @@ import (
 	"github.com/MFS-code/Kontext/internal/podbuilder"
 	"github.com/MFS-code/Kontext/internal/runtimepolicy"
 )
+
+// ResolutionErrorCode identifies a stable Task resolution failure class.
+type ResolutionErrorCode string
+
+const (
+	ErrorMissingAgent      ResolutionErrorCode = "MissingAgent"
+	ErrorWrongMode         ResolutionErrorCode = "WrongMode"
+	ErrorInvalidTemplate   ResolutionErrorCode = "InvalidTemplate"
+	ErrorMissingParameters ResolutionErrorCode = "MissingParameters"
+	ErrorUnusedParameters  ResolutionErrorCode = "UnusedParameters"
+	ErrorConflictingFields ResolutionErrorCode = "ConflictingFields"
+)
+
+// ResolutionError is returned for every rejected Task invocation.
+type ResolutionError struct {
+	Code      ResolutionErrorCode
+	AgentName string
+	Mode      kontextv1alpha1.AgentMode
+	Names     []string
+	Detail    string
+}
+
+func (e *ResolutionError) Error() string {
+	switch e.Code {
+	case ErrorMissingAgent:
+		return fmt.Sprintf("Task resolution failed [%s]: Agent %q was not found", e.Code, e.AgentName)
+	case ErrorWrongMode:
+		return fmt.Sprintf("Task resolution failed [%s]: Agent %q has mode %q", e.Code, e.AgentName, e.Mode)
+	case ErrorInvalidTemplate:
+		return fmt.Sprintf("Task resolution failed [%s]: %s", e.Code, e.Detail)
+	case ErrorMissingParameters:
+		return fmt.Sprintf("Task resolution failed [%s]: missing parameters: %s", e.Code, strings.Join(e.Names, ", "))
+	case ErrorUnusedParameters:
+		if len(e.Names) == 0 {
+			return fmt.Sprintf("Task resolution failed [%s]: static goals do not accept parameters", e.Code)
+		}
+		return fmt.Sprintf("Task resolution failed [%s]: unused parameters: %s", e.Code, strings.Join(e.Names, ", "))
+	case ErrorConflictingFields:
+		return fmt.Sprintf("Task resolution failed [%s]: invocation supplies locked fields: %s", e.Code, strings.Join(e.Names, ", "))
+	default:
+		return fmt.Sprintf("Task resolution failed [%s]", e.Code)
+	}
+}
 
 // NewForAgent builds an owned AgentRun with a fully resolved snapshot of the
 // Agent execution fields and the supplied concrete goal.
@@ -46,4 +95,214 @@ func NewForAgent(
 		return nil, err
 	}
 	return run, nil
+}
+
+// ResolveTask resolves a sparse user invocation against a Task Agent. It is
+// pure: neither input is mutated, and the returned run shares no execution
+// data with either input.
+func ResolveTask(
+	agent *kontextv1alpha1.Agent,
+	invocation *kontextv1alpha1.AgentRun,
+	scheme *runtime.Scheme,
+) (*kontextv1alpha1.AgentRun, error) {
+	referenceName := ""
+	if invocation != nil && invocation.Spec.AgentRef != nil {
+		referenceName = invocation.Spec.AgentRef.Name
+	}
+	if agent == nil || referenceName == "" || referenceName != agent.Name ||
+		(invocation.Namespace != "" && invocation.Namespace != agent.Namespace) {
+		return nil, &ResolutionError{Code: ErrorMissingAgent, AgentName: referenceName}
+	}
+	if agent.Spec.Mode != kontextv1alpha1.AgentModeTask {
+		return nil, &ResolutionError{
+			Code:      ErrorWrongMode,
+			AgentName: agent.Name,
+			Mode:      agent.Spec.Mode,
+		}
+	}
+
+	if fields := lockedInvocationFields(invocation.Spec); len(fields) > 0 {
+		return nil, &ResolutionError{Code: ErrorConflictingFields, Names: fields}
+	}
+
+	goal, err := resolveGoal(agent.Spec, invocation.Spec.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved, err := NewForAgent(agent, invocation.Name, goal, scheme)
+	if err != nil {
+		return nil, err
+	}
+	resolved.TypeMeta = invocation.TypeMeta
+	resolved.Annotations = maps.Clone(invocation.Annotations)
+	resolved.Finalizers = append([]string(nil), invocation.Finalizers...)
+	for key, value := range invocation.Labels {
+		if resolved.Labels == nil {
+			resolved.Labels = make(map[string]string)
+		}
+		resolved.Labels[key] = value
+	}
+	resolved.Labels[podbuilder.LabelAgentName] = agent.Name
+	resolved.Spec.Parameters = maps.Clone(invocation.Spec.Parameters)
+	return resolved, nil
+}
+
+func lockedInvocationFields(spec kontextv1alpha1.AgentRunSpec) []string {
+	fields := make([]string, 0, 10)
+	if spec.Goal != "" {
+		fields = append(fields, "goal")
+	}
+	if spec.Provider != "" {
+		fields = append(fields, "provider")
+	}
+	if spec.Model != "" {
+		fields = append(fields, "model")
+	}
+	if spec.Tools != nil {
+		fields = append(fields, "tools")
+	}
+	if spec.Budget != nil {
+		fields = append(fields, "budget")
+	}
+	if spec.SecretRef != nil {
+		fields = append(fields, "secretRef")
+	}
+	if spec.KnowledgeConfigMapRef != nil {
+		fields = append(fields, "knowledgeConfigMapRef")
+	}
+	if spec.ServiceAccountName != "" {
+		fields = append(fields, "serviceAccountName")
+	}
+	if !reflect.DeepEqual(spec.Runtime, kontextv1alpha1.RuntimeSpec{}) {
+		fields = append(fields, "runtime")
+	}
+	if spec.Env != nil {
+		fields = append(fields, "env")
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+func resolveGoal(spec kontextv1alpha1.AgentSpec, parameters map[string]string) (string, error) {
+	hasGoal := spec.Goal != ""
+	hasTemplate := spec.GoalTemplate != ""
+	if hasGoal == hasTemplate {
+		return "", &ResolutionError{
+			Code:   ErrorInvalidTemplate,
+			Detail: "Task Agent must configure exactly one of goal or goalTemplate",
+		}
+	}
+	if hasGoal {
+		if parameters != nil {
+			names := sortedMapKeys(parameters)
+			return "", &ResolutionError{Code: ErrorUnusedParameters, Names: names}
+		}
+		return spec.Goal, nil
+	}
+	return interpolateGoal(spec.GoalTemplate, parameters)
+}
+
+func interpolateGoal(template string, parameters map[string]string) (string, error) {
+	var rendered strings.Builder
+	used := make(map[string]struct{})
+	missing := make(map[string]struct{})
+
+	for index := 0; index < len(template); {
+		switch {
+		case strings.HasPrefix(template[index:], "$${"):
+			name, next, err := parsePlaceholder(template, index+1)
+			if err != nil {
+				return "", err
+			}
+			rendered.WriteString("${")
+			rendered.WriteString(name)
+			rendered.WriteByte('}')
+			index = next
+		case strings.HasPrefix(template[index:], "${"):
+			name, next, err := parsePlaceholder(template, index)
+			if err != nil {
+				return "", err
+			}
+			value, ok := parameters[name]
+			if !ok {
+				missing[name] = struct{}{}
+			} else {
+				used[name] = struct{}{}
+				rendered.WriteString(value)
+			}
+			index = next
+		default:
+			rendered.WriteByte(template[index])
+			index++
+		}
+	}
+
+	if len(missing) > 0 {
+		return "", &ResolutionError{Code: ErrorMissingParameters, Names: sortedSetKeys(missing)}
+	}
+	unused := make(map[string]struct{})
+	for name := range parameters {
+		if _, ok := used[name]; !ok {
+			unused[name] = struct{}{}
+		}
+	}
+	if len(unused) > 0 {
+		return "", &ResolutionError{Code: ErrorUnusedParameters, Names: sortedSetKeys(unused)}
+	}
+	return rendered.String(), nil
+}
+
+func parsePlaceholder(template string, start int) (string, int, error) {
+	nameStart := start + 2
+	endOffset := strings.IndexByte(template[nameStart:], '}')
+	if endOffset < 0 {
+		return "", 0, &ResolutionError{
+			Code:   ErrorInvalidTemplate,
+			Detail: fmt.Sprintf("unterminated placeholder at byte %d", start),
+		}
+	}
+	end := nameStart + endOffset
+	name := template[nameStart:end]
+	if !validParameterName(name) {
+		return "", 0, &ResolutionError{
+			Code:   ErrorInvalidTemplate,
+			Detail: fmt.Sprintf("invalid placeholder %q at byte %d", name, start),
+		}
+	}
+	return name, end + 1, nil
+}
+
+func validParameterName(name string) bool {
+	if name == "" || !asciiLetterOrUnderscore(name[0]) {
+		return false
+	}
+	for index := 1; index < len(name); index++ {
+		if !asciiLetterOrUnderscore(name[index]) && (name[index] < '0' || name[index] > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func asciiLetterOrUnderscore(value byte) bool {
+	return value == '_' || value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
+}
+
+func sortedMapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedSetKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/runfactory/runfactory.go
+++ b/internal/runfactory/runfactory.go
@@ -105,8 +105,12 @@ func ResolveTask(
 	invocation *kontextv1alpha1.AgentRun,
 	scheme *runtime.Scheme,
 ) (*kontextv1alpha1.AgentRun, error) {
+	if invocation == nil {
+		return nil, &ResolutionError{Code: ErrorMissingAgent}
+	}
+
 	referenceName := ""
-	if invocation != nil && invocation.Spec.AgentRef != nil {
+	if invocation.Spec.AgentRef != nil {
 		referenceName = invocation.Spec.AgentRef.Name
 	}
 	if agent == nil || referenceName == "" || referenceName != agent.Name ||

--- a/internal/runfactory/runfactory_test.go
+++ b/internal/runfactory/runfactory_test.go
@@ -303,6 +303,7 @@ func TestSnapshotFieldCoverage(t *testing.T) {
 		"Goal",
 		"KnowledgeConfigMapRef",
 		"Model",
+		"Parameters",
 		"Provider",
 		"Runtime",
 		"SecretRef",

--- a/internal/runfactory/task_resolver_test.go
+++ b/internal/runfactory/task_resolver_test.go
@@ -1,0 +1,455 @@
+package runfactory_test
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+	"github.com/MFS-code/Kontext/internal/runfactory"
+)
+
+func TestResolveTaskInterpolation(t *testing.T) {
+	tests := []struct {
+		name       string
+		template   string
+		parameters map[string]string
+		want       string
+		wantCode   runfactory.ResolutionErrorCode
+	}{
+		{name: "placeholder at start", template: "${name} suffix", parameters: map[string]string{"name": "prefix"}, want: "prefix suffix"},
+		{name: "placeholder in middle", template: "before ${name} after", parameters: map[string]string{"name": "middle"}, want: "before middle after"},
+		{name: "placeholder at end", template: "prefix ${name}", parameters: map[string]string{"name": "suffix"}, want: "prefix suffix"},
+		{name: "adjacent placeholders", template: "${first}${second}", parameters: map[string]string{"first": "a", "second": "b"}, want: "ab"},
+		{name: "repeated parameter", template: "${name}/${name}", parameters: map[string]string{"name": "same"}, want: "same/same"},
+		{name: "empty value", template: "before${value}after", parameters: map[string]string{"value": ""}, want: "beforeafter"},
+		{name: "Unicode value", template: "say ${value}", parameters: map[string]string{"value": "こんにちは 🌍"}, want: "say こんにちは 🌍"},
+		{name: "multiline value", template: "begin\n${value}\nend", parameters: map[string]string{"value": "one\ntwo"}, want: "begin\none\ntwo\nend"},
+		{name: "escaped placeholder", template: "$${name}", want: "${name}"},
+		{name: "escaped and resolved", template: "$${literal} ${value}", parameters: map[string]string{"value": "resolved"}, want: "${literal} resolved"},
+		{name: "replacement is not re-expanded", template: "${value}", parameters: map[string]string{"value": "${other}"}, want: "${other}"},
+		{name: "ordinary dollar is literal", template: "cost $5", want: "cost $5"},
+		{name: "missing parameter", template: "${missing}", wantCode: runfactory.ErrorMissingParameters},
+		{name: "missing names are stable", template: "${z} ${a}", wantCode: runfactory.ErrorMissingParameters},
+		{name: "unused parameter", template: "constant", parameters: map[string]string{"unused": "value"}, wantCode: runfactory.ErrorUnusedParameters},
+		{name: "escaped parameter is unused", template: "$${name}", parameters: map[string]string{"name": "value"}, wantCode: runfactory.ErrorUnusedParameters},
+		{name: "empty placeholder", template: "${}", wantCode: runfactory.ErrorInvalidTemplate},
+		{name: "unterminated placeholder", template: "${name", wantCode: runfactory.ErrorInvalidTemplate},
+		{name: "invalid leading digit", template: "${1name}", wantCode: runfactory.ErrorInvalidTemplate},
+		{name: "invalid punctuation", template: "${bad-name}", wantCode: runfactory.ErrorInvalidTemplate},
+		{name: "nested placeholder", template: "${outer${inner}}", wantCode: runfactory.ErrorInvalidTemplate},
+		{name: "malformed escaped placeholder", template: "$${name", wantCode: runfactory.ErrorInvalidTemplate},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			agent := taskAgent("task", "", test.template)
+			invocation := taskInvocation("task-run", "task", test.parameters)
+
+			got, err := runfactory.ResolveTask(agent, invocation, taskResolverScheme(t))
+			if test.wantCode != "" {
+				assertResolutionErrorCode(t, err, test.wantCode)
+				if got != nil {
+					t.Fatalf("expected no resolved run, got %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolve Task: %v", err)
+			}
+			if got.Spec.Goal != test.want {
+				t.Fatalf("resolved goal = %q, want %q", got.Spec.Goal, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveTaskStaticGoal(t *testing.T) {
+	tests := []struct {
+		name       string
+		goal       string
+		template   string
+		parameters map[string]string
+		wantCode   runfactory.ResolutionErrorCode
+	}{
+		{name: "static goal", goal: "run the task"},
+		{name: "static goal rejects parameters", goal: "run the task", parameters: map[string]string{"input": "value"}, wantCode: runfactory.ErrorUnusedParameters},
+		{name: "static goal rejects allocated empty parameters", goal: "run the task", parameters: map[string]string{}, wantCode: runfactory.ErrorUnusedParameters},
+		{name: "neither goal nor template", wantCode: runfactory.ErrorInvalidTemplate},
+		{name: "both goal and template", goal: "static", template: "${input}", wantCode: runfactory.ErrorInvalidTemplate},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			agent := taskAgent("task", test.goal, test.template)
+			invocation := taskInvocation("task-run", "task", test.parameters)
+			got, err := runfactory.ResolveTask(agent, invocation, taskResolverScheme(t))
+			if test.wantCode != "" {
+				assertResolutionErrorCode(t, err, test.wantCode)
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolve static Task: %v", err)
+			}
+			if got.Spec.Goal != test.goal {
+				t.Fatalf("resolved goal = %q, want %q", got.Spec.Goal, test.goal)
+			}
+		})
+	}
+}
+
+func TestResolveTaskRejectsEveryLockedExecutionField(t *testing.T) {
+	emptyString := ""
+	tests := []struct {
+		name  string
+		field string
+		apply func(*kontextv1alpha1.AgentRunSpec)
+	}{
+		{name: "goal", field: "goal", apply: func(spec *kontextv1alpha1.AgentRunSpec) { spec.Goal = "override" }},
+		{name: "provider", field: "provider", apply: func(spec *kontextv1alpha1.AgentRunSpec) { spec.Provider = "fake" }},
+		{name: "model", field: "model", apply: func(spec *kontextv1alpha1.AgentRunSpec) { spec.Model = "override" }},
+		{name: "tools", field: "tools", apply: func(spec *kontextv1alpha1.AgentRunSpec) { spec.Tools = []string{} }},
+		{name: "budget", field: "budget", apply: func(spec *kontextv1alpha1.AgentRunSpec) { spec.Budget = &kontextv1alpha1.BudgetSpec{} }},
+		{name: "secretRef", field: "secretRef", apply: func(spec *kontextv1alpha1.AgentRunSpec) { spec.SecretRef = &kontextv1alpha1.SecretRef{} }},
+		{name: "knowledgeConfigMapRef", field: "knowledgeConfigMapRef", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.KnowledgeConfigMapRef = &kontextv1alpha1.ConfigMapRef{}
+		}},
+		{name: "serviceAccountName", field: "serviceAccountName", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.ServiceAccountName = "runner"
+		}},
+		{name: "runtime image", field: "runtime", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.Runtime.Image = "override"
+		}},
+		{name: "runtime empty command", field: "runtime", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.Runtime.Command = []string{}
+		}},
+		{name: "runtime empty args", field: "runtime", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.Runtime.Args = []string{}
+		}},
+		{name: "runtime empty result", field: "runtime", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.Runtime.Result = &kontextv1alpha1.RuntimeResultSpec{}
+		}},
+		{name: "runtime empty security context", field: "runtime", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.Runtime.SecurityContext = &kontextv1alpha1.RuntimeSecurityContext{}
+		}},
+		{name: "runtime nested capabilities", field: "runtime", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.Runtime.SecurityContext = &kontextv1alpha1.RuntimeSecurityContext{
+				Capabilities: &kontextv1alpha1.RuntimeCapabilities{Drop: []string{}},
+			}
+		}},
+		{name: "runtime nested seccomp", field: "runtime", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.Runtime.SecurityContext = &kontextv1alpha1.RuntimeSecurityContext{
+				SeccompProfile: &kontextv1alpha1.RuntimeSeccompProfile{},
+			}
+		}},
+		{name: "env", field: "env", apply: func(spec *kontextv1alpha1.AgentRunSpec) { spec.Env = []kontextv1alpha1.EnvVar{} }},
+		{name: "env nested literal", field: "env", apply: func(spec *kontextv1alpha1.AgentRunSpec) {
+			spec.Env = []kontextv1alpha1.EnvVar{{Name: "EMPTY", Value: &emptyString}}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			agent := taskAgent("task", "source goal", "")
+			invocation := taskInvocation("task-run", "task", nil)
+			test.apply(&invocation.Spec)
+
+			got, err := runfactory.ResolveTask(agent, invocation, taskResolverScheme(t))
+			resolutionErr := assertResolutionErrorCode(t, err, runfactory.ErrorConflictingFields)
+			if got != nil {
+				t.Fatalf("expected no resolved run, got %#v", got)
+			}
+			if !reflect.DeepEqual(resolutionErr.Names, []string{test.field}) {
+				t.Fatalf("conflicting fields = %v, want [%s]", resolutionErr.Names, test.field)
+			}
+		})
+	}
+}
+
+func TestResolveTaskReportsStableErrors(t *testing.T) {
+	scheme := taskResolverScheme(t)
+	tests := []struct {
+		name       string
+		agent      *kontextv1alpha1.Agent
+		invocation *kontextv1alpha1.AgentRun
+		wantCode   runfactory.ResolutionErrorCode
+		wantText   string
+	}{
+		{
+			name:       "nil Agent",
+			invocation: taskInvocation("run", "missing", nil),
+			wantCode:   runfactory.ErrorMissingAgent,
+			wantText:   `Task resolution failed [MissingAgent]: Agent "missing" was not found`,
+		},
+		{
+			name:       "missing reference",
+			agent:      taskAgent("task", "goal", ""),
+			invocation: taskInvocation("run", "", nil),
+			wantCode:   runfactory.ErrorMissingAgent,
+			wantText:   `Task resolution failed [MissingAgent]: Agent "" was not found`,
+		},
+		{
+			name:       "reference mismatch",
+			agent:      taskAgent("task", "goal", ""),
+			invocation: taskInvocation("run", "other", nil),
+			wantCode:   runfactory.ErrorMissingAgent,
+			wantText:   `Task resolution failed [MissingAgent]: Agent "other" was not found`,
+		},
+		{
+			name: "wrong mode",
+			agent: &kontextv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: "default"},
+				Spec:       kontextv1alpha1.AgentSpec{Mode: kontextv1alpha1.AgentModeService},
+			},
+			invocation: taskInvocation("run", "service", nil),
+			wantCode:   runfactory.ErrorWrongMode,
+			wantText:   `Task resolution failed [WrongMode]: Agent "service" has mode "Service"`,
+		},
+		{
+			name:       "sorted missing parameters",
+			agent:      taskAgent("task", "${z} ${a}", ""),
+			invocation: taskInvocation("run", "task", nil),
+			wantCode:   runfactory.ErrorInvalidTemplate,
+			wantText:   `Task resolution failed [InvalidTemplate]: Task Agent must configure exactly one of goal or goalTemplate`,
+		},
+		{
+			name:       "sorted conflicting fields",
+			agent:      taskAgent("task", "goal", ""),
+			invocation: taskInvocation("run", "task", nil),
+			wantCode:   runfactory.ErrorConflictingFields,
+			wantText:   `Task resolution failed [ConflictingFields]: invocation supplies locked fields: env, tools`,
+		},
+	}
+	tests[4].agent = taskAgent("task", "", "${z} ${a}")
+	tests[4].wantCode = runfactory.ErrorMissingParameters
+	tests[4].wantText = `Task resolution failed [MissingParameters]: missing parameters: a, z`
+	tests[5].invocation.Spec.Tools = []string{}
+	tests[5].invocation.Spec.Env = []kontextv1alpha1.EnvVar{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := runfactory.ResolveTask(test.agent, test.invocation, scheme)
+			assertResolutionErrorCode(t, err, test.wantCode)
+			if err.Error() != test.wantText {
+				t.Fatalf("error = %q, want %q", err.Error(), test.wantText)
+			}
+		})
+	}
+}
+
+func TestResolveTaskBuildsIsolatedSnapshot(t *testing.T) {
+	agent := taskAgent("task", "", "process ${input}")
+	agent.UID = types.UID("task-uid")
+	agent.Spec.Provider = " OpenAI-Compatible "
+	agent.Spec.Tools = []string{"shell"}
+	agent.Spec.Budget = &kontextv1alpha1.BudgetSpec{Tokens: pointer(int32(42))}
+	agent.Spec.SecretRef = &kontextv1alpha1.SecretRef{Name: "provider"}
+	agent.Spec.KnowledgeConfigMapRef = &kontextv1alpha1.ConfigMapRef{Name: "knowledge"}
+	agent.Spec.ServiceAccountName = "runner"
+	agent.Spec.Runtime = kontextv1alpha1.RuntimeSpec{
+		Image:   "example/runtime:v1",
+		Command: []string{"/runtime"},
+		Args:    []string{"task"},
+		SecurityContext: &kontextv1alpha1.RuntimeSecurityContext{
+			Capabilities: &kontextv1alpha1.RuntimeCapabilities{Drop: []string{"ALL"}},
+		},
+	}
+	value := "literal"
+	agent.Spec.Env = []kontextv1alpha1.EnvVar{{Name: "VALUE", Value: &value}}
+	invocation := taskInvocation("user-run", "task", map[string]string{"input": "résumé\ntext"})
+	invocation.TypeMeta = metav1.TypeMeta{APIVersion: "kontext.dev/v1alpha1", Kind: "AgentRun"}
+	invocation.Labels = map[string]string{"user": "label", podbuilder.LabelAgentName: "wrong"}
+	invocation.Annotations = map[string]string{"note": "keep"}
+	invocation.Finalizers = []string{"example/finalizer"}
+	agentBefore := agent.DeepCopy()
+	invocationBefore := invocation.DeepCopy()
+
+	got, err := runfactory.ResolveTask(agent, invocation, taskResolverScheme(t))
+	if err != nil {
+		t.Fatalf("resolve Task: %v", err)
+	}
+	if !reflect.DeepEqual(agent, agentBefore) {
+		t.Fatal("resolver mutated Agent input")
+	}
+	if !reflect.DeepEqual(invocation, invocationBefore) {
+		t.Fatal("resolver mutated invocation input")
+	}
+	if got.Spec.Goal != "process résumé\ntext" {
+		t.Fatalf("resolved goal = %q", got.Spec.Goal)
+	}
+	if got.Spec.Provider != "openai-compatible" {
+		t.Fatalf("provider = %q, want normalized openai-compatible", got.Spec.Provider)
+	}
+	if got.Labels["user"] != "label" || got.Labels[podbuilder.LabelAgentName] != "task" {
+		t.Fatalf("labels were not preserved and normalized: %#v", got.Labels)
+	}
+	if got.Annotations["note"] != "keep" || !reflect.DeepEqual(got.Finalizers, []string{"example/finalizer"}) {
+		t.Fatalf("invocation metadata was not preserved: %#v", got.ObjectMeta)
+	}
+	if !metav1.IsControlledBy(got, agent) {
+		t.Fatalf("resolved run is not controlled by Agent: %#v", got.OwnerReferences)
+	}
+
+	agent.Spec.Tools[0] = "changed"
+	*agent.Spec.Budget.Tokens = 99
+	agent.Spec.Runtime.Command[0] = "/changed"
+	agent.Spec.Runtime.SecurityContext.Capabilities.Drop[0] = "CHANGED"
+	*agent.Spec.Env[0].Value = "changed"
+	invocation.Spec.Parameters["input"] = "changed"
+	invocation.Labels["user"] = "changed"
+	invocation.Annotations["note"] = "changed"
+	invocation.Finalizers[0] = "changed"
+
+	if got.Spec.Tools[0] != "shell" ||
+		*got.Spec.Budget.Tokens != 42 ||
+		got.Spec.Runtime.Command[0] != "/runtime" ||
+		got.Spec.Runtime.SecurityContext.Capabilities.Drop[0] != "ALL" ||
+		*got.Spec.Env[0].Value != "literal" ||
+		got.Spec.Parameters["input"] != "résumé\ntext" ||
+		got.Labels["user"] != "label" ||
+		got.Annotations["note"] != "keep" ||
+		got.Finalizers[0] != "example/finalizer" {
+		t.Fatalf("resolved run shares data with an input: %#v", got)
+	}
+}
+
+func FuzzResolveTask(f *testing.F) {
+	seeds := []struct {
+		template string
+		key      string
+		value    string
+	}{
+		{template: "${input}", key: "input", value: "value"},
+		{template: "$${input}", key: "", value: ""},
+		{template: "${input}/${input}", key: "input", value: ""},
+		{template: "before ${input} after", key: "input", value: "こんにちは\nworld"},
+		{template: "${missing}", key: "unused", value: "value"},
+		{template: "${", key: "", value: ""},
+		{template: "${bad-name}", key: "bad-name", value: "value"},
+	}
+	for _, seed := range seeds {
+		f.Add(seed.template, seed.key, seed.value)
+	}
+
+	scheme := taskResolverScheme(f)
+	f.Fuzz(func(t *testing.T, template, key, value string) {
+		agent := taskAgent("task", "", template)
+		var parameters map[string]string
+		if key != "" {
+			parameters = map[string]string{key: value}
+		}
+		invocation := taskInvocation("run", "task", parameters)
+		agentBefore := agent.DeepCopy()
+		invocationBefore := invocation.DeepCopy()
+
+		first, firstErr := runfactory.ResolveTask(agent, invocation, scheme)
+		second, secondErr := runfactory.ResolveTask(agent, invocation, scheme)
+
+		if !reflect.DeepEqual(agent, agentBefore) {
+			t.Fatal("resolver mutated Agent input")
+		}
+		if !reflect.DeepEqual(invocation, invocationBefore) {
+			t.Fatal("resolver mutated invocation input")
+		}
+		if !reflect.DeepEqual(first, second) {
+			t.Fatalf("non-deterministic result:\nfirst:  %#v\nsecond: %#v", first, second)
+		}
+		if errorText(firstErr) != errorText(secondErr) {
+			t.Fatalf("non-deterministic errors: %q and %q", errorText(firstErr), errorText(secondErr))
+		}
+		for _, err := range []error{firstErr, secondErr} {
+			if err == nil {
+				continue
+			}
+			var resolutionErr *runfactory.ResolutionError
+			if !errors.As(err, &resolutionErr) {
+				t.Fatalf("resolver returned untyped error %T: %v", err, err)
+			}
+		}
+	})
+}
+
+func taskAgent(name, goal, goalTemplate string) *kontextv1alpha1.Agent {
+	return &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:         kontextv1alpha1.AgentModeTask,
+			Goal:         goal,
+			GoalTemplate: goalTemplate,
+			Provider:     "fake",
+			Model:        "test/model",
+			Runtime:      kontextv1alpha1.RuntimeSpec{Image: "example/runtime:test"},
+		},
+	}
+}
+
+func taskInvocation(name, agentName string, parameters map[string]string) *kontextv1alpha1.AgentRun {
+	var agentRef *kontextv1alpha1.AgentRef
+	if agentName != "" {
+		agentRef = &kontextv1alpha1.AgentRef{Name: agentName}
+	}
+	return &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			AgentRef:   agentRef,
+			Parameters: parameters,
+		},
+	}
+}
+
+func taskResolverScheme(tb testing.TB) *runtime.Scheme {
+	tb.Helper()
+	scheme := runtime.NewScheme()
+	if err := kontextv1alpha1.AddToScheme(scheme); err != nil {
+		tb.Fatalf("add Kontext types to scheme: %v", err)
+	}
+	return scheme
+}
+
+func assertResolutionErrorCode(
+	t *testing.T,
+	err error,
+	want runfactory.ResolutionErrorCode,
+) *runfactory.ResolutionError {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected resolution error %s", want)
+	}
+	var resolutionErr *runfactory.ResolutionError
+	if !errors.As(err, &resolutionErr) {
+		t.Fatalf("error type = %T, want *runfactory.ResolutionError: %v", err, err)
+	}
+	if resolutionErr.Code != want {
+		t.Fatalf("error code = %s, want %s: %v", resolutionErr.Code, want, err)
+	}
+	if !sortStringsEqual(resolutionErr.Names) {
+		t.Fatalf("error names are not sorted: %v", resolutionErr.Names)
+	}
+	return resolutionErr
+}
+
+func sortStringsEqual(values []string) bool {
+	for index := 1; index < len(values); index++ {
+		if strings.Compare(values[index-1], values[index]) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func errorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func pointer[T any](value T) *T {
+	return &value
+}

--- a/internal/runfactory/task_resolver_test.go
+++ b/internal/runfactory/task_resolver_test.go
@@ -182,6 +182,12 @@ func TestResolveTaskReportsStableErrors(t *testing.T) {
 		wantText   string
 	}{
 		{
+			name:     "nil invocation",
+			agent:    taskAgent("task", "goal", ""),
+			wantCode: runfactory.ErrorMissingAgent,
+			wantText: `Task resolution failed [MissingAgent]: Agent "" was not found`,
+		},
+		{
 			name:       "nil Agent",
 			invocation: taskInvocation("run", "missing", nil),
 			wantCode:   runfactory.ErrorMissingAgent,
@@ -213,24 +219,26 @@ func TestResolveTaskReportsStableErrors(t *testing.T) {
 		},
 		{
 			name:       "sorted missing parameters",
-			agent:      taskAgent("task", "${z} ${a}", ""),
+			agent:      taskAgent("task", "", "${z} ${a}"),
 			invocation: taskInvocation("run", "task", nil),
-			wantCode:   runfactory.ErrorInvalidTemplate,
-			wantText:   `Task resolution failed [InvalidTemplate]: Task Agent must configure exactly one of goal or goalTemplate`,
+			wantCode:   runfactory.ErrorMissingParameters,
+			wantText:   `Task resolution failed [MissingParameters]: missing parameters: a, z`,
 		},
 		{
-			name:       "sorted conflicting fields",
-			agent:      taskAgent("task", "goal", ""),
-			invocation: taskInvocation("run", "task", nil),
-			wantCode:   runfactory.ErrorConflictingFields,
-			wantText:   `Task resolution failed [ConflictingFields]: invocation supplies locked fields: env, tools`,
+			name:  "sorted conflicting fields",
+			agent: taskAgent("task", "goal", ""),
+			invocation: &kontextv1alpha1.AgentRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "default"},
+				Spec: kontextv1alpha1.AgentRunSpec{
+					AgentRef: &kontextv1alpha1.AgentRef{Name: "task"},
+					Tools:    []string{},
+					Env:      []kontextv1alpha1.EnvVar{},
+				},
+			},
+			wantCode: runfactory.ErrorConflictingFields,
+			wantText: `Task resolution failed [ConflictingFields]: invocation supplies locked fields: env, tools`,
 		},
 	}
-	tests[4].agent = taskAgent("task", "", "${z} ${a}")
-	tests[4].wantCode = runfactory.ErrorMissingParameters
-	tests[4].wantText = `Task resolution failed [MissingParameters]: missing parameters: a, z`
-	tests[5].invocation.Spec.Tools = []string{}
-	tests[5].invocation.Spec.Env = []kontextv1alpha1.EnvVar{}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- define sparse user-created `AgentRun` CREATE requests as the future explicit Task trigger while keeping every persisted AgentRun a complete immutable execution snapshot
- retain required `goal`, `model`, and `runtime.image` CRD fields so sparse requests are rejected until #83/#84 mutating admission resolves them before final schema validation
- add immutable invocation parameters, strict one-pass `${name}` rendering with `$${name}` escaping, locked execution fields, and stable typed resolver errors
- document Kubernetes admission ordering, Task ownership/concurrency/status semantics, and the deliberate absence of webhook/controller behavior in this PR
- regenerate CRDs and add resolver, fuzz/property, field-coverage, deep-copy, CEL envtest, and controller-safety regression coverage

## Test plan
- [x] `go test ./api/v1alpha1 ./internal/runfactory`
- [x] focused Task persistence API/CEL envtests, including sparse rejection and controller non-observability
- [x] `go test ./internal/runfactory -run='^$' -fuzz='^FuzzResolveTask$' -fuzztime=10s` (493,093 executions, pass)
- [x] `make verify`
- [x] `make test`
- [x] `make vulncheck` (no vulnerabilities found)
- [x] operator image rebuild and existing reference image smoke checks
- [x] isolated kind e2e regression, including Service recast
- [x] isolated keyless eval regression (10/10 cases, 0 collection errors, 0 assertion failures)
- [x] isolated Calico NetworkPolicy and Playwright MCP regression

No webhook is registered and no Task controller behavior is implemented here. Sparse requests remain rejected until the follow-up admission work is installed.

Closes #82