### PR TITLE
Implement Task admission and execution flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,9 @@ jobs:
       - name: Run keyless kind end-to-end scenarios
         run: ./scripts/e2e-kind.sh
 
+      - name: Run Task mode kind scenario
+        run: ./scripts/e2e-kind-task.sh
+
       - name: Run Scheduled mode kind scenario
         run: ./scripts/e2e-kind-scheduled.sh
 

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,10 @@ kind-install: docker-build docker-build-echo docker-build-reporter docker-build-
 test-webhook-kind: ## Run focused webhook TLS and HA acceptance on the current cluster.
 	./scripts/e2e-kind-webhook.sh
 
+.PHONY: test-task-kind
+test-task-kind: ## Run focused Task admission and execution acceptance on the current cluster.
+	./scripts/e2e-kind-task.sh
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Kontext adds two custom resources under `kontext.dev/v1alpha1`, deliberately mir
 | Kontext | Kubernetes analogue | Behavior |
 |---|---|---|
 | `Agent` (mode `Service`) | `Deployment` | Always-on. The controller keeps one live `AgentRun` and re-casts it with backoff when it exits. |
-| `Agent` (mode `Task`) | reusable template | Schema available; the controller reports `UnsupportedMode`. Create a standalone `AgentRun` for one-shot work. |
+| `Agent` (mode `Task`) | reusable template | Creating the Agent runs nothing. A sparse, user-named `AgentRun` resolves the template and starts one immutable execution. |
 | `Agent` (mode `Scheduled`) | `CronJob` | Mints one-shot `AgentRun`s from a standard five-field cron schedule with deadlines, concurrency policy, suspension, and bounded history. |
 | `AgentRun` | `Job` / `Pod` | One bounded execution. Owns exactly one Pod, holds the immutable spec snapshot, the final `.status.result`, and usage. |
 
@@ -276,10 +276,9 @@ scripts/                   kind install + e2e
 
 The current public release is `v0.1.0-alpha.1`. Its GitHub release contains
 the digest-pinned install manifest and versioned multi-architecture images.
-`v1alpha1` is alpha on purpose: the API shape is allowed to evolve. `Service`,
-`Scheduled`, and standalone `AgentRun` paths are implemented and covered by
-envtest and kind e2e. `Task` remains a reserved reusable template; create a
-standalone `AgentRun` for one-shot work.
+`v1alpha1` is alpha on purpose: the API shape is allowed to evolve. `Task`,
+`Service`, `Scheduled`, and standalone `AgentRun` paths are implemented and
+covered by envtest and kind e2e.
 
 ## License
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -139,28 +139,25 @@ One bounded execution. Maps to exactly one Pod. **Spec is immutable after creati
 
 
 When created from an `Agent`, execution fields are snapshotted so the run does
-not drift if the `Agent` changes later. Service and future Scheduled
-controllers continue to create fully resolved runs. Standalone runs continue
-to provide a complete execution spec directly.
+not drift if the `Agent` changes later. Service and Scheduled controllers
+create fully resolved runs. Standalone runs provide a complete execution spec
+directly.
 
 ### Task invocation and resolution
 
-Creating a Task `Agent` never starts work. Once Task CREATE admission is
-installed, a user explicitly triggers it by submitting a user-named
-`AgentRun` whose `spec.agentRef.name` names that Task Agent. Runs may be
-submitted concurrently; there is no generated-name or single-active-run
-restriction.
+Creating a Task `Agent` never starts work. A user explicitly triggers it by
+submitting a user-named `AgentRun` whose `spec.agentRef.name` names that Task
+Agent. Runs may be submitted concurrently; there is no generated-name or
+single-active-run restriction.
 
 A Task invocation request is sparse: it may contain only `agentRef` and
 optional `parameters`. Kubernetes
 [invokes mutating admission first](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
-and then validates the final object against the CRD. Future CREATE admission
-therefore receives the sparse request, resolves it in memory, and returns the
-complete immutable execution snapshot that the API server validates and
-stores. The persisted `AgentRun.spec` always includes `goal`, `model`, and
-`runtime.image`; an unresolved sparse object is never valid stored state.
-Without the Task webhook infrastructure and mutator from #83/#84, the API
-server rejects the sparse request as missing required fields.
+and then validates the final object against the CRD. Task CREATE admission
+receives the sparse request, resolves it in memory, and returns the complete
+immutable execution snapshot that the API server validates and stores. The
+persisted `AgentRun.spec` always includes `goal`, `model`, and `runtime.image`;
+an unresolved sparse object is never valid stored state.
 
 Resolution copies runtime, provider, model, tools, budget, service account,
 Secret reference, knowledge ConfigMap reference, and environment from the
@@ -189,10 +186,11 @@ maps, slices, pointers, and nested values are isolated from later mutation.
 Provider defaults and aliases are normalized while the execution snapshot is
 built, once at this boundary.
 
-The pure resolver in `internal/runfactory` defines these semantics for future
-admission code. This version does not register a webhook, so sparse Task
-CREATE requests remain schema-invalid and cannot reach the AgentRun
-controller.
+The pure resolver in `internal/runfactory` defines these semantics. The CREATE
+webhook fetches the referenced same-namespace Agent through the API reader,
+rejects invalid requests, and returns the resolver's complete object as the
+admission patch. Complete standalone and controller-created runs do not match
+the sparse webhook and remain independent of Task admission.
 
 ### `status`
 
@@ -227,9 +225,8 @@ For Task Agents, `status.lastRunName` is the newest retained owned Task run by
 creation time. `status.runsCreated` is the exact number of currently retained
 owned Task runs, not a lifetime counter. Deleting an owned run can therefore
 decrease `runsCreated` and can move or clear `lastRunName`. These Task meanings
-do not change the existing Service status semantics. Task status
-reconciliation is intentionally deferred; this section defines the contract
-it must implement.
+do not change the existing Service status semantics. `currentRunName` and
+`restarts` stay empty for Task Agents.
 
 ### Contract evolution policy
 

--- a/api/v1alpha1/agentrun_types.go
+++ b/api/v1alpha1/agentrun_types.go
@@ -20,9 +20,9 @@ type AgentRef struct {
 }
 
 // AgentRunSpec defines the desired state of AgentRun. Persisted specs are
-// always complete. A future CREATE mutating webhook may decode a sparse Task
-// request into this type, but it must resolve the required execution fields
-// before API-server schema validation and persistence.
+// always complete. The CREATE mutating webhook decodes sparse Task requests
+// into this type and resolves required execution fields before API-server
+// schema validation and persistence.
 // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="AgentRun spec is immutable"
 // +kubebuilder:validation:XValidation:rule="has(self.agentRef) || !has(self.parameters)",message="parameters require agentRef"
 // +kubebuilder:validation:XValidation:rule="has(self.goal) && has(self.model) && has(self.runtime)",message="persisted AgentRun spec must contain a complete execution snapshot"

--- a/api/v1alpha1/task_contract_test.go
+++ b/api/v1alpha1/task_contract_test.go
@@ -7,11 +7,11 @@ import (
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 )
 
-func TestSparseTaskCreateRequestDecodesForFutureMutation(t *testing.T) {
+func TestSparseTaskCreateRequestDecodesForAdmissionMutation(t *testing.T) {
 	// Kubernetes invokes mutating admission before it validates the final
-	// object against the CRD. The future Task webhook can therefore decode this
-	// request shape, resolve it in memory, and return a complete object. It must
-	// never marshal or persist this unresolved value.
+	// object against the CRD. The Task webhook decodes this request shape,
+	// resolves it in memory, and returns a complete object. It must never
+	// marshal or persist this unresolved value.
 	data := []byte(`{"agentRef":{"name":"task"},"parameters":{"input":"value"}}`)
 	var invocation kontextv1alpha1.AgentRunSpec
 	if err := json.Unmarshal(data, &invocation); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,7 +110,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	webhookServer.Register(webhooktls.DefaultWebhookPath, webhooktls.Handler())
+	webhookServer.Register(
+		webhooktls.DefaultWebhookPath,
+		webhooktls.Handler(mgr.GetAPIReader(), mgr.GetScheme()),
+	)
 	if err := mgr.Add(certificateLifecycle); err != nil {
 		setupLog.Error(err, "unable to add webhook certificate lifecycle")
 		os.Exit(1)

--- a/config/crd/bases/kontext.dev_agentruns.yaml
+++ b/config/crd/bases/kontext.dev_agentruns.yaml
@@ -51,9 +51,9 @@ spec:
           spec:
             description: |-
               AgentRunSpec defines the desired state of AgentRun. Persisted specs are
-              always complete. A future CREATE mutating webhook may decode a sparse Task
-              request into this type, but it must resolve the required execution fields
-              before API-server schema validation and persistence.
+              always complete. The CREATE mutating webhook decodes sparse Task requests
+              into this type and resolves required execution fields before API-server
+              schema validation and persistence.
             properties:
               agentRef:
                 description: AgentRef links an AgentRun to its owning Agent.

--- a/deploy/examples/v1alpha1/README.md
+++ b/deploy/examples/v1alpha1/README.md
@@ -52,6 +52,15 @@ results are opt-in.
 `/kontext/knowledge`. It is useful for small fixtures and operating
 instructions; it is not production retrieval or RAG.
 
+## Task mode
+
+Apply `echo-task-agent.yaml`, then `echo-task-invocation.yaml`. The first
+manifest creates a reusable parameterized definition and no run. The second is
+a sparse invocation: admission renders `${subject}`, preserves `$${subject}` as
+literal text, snapshots the Agent execution fields, and attaches ownership.
+Inspect the complete stored spec with
+`kubectl get agentrun echo-task-docs -o yaml`.
+
 ## Service mode
 
 `echo-service-agent.yaml` is intentionally long-running. It omits

--- a/deploy/examples/v1alpha1/echo-task-agent.yaml
+++ b/deploy/examples/v1alpha1/echo-task-agent.yaml
@@ -1,0 +1,13 @@
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: echo-task
+spec:
+  mode: Task
+  goalTemplate: Summarize ${subject}; preserve the literal $${subject}.
+  provider: echo
+  model: echo-model
+  runtime:
+    image: ghcr.io/mfs-code/kontext-echo:RELEASE_TAG
+  budget:
+    wallclock: 2m

--- a/deploy/examples/v1alpha1/echo-task-invocation.yaml
+++ b/deploy/examples/v1alpha1/echo-task-invocation.yaml
@@ -1,0 +1,9 @@
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: echo-task-docs
+spec:
+  agentRef:
+    name: echo-task
+  parameters:
+    subject: Task admission

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ when it dies.
 | Kontext | Kubernetes analogue | Behavior |
 |---|---|---|
 | `Agent` (mode `Service`) | `Deployment` | Always-on. The controller keeps one live `AgentRun` and re-casts it when it exits. |
-| `Agent` (mode `Task`) | reusable template | Schema available; the controller reports `UnsupportedMode`. Use a standalone `AgentRun` for one-shot work. |
+| `Agent` (mode `Task`) | reusable template | Creating the Agent runs nothing. Sparse named invocations become immutable owned `AgentRun`s. |
 | `Agent` (mode `Scheduled`) | `CronJob` | Mints one-shot `AgentRun`s from standard five-field cron slots with safe overlap and deadline policy. |
 | `AgentRun` | `Job` / `Pod` | One bounded execution. Owns exactly one Pod and holds `.status.result`. |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,6 +18,9 @@ Kontext maintains and tests the following paths:
   bounded terminal result and measured usage in status.
 - An `Agent` in `Service` mode keeps one active child `AgentRun`. When that run
   ends or its Pod disappears, the controller creates a new run with backoff.
+- An `Agent` in `Task` mode creates no work by itself. A sparse, user-named
+  `AgentRun` resolves through fail-closed admission into an immutable owned
+  snapshot; concurrent invocations are supported.
 - An `Agent` in `Scheduled` mode creates one-shot children from standard
   five-field cron slots. It supports IANA time zones, starting deadlines,
   `Allow`/`Forbid` overlap policy, suspension, and completed-run history limits.
@@ -27,14 +30,6 @@ Kontext maintains and tests the following paths:
 - Release images support `linux/amd64` and `linux/arm64`.
 - The maintained Go reference runtime supports its documented fake, Anthropic,
   OpenAI, and OpenAI-compatible paths and bounded tool loop.
-
-The following mode exists in the alpha API but does not have controller
-behavior:
-
-- `Agent` mode `Task`
-
-The controller reports an `UnsupportedMode` condition for Task. Callers that
-need one-shot work outside a schedule must create an `AgentRun` directly.
 
 Scheduled mode intentionally does not provide catch-up bursts. After downtime,
 only the latest due slot is considered and only while it remains within
@@ -275,8 +270,11 @@ kubectl describe agentrun <name> -n <namespace>
 
 Inspect `status.phase`, `status.message`, `status.conditions`, `status.podName`,
 and the completion timestamps. For an `Agent`, inspect `Ready` and
-`Progressing`. `UnsupportedMode` means the mode is reserved but not
-implemented.
+`Progressing`. For Task admission failures, inspect the API error for the
+stable resolution class (`MissingAgent`, `WrongMode`, `InvalidTemplate`,
+`MissingParameters`, `UnusedParameters`, or `ConflictingFields`). A matching
+sparse request fails closed while the webhook is unavailable; complete
+standalone and controller-created runs do not depend on that webhook.
 
 ### Check the workload Pod
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,10 +57,44 @@ kubectl get agentrun review -o jsonpath='{.status.result}{"\n"}'
 a special "reasoning" channel. `.status.result` is the bounded terminal
 summary projected onto the custom resource.
 
+## Reuse a Task template
+
+Create a Task Agent and a sparse invocation:
+
+```yaml
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: echo-task
+spec:
+  mode: Task
+  goalTemplate: "Summarize ${subject}"
+  provider: echo
+  model: echo-model
+  runtime:
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+---
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: echo-task-release
+spec:
+  agentRef:
+    name: echo-task
+  parameters:
+    subject: this release
+```
+
+Creating the Agent alone starts no Pod. Creating the sparse `AgentRun` causes
+admission to render the goal and copy the Agent's execution fields into one
+immutable, owned snapshot. Inspect the stored form with
+`kubectl get agentrun echo-task-release -o yaml`.
+
 ## Clean up this demo
 
 ```bash
 kubectl delete agentrun review --ignore-not-found=true
+kubectl delete agent echo-task --ignore-not-found=true
 ```
 
 Uninstalling the control plane is covered in [Releases](/docs/releases).

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -19,7 +19,8 @@ model, budgets, and related fields.
   restored across recasts.
 - **Task** — reusable one-shot template. Creating the Agent does not execute
   it. A user explicitly triggers work by creating a named `AgentRun` that
-  references it. Task controller status reconciliation remains reserved.
+  references it. Admission resolves the immutable execution snapshot before
+  storage, and the controller projects retained child status.
 - **Scheduled** — cron-style one-shot execution. The controller evaluates a
   standard five-field expression in the configured IANA time zone and mints at
   most the latest eligible slot. `Forbid` is the default overlap policy;
@@ -44,11 +45,11 @@ progress; `currentRunName`, `restarts`, and backoff apply only to Service mode.
 cleared when history limits prune every child. `lastScheduleTime` remains the
 historical latest observed slot even after that child is pruned.
 
-### Future Task invocation requests
+### Task invocation requests
 
 A Task Agent configures exactly one static `goal` or parameterized
-`goalTemplate`. Once the Task CREATE webhook is installed, its sparse request
-shape contains only `agentRef` and optional string `parameters`:
+`goalTemplate`. Its sparse request shape contains only `agentRef` and optional
+string `parameters`:
 
 ```yaml
 apiVersion: kontext.dev/v1alpha1
@@ -69,13 +70,11 @@ references, environment, and the concrete goal are locked to the Agent
 template. Use a standalone run or another Agent definition when those fields
 must differ.
 
-This YAML is an admission request shape, not a valid persisted AgentRun in the
-current release. Kubernetes runs mutating admission before final CRD
-validation, so #84 will resolve the request before the API server validates and
-stores it. Persisted AgentRuns always contain `goal`, `model`, and
-`runtime.image`. Until the webhook infrastructure and mutator from #83/#84 are
-installed, the API server rejects sparse CREATE requests; use standalone runs
-for end-to-end execution.
+Kubernetes runs mutating admission before final CRD validation. The webhook
+resolves this request against the same-namespace Task Agent, and the API server
+validates and stores only the complete snapshot. Persisted AgentRuns always
+contain `goal`, `model`, and `runtime.image`. If admission cannot resolve a
+matching sparse request, creation fails closed with an actionable error.
 
 Task runs are user-named and can execute concurrently. For Task status,
 `lastRunName` means the newest retained owned run by creation time, while

--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -52,10 +52,77 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	case kontextv1alpha1.AgentModeScheduled:
 		return r.reconcileScheduled(ctx, &agent)
 	case kontextv1alpha1.AgentModeTask:
-		return ctrl.Result{}, r.setAgentStatus(ctx, &agent, agent.Status, conditions.UnsupportedMode(string(agent.Spec.Mode))...)
+		return r.reconcileTask(ctx, &agent)
 	default:
 		return ctrl.Result{}, r.setAgentStatus(ctx, &agent, agent.Status, conditions.InvalidMode(string(agent.Spec.Mode))...)
 	}
+}
+
+func (r *AgentReconciler) reconcileTask(
+	ctx context.Context,
+	agent *kontextv1alpha1.Agent,
+) (ctrl.Result, error) {
+	var children kontextv1alpha1.AgentRunList
+	if err := r.List(ctx, &children, client.InNamespace(agent.Namespace)); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var newest *kontextv1alpha1.AgentRun
+	var retained int32
+	for i := range children.Items {
+		run := &children.Items[i]
+		if !metav1.IsControlledBy(run, agent) {
+			continue
+		}
+		if retained == maxRunSuffix {
+			return ctrl.Result{}, fmt.Errorf(
+				"Task Agent %s/%s owns more than %d retained AgentRuns",
+				agent.Namespace,
+				agent.Name,
+				maxRunSuffix,
+			)
+		}
+		retained++
+		if newest == nil ||
+			run.CreationTimestamp.After(newest.CreationTimestamp.Time) ||
+			run.CreationTimestamp.Equal(&newest.CreationTimestamp) && run.Name > newest.Name {
+			newest = run
+		}
+	}
+
+	next := kontextv1alpha1.AgentStatus{
+		RunsCreated:        retained,
+		ObservedGeneration: agent.Generation,
+	}
+	if newest != nil {
+		next.LastRunName = newest.Name
+	}
+
+	if err := runfactory.ValidateTask(agent); err != nil {
+		return ctrl.Result{}, r.setAgentStatus(ctx, agent, next, metav1.Condition{
+			Type:    conditions.Ready,
+			Status:  metav1.ConditionFalse,
+			Reason:  "InvalidTemplate",
+			Message: err.Error(),
+		}, metav1.Condition{
+			Type:    conditions.Progressing,
+			Status:  metav1.ConditionFalse,
+			Reason:  "InvalidTemplate",
+			Message: "Task invocations are blocked until the template is valid.",
+		})
+	}
+
+	return ctrl.Result{}, r.setAgentStatus(ctx, agent, next, metav1.Condition{
+		Type:    conditions.Ready,
+		Status:  metav1.ConditionTrue,
+		Reason:  "TemplateReady",
+		Message: "Task template is ready for invocations.",
+	}, metav1.Condition{
+		Type:    conditions.Progressing,
+		Status:  metav1.ConditionFalse,
+		Reason:  "Idle",
+		Message: "Task Agents run only when an AgentRun is created.",
+	})
 }
 
 func (r *AgentReconciler) reconcileService(ctx context.Context, agent *kontextv1alpha1.Agent) (ctrl.Result, error) {

--- a/internal/controller/agent_controller_test.go
+++ b/internal/controller/agent_controller_test.go
@@ -880,7 +880,7 @@ func TestAgentReconcilerUsesOwnedCanonicalRunSequence(t *testing.T) {
 	}
 }
 
-func TestAgentReconcilerUnsupportedMode(t *testing.T) {
+func TestAgentReconcilerProjectsTaskReadinessAndRetainedChildren(t *testing.T) {
 	ctx := context.Background()
 	agent := &kontextv1alpha1.Agent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -888,10 +888,10 @@ func TestAgentReconcilerUnsupportedMode(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: kontextv1alpha1.AgentSpec{
-			Mode:    kontextv1alpha1.AgentModeTask,
-			Goal:    "one shot",
-			Model:   "echo-model",
-			Runtime: echoRuntimeSpec(),
+			Mode:         kontextv1alpha1.AgentModeTask,
+			GoalTemplate: "Review ${area}.",
+			Model:        "echo-model",
+			Runtime:      echoRuntimeSpec(),
 		},
 	}
 	if err := k8sClient.Create(ctx, agent); err != nil {
@@ -904,22 +904,108 @@ func TestAgentReconcilerUnsupportedMode(t *testing.T) {
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
 		t.Fatalf("get agent: %v", err)
 	}
-	found := false
+	if updated.Status.RunsCreated != 0 ||
+		updated.Status.LastRunName != "" ||
+		updated.Status.CurrentRunName != "" ||
+		updated.Status.Restarts != 0 ||
+		updated.Status.ObservedGeneration != updated.Generation {
+		t.Fatalf("new Task Agent minted or projected a run: %#v", updated.Status)
+	}
+	ready := false
 	for _, condition := range updated.Status.Conditions {
-		if condition.Type == conditions.Ready && condition.Reason == "UnsupportedMode" {
-			if condition.ObservedGeneration != updated.Generation {
-				t.Fatalf(
-					"condition observed generation %d, want %d",
-					condition.ObservedGeneration,
-					updated.Generation,
-				)
-			}
-			found = true
-			break
+		if condition.Type == conditions.Ready &&
+			condition.Status == metav1.ConditionTrue &&
+			condition.Reason == "TemplateReady" &&
+			condition.ObservedGeneration == updated.Generation {
+			ready = true
 		}
 	}
-	if !found {
-		t.Fatalf("expected UnsupportedMode condition, got %#v", updated.Status.Conditions)
+	if !ready {
+		t.Fatalf("expected ready Task template, got %#v", updated.Status.Conditions)
+	}
+
+	first := taskRunForAgent(agent, "z-first")
+	createOwnedAgentRun(ctx, t, agent, first)
+	time.Sleep(1100 * time.Millisecond)
+	second := taskRunForAgent(agent, "a-second")
+	createOwnedAgentRun(ctx, t, agent, second)
+
+	ownedWithoutLabel := taskRunForAgent(agent, "owned-without-label")
+	ownedWithoutLabel.Labels = nil
+	time.Sleep(1100 * time.Millisecond)
+	createOwnedAgentRun(ctx, t, agent, ownedWithoutLabel)
+
+	unrelated := taskRunForAgent(agent, "unrelated-same-label")
+	if err := k8sClient.Create(ctx, unrelated); err != nil {
+		t.Fatalf("create unrelated same-label run: %v", err)
+	}
+
+	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get projected Task Agent: %v", err)
+	}
+	if updated.Status.RunsCreated != 3 ||
+		updated.Status.LastRunName != ownedWithoutLabel.Name ||
+		updated.Status.CurrentRunName != "" ||
+		updated.Status.Restarts != 0 {
+		t.Fatalf("unexpected concurrent Task projection: %#v", updated.Status)
+	}
+
+	if err := k8sClient.Delete(ctx, ownedWithoutLabel); err != nil {
+		t.Fatalf("delete newest retained Task run: %v", err)
+	}
+	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get Task Agent after retained deletion: %v", err)
+	}
+	if updated.Status.RunsCreated != 2 || updated.Status.LastRunName != second.Name {
+		t.Fatalf("retained Task projection did not decrease exactly: %#v", updated.Status)
+	}
+
+	updated.Spec.GoalTemplate = "Review ${area} for ${"
+	if err := k8sClient.Update(ctx, &updated); err != nil {
+		t.Fatalf("update Task template: %v", err)
+	}
+	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get invalid Task Agent status: %v", err)
+	}
+	if updated.Status.ObservedGeneration != updated.Generation {
+		t.Fatalf(
+			"observed generation = %d, want %d",
+			updated.Status.ObservedGeneration,
+			updated.Generation,
+		)
+	}
+	for _, condition := range updated.Status.Conditions {
+		if condition.Type == conditions.Ready &&
+			condition.Status == metav1.ConditionFalse &&
+			condition.Reason == "InvalidTemplate" {
+			return
+		}
+	}
+	t.Fatalf("malformed Task template remained Ready: %#v", updated.Status.Conditions)
+}
+
+func taskRunForAgent(
+	agent *kontextv1alpha1.Agent,
+	name string,
+) *kontextv1alpha1.AgentRun {
+	return &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: agent.Namespace,
+			Labels: map[string]string{
+				podbuilder.LabelAgentName: agent.Name,
+			},
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			AgentRef:   &kontextv1alpha1.AgentRef{Name: agent.Name},
+			Parameters: map[string]string{"area": name},
+			Goal:       "Review " + name + ".",
+			Model:      agent.Spec.Model,
+			Runtime:    agent.Spec.Runtime,
+		},
 	}
 }
 

--- a/internal/controller/task_api_validation_test.go
+++ b/internal/controller/task_api_validation_test.go
@@ -200,9 +200,9 @@ func TestAgentRunParametersAndSpecAreImmutable(t *testing.T) {
 }
 
 func TestAgentRunReconcilerCannotObserveAdmittedSparseSpec(t *testing.T) {
-	// Kubernetes mutating admission runs before final CRD validation. Until the
-	// future Task mutator is installed, this sparse CREATE must fail validation,
-	// leaving no object for the AgentRun controller to reconcile.
+	// This controller-only envtest intentionally installs no webhook. The CRD
+	// must reject a sparse CREATE by itself, leaving no unresolved object for
+	// the AgentRun controller to observe if admission is absent.
 	ctx := context.Background()
 	name := "sparse-run-never-admitted"
 	run := unstructuredAgentRun(name, map[string]any{

--- a/internal/runfactory/runfactory.go
+++ b/internal/runfactory/runfactory.go
@@ -152,6 +152,26 @@ func ResolveTask(
 	return resolved, nil
 }
 
+// ValidateTask reports whether a Task Agent can resolve invocations. Missing
+// invocation parameters are expected here; template syntax and mode are not.
+func ValidateTask(agent *kontextv1alpha1.Agent) error {
+	if agent == nil {
+		return &ResolutionError{Code: ErrorMissingAgent}
+	}
+	if agent.Spec.Mode != kontextv1alpha1.AgentModeTask {
+		return &ResolutionError{
+			Code:      ErrorWrongMode,
+			AgentName: agent.Name,
+			Mode:      agent.Spec.Mode,
+		}
+	}
+	_, err := resolveGoal(agent.Spec, nil)
+	if resolutionErr, ok := err.(*ResolutionError); ok && resolutionErr.Code == ErrorMissingParameters {
+		return nil
+	}
+	return err
+}
+
 func lockedInvocationFields(spec kontextv1alpha1.AgentRunSpec) []string {
 	fields := make([]string, 0, 10)
 	if spec.Goal != "" {

--- a/internal/webhooktls/envtest_test.go
+++ b/internal/webhooktls/envtest_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
 )
 
 func TestEnvtestRealTLSAndNarrowAdmissionBypass(t *testing.T) {
@@ -77,7 +79,7 @@ func TestEnvtestRealTLSAndNarrowAdmissionBypass(t *testing.T) {
 			TLSOption(store),
 		},
 	})
-	server.Register(DefaultWebhookPath, Handler())
+	server.Register(DefaultWebhookPath, Handler(k8sClient, scheme))
 	serverContext, cancelServer := context.WithCancel(ctx)
 	t.Cleanup(cancelServer)
 	serverErrors := make(chan error, 1)
@@ -101,17 +103,198 @@ func TestEnvtestRealTLSAndNarrowAdmissionBypass(t *testing.T) {
 		t.Fatalf("point envtest registration at TLS server: %v", err)
 	}
 
+	staticAgent := testTaskAgent("static-task", "static goal", "")
+	if err := k8sClient.Create(ctx, staticAgent); err != nil {
+		t.Fatalf("create static Task Agent: %v", err)
+	}
+	templateAgent := testTaskAgent(
+		"template-task",
+		"",
+		"Summarize ${area}; keep $${literal}; repeat ${area}.",
+	)
+	if err := k8sClient.Create(ctx, templateAgent); err != nil {
+		t.Fatalf("create parameterized Task Agent: %v", err)
+	}
+	badTemplateAgent := testTaskAgent("bad-template", "", "broken ${name")
+	if err := k8sClient.Create(ctx, badTemplateAgent); err != nil {
+		t.Fatalf("create malformed Task Agent: %v", err)
+	}
+	serviceAgent := testTaskAgent("service-agent", "serve", "")
+	serviceAgent.Spec.Mode = kontextv1alpha1.AgentModeService
+	if err := k8sClient.Create(ctx, serviceAgent); err != nil {
+		t.Fatalf("create Service Agent: %v", err)
+	}
+	scheduledAgent := testTaskAgent("scheduled-agent", "scheduled", "")
+	scheduledAgent.Spec.Mode = kontextv1alpha1.AgentModeScheduled
+	scheduledAgent.Spec.Schedule = &kontextv1alpha1.ScheduleSpec{Expression: "0 * * * *"}
+	if err := k8sClient.Create(ctx, scheduledAgent); err != nil {
+		t.Fatalf("create Scheduled Agent: %v", err)
+	}
+
 	complete := testAgentRun("complete-bypass", completeSpec())
 	if err := k8sClient.Create(ctx, complete); err != nil {
 		t.Fatalf("create nonmatching complete AgentRun: %v", err)
 	}
 
-	sparse := testAgentRun("sparse-through-webhook", map[string]any{
-		"agentRef": map[string]any{"name": "task"},
+	staticInvocation := testAgentRun("static-through-webhook", map[string]any{
+		"agentRef": map[string]any{"name": staticAgent.Name},
 	})
-	err = k8sClient.Create(ctx, sparse)
+	if err := k8sClient.Create(ctx, staticInvocation); err != nil {
+		t.Fatalf("create static sparse Task invocation: %v", err)
+	}
+	var staticRun kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, client.ObjectKey{
+		Namespace: "default",
+		Name:      staticInvocation.GetName(),
+	}, &staticRun); err != nil {
+		t.Fatalf("get resolved static Task run: %v", err)
+	}
+	assertResolvedTaskRun(t, &staticRun, staticAgent, "static goal", nil)
+
+	templateInvocation := testAgentRun("template-through-webhook", map[string]any{
+		"agentRef":   map[string]any{"name": templateAgent.Name},
+		"parameters": map[string]any{"area": "API\nserver"},
+	})
+	templateInvocation.SetLabels(map[string]string{"example.test/source": "envtest"})
+	if err := k8sClient.Create(ctx, templateInvocation); err != nil {
+		t.Fatalf("create parameterized sparse Task invocation: %v", err)
+	}
+	var templateRun kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, client.ObjectKey{
+		Namespace: "default",
+		Name:      templateInvocation.GetName(),
+	}, &templateRun); err != nil {
+		t.Fatalf("get resolved parameterized Task run: %v", err)
+	}
+	assertResolvedTaskRun(
+		t,
+		&templateRun,
+		templateAgent,
+		"Summarize API\nserver; keep ${literal}; repeat API\nserver.",
+		map[string]string{"area": "API\nserver"},
+	)
+	if templateRun.Labels["example.test/source"] != "envtest" {
+		t.Fatalf("invocation label was not retained: %#v", templateRun.Labels)
+	}
+
+	rejections := []struct {
+		name      string
+		agentName string
+		spec      map[string]any
+		want      string
+	}{
+		{
+			name:      "missing-agent",
+			agentName: "does-not-exist",
+			want:      "MissingAgent",
+		},
+		{
+			name:      "wrong-mode",
+			agentName: serviceAgent.Name,
+			want:      "WrongMode",
+		},
+		{
+			name:      "missing-parameter",
+			agentName: templateAgent.Name,
+			want:      "missing parameters: area",
+		},
+		{
+			name:      "unused-parameter",
+			agentName: templateAgent.Name,
+			spec:      map[string]any{"parameters": map[string]any{"area": "api", "extra": "no"}},
+			want:      "unused parameters: extra",
+		},
+		{
+			name:      "static-parameters",
+			agentName: staticAgent.Name,
+			spec:      map[string]any{"parameters": map[string]any{"extra": "no"}},
+			want:      "unused parameters: extra",
+		},
+		{
+			name:      "malformed-template",
+			agentName: badTemplateAgent.Name,
+			spec:      map[string]any{"parameters": map[string]any{"name": "value"}},
+			want:      "InvalidTemplate",
+		},
+		{
+			name:      "locked-goal",
+			agentName: staticAgent.Name,
+			spec:      map[string]any{"goal": "override"},
+			want:      "locked fields: goal",
+		},
+	}
+	for _, test := range rejections {
+		t.Run(test.name, func(t *testing.T) {
+			spec := map[string]any{
+				"agentRef": map[string]any{"name": test.agentName},
+			}
+			for key, value := range test.spec {
+				spec[key] = value
+			}
+			err := k8sClient.Create(ctx, testAgentRun("reject-"+test.name, spec))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("create error = %v, want text %q", err, test.want)
+			}
+		})
+	}
+
+	originalGoal := templateRun.Spec.Goal
+	templateRun.Spec.Goal = "mutated"
+	err = k8sClient.Update(ctx, &templateRun)
 	if !apierrors.IsInvalid(err) {
-		t.Fatalf("sparse request should pass TLS admission then fail schema validation, got %v", err)
+		t.Fatalf("resolved Task spec update should be immutable, got %v", err)
+	}
+	templateRun.Spec.Goal = originalGoal
+
+	completeService := testAgentRun("complete-service-bypass", map[string]any{
+		"agentRef": map[string]any{"name": serviceAgent.Name},
+		"goal":     "controller snapshot",
+		"provider": "echo",
+		"model":    "echo-model",
+		"runtime":  map[string]any{"image": "example.invalid/controller:test"},
+	})
+	if err := k8sClient.Create(ctx, completeService); err != nil {
+		t.Fatalf("create complete Service snapshot: %v", err)
+	}
+	var persistedService unstructured.Unstructured
+	persistedService.SetGroupVersionKind(completeService.GroupVersionKind())
+	if err := k8sClient.Get(ctx, client.ObjectKey{
+		Namespace: "default",
+		Name:      completeService.GetName(),
+	}, &persistedService); err != nil {
+		t.Fatalf("get complete Service snapshot: %v", err)
+	}
+	if !reflect.DeepEqual(persistedService.Object["spec"], completeService.Object["spec"]) {
+		t.Fatalf(
+			"complete Service snapshot changed:\ngot:  %#v\nwant: %#v",
+			persistedService.Object["spec"],
+			completeService.Object["spec"],
+		)
+	}
+	completeScheduled := testAgentRun("complete-scheduled-bypass", map[string]any{
+		"agentRef": map[string]any{"name": scheduledAgent.Name},
+		"goal":     "scheduled controller snapshot",
+		"provider": "echo",
+		"model":    "echo-model",
+		"runtime":  map[string]any{"image": "example.invalid/controller:test"},
+	})
+	if err := k8sClient.Create(ctx, completeScheduled); err != nil {
+		t.Fatalf("create complete Scheduled snapshot: %v", err)
+	}
+	var persistedScheduled unstructured.Unstructured
+	persistedScheduled.SetGroupVersionKind(completeScheduled.GroupVersionKind())
+	if err := k8sClient.Get(ctx, client.ObjectKey{
+		Namespace: "default",
+		Name:      completeScheduled.GetName(),
+	}, &persistedScheduled); err != nil {
+		t.Fatalf("get complete Scheduled snapshot: %v", err)
+	}
+	if !reflect.DeepEqual(persistedScheduled.Object["spec"], completeScheduled.Object["spec"]) {
+		t.Fatalf(
+			"complete Scheduled snapshot changed:\ngot:  %#v\nwant: %#v",
+			persistedScheduled.Object["spec"],
+			completeScheduled.Object["spec"],
+		)
 	}
 
 	if err := k8sClient.Get(ctx, client.ObjectKey{Name: DefaultWebhookName}, &registration); err != nil {
@@ -122,7 +305,7 @@ func TestEnvtestRealTLSAndNarrowAdmissionBypass(t *testing.T) {
 		t.Fatalf("break admission trust: %v", err)
 	}
 	untrustedSparse := testAgentRun("sparse-fails-closed", map[string]any{
-		"agentRef": map[string]any{"name": "task"},
+		"agentRef": map[string]any{"name": staticAgent.Name},
 	})
 	err = k8sClient.Create(ctx, untrustedSparse)
 	if err == nil || apierrors.IsInvalid(err) || !strings.Contains(err.Error(), "failed calling webhook") {
@@ -179,5 +362,51 @@ func completeSpec() map[string]any {
 		"runtime": map[string]any{
 			"image": "example.invalid/runtime:test",
 		},
+	}
+}
+
+func testTaskAgent(name string, goal string, goalTemplate string) *kontextv1alpha1.Agent {
+	return &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:         kontextv1alpha1.AgentModeTask,
+			Goal:         goal,
+			GoalTemplate: goalTemplate,
+			Provider:     " ECHO ",
+			Model:        "echo-model",
+			Tools:        []string{"shell"},
+			Budget:       &kontextv1alpha1.BudgetSpec{Wallclock: "2m"},
+			Runtime: kontextv1alpha1.RuntimeSpec{
+				Image: "example.invalid/task:test",
+				Args:  []string{"run"},
+			},
+		},
+	}
+}
+
+func assertResolvedTaskRun(
+	t *testing.T,
+	run *kontextv1alpha1.AgentRun,
+	agent *kontextv1alpha1.Agent,
+	goal string,
+	parameters map[string]string,
+) {
+	t.Helper()
+	if run.Spec.AgentRef == nil || run.Spec.AgentRef.Name != agent.Name ||
+		run.Spec.Goal != goal ||
+		run.Spec.Provider != "echo" ||
+		run.Spec.Model != agent.Spec.Model ||
+		run.Spec.Runtime.Image != agent.Spec.Runtime.Image ||
+		!reflect.DeepEqual(run.Spec.Parameters, parameters) {
+		t.Fatalf("persisted Task snapshot is incomplete: %#v", run.Spec)
+	}
+	if run.Labels[podbuilder.LabelAgentName] != agent.Name {
+		t.Fatalf("canonical Agent label = %#v", run.Labels)
+	}
+	if !metav1.IsControlledBy(run, agent) {
+		t.Fatalf("Task run is not controller-owned by Agent: %#v", run.OwnerReferences)
+	}
+	if !reflect.DeepEqual(run.Status, kontextv1alpha1.AgentRunStatus{}) {
+		t.Fatalf("admission unexpectedly created observable status: %#v", run.Status)
 	}
 }

--- a/internal/webhooktls/envtest_test.go
+++ b/internal/webhooktls/envtest_test.go
@@ -137,7 +137,8 @@ func TestEnvtestRealTLSAndNarrowAdmissionBypass(t *testing.T) {
 	}
 
 	staticInvocation := testAgentRun("static-through-webhook", map[string]any{
-		"agentRef": map[string]any{"name": staticAgent.Name},
+		"agentRef":   map[string]any{"name": staticAgent.Name},
+		"parameters": map[string]any{},
 	})
 	if err := k8sClient.Create(ctx, staticInvocation); err != nil {
 		t.Fatalf("create static sparse Task invocation: %v", err)

--- a/internal/webhooktls/handler.go
+++ b/internal/webhooktls/handler.go
@@ -2,17 +2,68 @@ package webhooktls
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/runfactory"
 )
 
-type PlumbingHandler struct{}
-
-func (PlumbingHandler) Handle(_ context.Context, _ admission.Request) admission.Response {
-	return admission.Allowed("Task mutation is reserved for issue #84")
+type TaskHandler struct {
+	reader client.Reader
+	scheme *runtime.Scheme
 }
 
-func Handler() http.Handler {
-	return &admission.Webhook{Handler: PlumbingHandler{}}
+func (h *TaskHandler) Handle(ctx context.Context, request admission.Request) admission.Response {
+	var invocation kontextv1alpha1.AgentRun
+	if err := json.Unmarshal(request.Object.Raw, &invocation); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	referenceName := ""
+	if invocation.Spec.AgentRef != nil {
+		referenceName = invocation.Spec.AgentRef.Name
+	}
+	if referenceName == "" {
+		return admission.Allowed("AgentRun does not reference a Task Agent")
+	}
+	namespace := request.Namespace
+	if namespace == "" {
+		namespace = invocation.Namespace
+	}
+	invocation.Namespace = namespace
+
+	var agent kontextv1alpha1.Agent
+	err := h.reader.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      referenceName,
+	}, &agent)
+	if apierrors.IsNotFound(err) {
+		return admission.Denied((&runfactory.ResolutionError{
+			Code:      runfactory.ErrorMissingAgent,
+			AgentName: referenceName,
+		}).Error())
+	}
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	resolved, err := runfactory.ResolveTask(&agent, &invocation, h.scheme)
+	if err != nil {
+		return admission.Denied(err.Error())
+	}
+	mutated, err := json.Marshal(resolved)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(request.Object.Raw, mutated)
+}
+
+func Handler(reader client.Reader, scheme *runtime.Scheme) http.Handler {
+	return &admission.Webhook{Handler: &TaskHandler{reader: reader, scheme: scheme}}
 }

--- a/internal/webhooktls/handler.go
+++ b/internal/webhooktls/handler.go
@@ -37,6 +37,9 @@ func (h *TaskHandler) Handle(ctx context.Context, request admission.Request) adm
 		namespace = invocation.Namespace
 	}
 	invocation.Namespace = namespace
+	if len(invocation.Spec.Parameters) == 0 {
+		invocation.Spec.Parameters = nil
+	}
 
 	var agent kontextv1alpha1.Agent
 	err := h.reader.Get(ctx, client.ObjectKey{

--- a/scripts/e2e-kind-task.sh
+++ b/scripts/e2e-kind-task.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Focused Task admission, execution, status, and ownership acceptance.
+set -euo pipefail
+
+# shellcheck source=scripts/lib/common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+ROOT_DIR="$(repo_root)"
+APPLY_EXAMPLE="${ROOT_DIR}/scripts/apply-example.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kontext-task-e2e.XXXXXX")"
+
+cleanup() {
+  kubectl delete agent echo-task task-static task-invalid task-wrong-mode \
+    --ignore-not-found=true --wait=false >/dev/null 2>&1 || true
+  kubectl delete agentrun \
+    echo-task-docs task-static-run task-concurrent-a task-concurrent-b \
+    --ignore-not-found=true --wait=false >/dev/null 2>&1 || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+need kubectl jq
+cleanup
+mkdir -p "${TMP_DIR}"
+
+wait_for_agent_count() {
+  local expected="$1"
+  for _ in $(seq 1 120); do
+    local count=""
+    count="$(kubectl get agent echo-task -o jsonpath='{.status.runsCreated}' 2>/dev/null || true)"
+    [[ "${count:-0}" == "${expected}" ]] && return 0
+    sleep 1
+  done
+  echo "timed out waiting for Task runsCreated=${expected}" >&2
+  return 1
+}
+
+expect_rejected() {
+  local name="$1"
+  local text="$2"
+  shift 2
+  if "$@" >"${TMP_DIR}/${name}.out" 2>&1; then
+    echo "${name} unexpectedly passed Task admission" >&2
+    return 1
+  fi
+  if ! grep -q "${text}" "${TMP_DIR}/${name}.out"; then
+    echo "${name} did not report ${text}" >&2
+    cat "${TMP_DIR}/${name}.out" >&2
+    return 1
+  fi
+}
+
+echo "==> creating parameterized Task Agent"
+"${APPLY_EXAMPLE}" echo-task-agent.yaml
+for _ in $(seq 1 60); do
+  ready="$(
+    kubectl get agent echo-task \
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true
+  )"
+  [[ "${ready}" == "True" ]] && break
+  sleep 1
+done
+[[ "${ready}" == "True" ]]
+if [[ "$(kubectl get agentrun -l kontext.dev/agent=echo-task -o name)" != "" ]]; then
+  echo "Task Agent creation minted an AgentRun" >&2
+  exit 1
+fi
+
+echo "==> invoking sparse Task through API admission"
+"${APPLY_EXAMPLE}" echo-task-invocation.yaml
+wait_for_run_phase echo-task-docs Succeeded
+goal="$(kubectl get agentrun echo-task-docs -o jsonpath='{.spec.goal}')"
+result="$(kubectl get agentrun echo-task-docs -o jsonpath='{.status.result}')"
+parameter="$(kubectl get agentrun echo-task-docs -o jsonpath='{.spec.parameters.subject}')"
+label="$(kubectl get agentrun echo-task-docs -o jsonpath='{.metadata.labels.kontext\.dev/agent}')"
+owner="$(kubectl get agentrun echo-task-docs -o jsonpath='{.metadata.ownerReferences[?(@.controller==true)].name}')"
+if [[ "${goal}" != 'Summarize Task admission; preserve the literal ${subject}.' ||
+  "${result}" != *"${goal}"* ||
+  "${parameter}" != "Task admission" ||
+  "${label}" != "echo-task" ||
+  "${owner}" != "echo-task" ]]; then
+  echo "sparse Task did not persist and execute the resolved snapshot" >&2
+  exit 1
+fi
+
+echo "==> proving resolved snapshots are immutable"
+expect_rejected immutable 'AgentRun spec is immutable' \
+  kubectl patch agentrun echo-task-docs --type=merge -p='{"spec":{"goal":"changed"}}'
+
+echo "==> proving static and concurrent user-named invocations"
+cat <<EOF | kubectl apply -f -
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: task-static
+spec:
+  mode: Task
+  goal: Run the static Task.
+  provider: echo
+  model: echo-model
+  runtime:
+    image: ${KONTEXT_ECHO_IMAGE:-kontext-echo:dev}
+---
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: task-static-run
+spec:
+  agentRef:
+    name: task-static
+EOF
+wait_for_run_phase task-static-run Succeeded
+
+for name in task-concurrent-a task-concurrent-b; do
+  kubectl create -f - >"${TMP_DIR}/${name}.create" <<EOF &
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: ${name}
+spec:
+  agentRef:
+    name: echo-task
+  parameters:
+    subject: ${name}
+EOF
+done
+wait
+wait_for_run_phase task-concurrent-a Succeeded
+wait_for_run_phase task-concurrent-b Succeeded
+wait_for_agent_count 3
+
+newest="$(
+  kubectl get agentrun -l kontext.dev/agent=echo-task -o json |
+    jq -r '.items | sort_by(.metadata.creationTimestamp, .metadata.name) | last.metadata.name'
+)"
+last_run="$(kubectl get agent echo-task -o jsonpath='{.status.lastRunName}')"
+if [[ "${last_run}" != "${newest}" ]]; then
+  echo "lastRunName=${last_run}, newest retained run=${newest}" >&2
+  exit 1
+fi
+kubectl delete agentrun "${newest}" --wait=true
+wait_for_agent_count 2
+
+echo "==> proving actionable Task admission rejection"
+cat <<EOF | kubectl apply -f -
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: task-invalid
+spec:
+  mode: Task
+  goalTemplate: 'broken \${name'
+  model: echo-model
+  runtime:
+    image: ${KONTEXT_ECHO_IMAGE:-kontext-echo:dev}
+---
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: task-wrong-mode
+spec:
+  mode: Service
+  goal: Stay running.
+  model: echo-model
+  runtime:
+    image: ${KONTEXT_ECHO_IMAGE:-kontext-echo:dev}
+EOF
+expect_rejected missing-agent MissingAgent kubectl create -f - <<'EOF'
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: task-reject-missing-agent
+spec:
+  agentRef:
+    name: missing
+EOF
+expect_rejected wrong-mode WrongMode kubectl create -f - <<'EOF'
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: task-reject-wrong-mode
+spec:
+  agentRef:
+    name: task-wrong-mode
+EOF
+expect_rejected missing-parameter MissingParameters kubectl create -f - <<'EOF'
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: task-reject-missing-parameter
+spec:
+  agentRef:
+    name: echo-task
+EOF
+expect_rejected unused-parameter UnusedParameters kubectl create -f - <<'EOF'
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: task-reject-unused-parameter
+spec:
+  agentRef:
+    name: echo-task
+  parameters:
+    subject: valid
+    extra: rejected
+EOF
+expect_rejected invalid-template InvalidTemplate kubectl create -f - <<'EOF'
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: task-reject-invalid-template
+spec:
+  agentRef:
+    name: task-invalid
+  parameters:
+    name: value
+EOF
+expect_rejected locked-field ConflictingFields kubectl create -f - <<'EOF'
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: task-reject-locked-field
+spec:
+  agentRef:
+    name: echo-task
+  parameters:
+    subject: valid
+  goal: override
+EOF
+
+echo "==> proving Agent ownership cascades retained Task runs"
+kubectl delete agent echo-task --wait=true
+for _ in $(seq 1 120); do
+  [[ "$(kubectl get agentrun -l kontext.dev/agent=echo-task -o name 2>/dev/null || true)" == "" ]] && break
+  sleep 1
+done
+if [[ "$(kubectl get agentrun -l kontext.dev/agent=echo-task -o name 2>/dev/null || true)" != "" ]]; then
+  echo "deleting the Task Agent did not garbage-collect retained runs" >&2
+  exit 1
+fi
+
+echo "focused Task mode acceptance passed"

--- a/scripts/e2e-kind-webhook.sh
+++ b/scripts/e2e-kind-webhook.sh
@@ -18,7 +18,11 @@ cleanup() {
     kill "${pid}" >/dev/null 2>&1 || true
   done
   kubectl scale deployment "${DEPLOYMENT}" -n "${NAMESPACE}" --replicas=1 >/dev/null 2>&1 || true
+  kubectl delete agent webhook-task -n default \
+    --ignore-not-found=true --wait=false >/dev/null 2>&1 || true
   kubectl delete agentrun webhook-complete-bypass webhook-complete-broken-trust \
+    webhook-task-bootstrap webhook-task-rotating webhook-task-rotated \
+    webhook-task-restarted webhook-task-ha \
     -n default --ignore-not-found=true --wait=false >/dev/null 2>&1 || true
   rm -rf "${TMP_DIR}"
 }
@@ -55,6 +59,33 @@ leaf_fingerprint() {
   secret_value 'tls\.crt' | openssl x509 -noout -fingerprint -sha256
 }
 
+create_task_invocation() {
+  local name="$1"
+  kubectl create -f - <<EOF
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: ${name}
+  namespace: default
+spec:
+  agentRef:
+    name: webhook-task
+EOF
+}
+
+create_task_invocation_retry() {
+  local name="$1"
+  for _ in $(seq 1 60); do
+    if create_task_invocation "${name}" >"${TMP_DIR}/${name}.out" 2>&1; then
+      cat "${TMP_DIR}/${name}.out"
+      return 0
+    fi
+    sleep 1
+  done
+  cat "${TMP_DIR}/${name}.out" >&2
+  return 1
+}
+
 echo "==> verifying fresh trusted bootstrap"
 kubectl rollout status deployment/"${DEPLOYMENT}" -n "${NAMESPACE}" --timeout=180s
 kubectl get service webhook-service -n "${NAMESPACE}" >/dev/null
@@ -71,7 +102,32 @@ if [[ "${secret_ca}" != "${registered_ca}" ]]; then
   exit 1
 fi
 
-echo "==> proving sparse validation and nonmatching bypass"
+echo "==> proving real sparse Task mutation and nonmatching bypass"
+cat <<EOF | kubectl apply -f -
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: webhook-task
+  namespace: default
+spec:
+  mode: Task
+  goal: Exercise webhook lifecycle admission.
+  provider: echo
+  model: echo-model
+  runtime:
+    image: ${ECHO_IMAGE}
+EOF
+if [[ "$(kubectl get agentrun -l kontext.dev/agent=webhook-task -o name)" != "" ]]; then
+  echo "Task Agent creation minted a run" >&2
+  exit 1
+fi
+create_task_invocation webhook-task-bootstrap
+wait_for_run_phase webhook-task-bootstrap Succeeded
+if [[ "$(kubectl get agentrun webhook-task-bootstrap -o jsonpath='{.spec.goal}')" != \
+  "Exercise webhook lifecycle admission." ]]; then
+  echo "bootstrap Task invocation was not resolved" >&2
+  exit 1
+fi
 cat <<EOF | kubectl apply -f -
 apiVersion: kontext.dev/v1alpha1
 kind: AgentRun
@@ -95,11 +151,11 @@ spec:
     name: reserved-task
 EOF
 then
-  echo "sparse AgentRun unexpectedly persisted without #84" >&2
+  echo "missing Task Agent unexpectedly passed admission" >&2
   exit 1
 fi
-if ! grep -Eq 'Required value|must contain a complete execution snapshot' "${TMP_DIR}/sparse.out"; then
-  echo "sparse request did not reach schema validation through trusted TLS" >&2
+if ! grep -q 'MissingAgent' "${TMP_DIR}/sparse.out"; then
+  echo "sparse request did not return actionable Task admission failure" >&2
   cat "${TMP_DIR}/sparse.out" >&2
   exit 1
 fi
@@ -178,6 +234,7 @@ kubectl patch secret "${SECRET}" -n "${NAMESPACE}" --type=json -p="$(
   printf '[{"op":"replace","path":"/data/tls.crt","value":"%s"},{"op":"replace","path":"/data/tls.key","value":"%s"}]' \
     "${near_cert}" "${near_key}"
 )"
+create_task_invocation webhook-task-rotating
 near_fingerprint="$(openssl x509 -in "${TMP_DIR}/near.crt" -noout -fingerprint -sha256)"
 for _ in $(seq 1 120); do
   new_fingerprint="$(leaf_fingerprint)"
@@ -188,6 +245,9 @@ if [[ "${new_fingerprint}" == "${old_fingerprint}" || "${new_fingerprint}" == "$
   echo "near-expiry certificate was not renewed" >&2
   exit 1
 fi
+create_task_invocation webhook-task-rotated
+wait_for_run_phase webhook-task-rotating Succeeded
+wait_for_run_phase webhook-task-rotated Succeeded
 
 echo "==> verifying restart reuse"
 renewed_fingerprint="${new_fingerprint}"
@@ -197,6 +257,8 @@ if [[ "$(leaf_fingerprint)" != "${renewed_fingerprint}" ]]; then
   echo "controller restart replaced valid shared certificate" >&2
   exit 1
 fi
+create_task_invocation_retry webhook-task-restarted
+wait_for_run_phase webhook-task-restarted Succeeded
 
 echo "==> verifying two-replica convergence"
 kubectl scale deployment "${DEPLOYMENT}" -n "${NAMESPACE}" --replicas=2
@@ -235,5 +297,7 @@ if [[ "${#fingerprints[@]}" -ne 2 || "${fingerprints[0]}" != "${fingerprints[1]}
   echo "two replicas do not serve the same shared certificate" >&2
   exit 1
 fi
+create_task_invocation webhook-task-ha
+wait_for_run_phase webhook-task-ha Succeeded
 
 echo "focused webhook TLS and HA acceptance passed"

--- a/scripts/verify-release-install.sh
+++ b/scripts/verify-release-install.sh
@@ -110,6 +110,11 @@ fi
 echo "==> running registry-backed keyless acceptance"
 KONTEXT_RELEASE_TAG="${CURRENT_VERSION}" "${ROOT_DIR}/scripts/e2e-kind.sh"
 
+echo "==> running registry-backed Task acceptance"
+KONTEXT_RELEASE_TAG="${CURRENT_VERSION}" \
+  KONTEXT_ECHO_IMAGE="$(kontext_image kontext-echo):${CURRENT_VERSION}" \
+  "${ROOT_DIR}/scripts/e2e-kind-task.sh"
+
 echo "==> running registry-backed Scheduled acceptance"
 KONTEXT_ECHO_IMAGE="$(kontext_image kontext-echo):${CURRENT_VERSION}" \
   "${ROOT_DIR}/scripts/e2e-kind-scheduled.sh"
@@ -118,7 +123,7 @@ echo "==> running registry-backed webhook TLS and HA acceptance"
 KONTEXT_ECHO_IMAGE="$(kontext_image kontext-echo):${CURRENT_VERSION}" \
   "${ROOT_DIR}/scripts/e2e-kind-webhook.sh"
 
-echo "==> verifying control-plane removal with CR retention"
+echo "==> verifying Task result and control-plane removal with CR retention"
 cat <<EOF | kubectl apply -f -
 apiVersion: kontext.dev/v1alpha1
 kind: Agent
@@ -128,10 +133,29 @@ metadata:
 spec:
   mode: Task
   goal: Verify custom-resource retention during control-plane removal.
+  provider: echo
   model: echo-model
   runtime:
     image: $(kontext_image kontext-echo):${CURRENT_VERSION}
+---
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: retained-install-invocation
+  namespace: default
+spec:
+  agentRef:
+    name: retained-install-check
 EOF
+wait_for_run_phase retained-install-invocation Succeeded default 180 1
+retained_result="$(
+  kubectl get agentrun retained-install-invocation -n default \
+    -o jsonpath='{.status.result}'
+)"
+if [[ "${retained_result}" != *"Verify custom-resource retention during control-plane removal."* ]]; then
+  echo "release Task invocation did not produce the expected terminal result" >&2
+  exit 1
+fi
 
 kubectl delete clusterrolebinding manager-rolebinding --ignore-not-found=true
 kubectl delete clusterrole manager-role --ignore-not-found=true
@@ -142,11 +166,23 @@ kubectl delete namespace kontext-system --ignore-not-found=true --wait=true
 
 kubectl get crd agents.kontext.dev agentruns.kontext.dev >/dev/null
 kubectl get agent retained-install-check -n default >/dev/null
+kubectl get agentrun retained-install-invocation -n default >/dev/null
 
 echo "==> reinstalling after retained-CRD removal"
 install_release "${CURRENT_MANIFEST}" true
 kubectl get agent retained-install-check -n default >/dev/null
+kubectl get agentrun retained-install-invocation -n default >/dev/null
 kubectl delete agent retained-install-check -n default --wait=true
+for _ in $(seq 1 120); do
+  if ! kubectl get agentrun retained-install-invocation -n default >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+if kubectl get agentrun retained-install-invocation -n default >/dev/null 2>&1; then
+  echo "retained Task Agent deletion did not cascade to its invocation" >&2
+  exit 1
+fi
 
 echo "==> verifying complete uninstall"
 kubectl delete -f "${CURRENT_MANIFEST}" --ignore-not-found=true --wait=true


### PR DESCRIPTION
## Summary
- replace the plumbing-only endpoint with fail-closed sparse Task CREATE resolution against the referenced same-namespace Agent
- persist complete immutable snapshots with original parameters, canonical labels, and controller ownership while leaving standalone, Service, and Scheduled complete runs unchanged
- reconcile Task readiness and exact retained-owned child status without minting runs or reusing Service-only fields
- add Task examples, documentation, webhook-aware envtest, focused kind acceptance, TLS restart/rotation coverage, and real release Task verification

## Behavior
- static and parameterized invocations resolve through the API server before CRD validation; malformed templates, missing or unused parameters, wrong modes, missing Agents, and locked-field overrides return stable actionable errors
- omitted, null, and explicitly empty parameter maps follow the same static Task path while non-empty unused parameters remain rejected
- concurrent user-named runs are supported; `lastRunName` follows newest retained creation time and `runsCreated` follows the exact retained-owned count
- Agent deletion cascades Task runs, resolved specs remain immutable, and Task Agent creation creates no AgentRun

## Test plan
- [x] `make verify`
- [x] `make test`
- [x] `make vulncheck`
- [x] `KUBEBUILDER_ASSETS=... go test ./internal/runfactory ./internal/webhooktls ./internal/controller`
- [x] `go test ./internal/runfactory -run='^$' -fuzz='^FuzzResolveTask$' -fuzztime=10s` (415,233 executions)
- [x] all maintained and fixture image builds plus local image smoke
- [x] `scripts/e2e-kind.sh`
- [x] `scripts/e2e-kind-task.sh`
- [x] `scripts/e2e-kind-scheduled.sh`
- [x] `scripts/eval-kind.sh` (keyless suite)
- [x] `scripts/e2e-kind-network-policy.sh` (Calico)
- [x] `scripts/e2e-kind-webhook.sh` (fail-closed trust, renewal, restart, and two-replica HA during Task creation)
- [x] `scripts/verify-release-install.sh` with locally rendered digest manifests, upgrade from `ae8af135b96a17b93476dc5e914a607401ad2f1b`, rollback, candidate restore, retained-CR checks, and full uninstall

## CI impact
- adds the focused Task mode script to required kind e2e
- extends the webhook TLS/HA gate and release verification with real sparse invocations and terminal results
- existing standalone, Service, Scheduled, eval, NetworkPolicy, and release lifecycle paths remain covered
- all hosted checks pass and Greptile reports 5/5 confidence

## Residual risks
- no known blocking code risks; local release verification used locally built digest-addressed images, while published registry artifacts remain the tag-time release workflow's responsibility

Closes #84