### PR TITLE
Synchronize Task, Scheduled, and webhook documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,7 +56,7 @@ body:
     attributes:
       label: Resource and mode
       description: State whether this is a standalone AgentRun or an Agent mode
-      placeholder: standalone AgentRun
+      placeholder: Task Agent invocation, Scheduled Agent, Service Agent, or standalone AgentRun
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,39 @@ jobs:
       - name: Scan for known Go vulnerabilities
         run: make vulncheck
 
+  docs-site:
+    name: Docs site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: docs-site
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install docs dependencies
+        run: npm ci
+
+      - name: Test docs sources and navigation
+        run: npm test
+
+      - name: Typecheck docs site
+        run: npm run typecheck
+
+      - name: Build docs and emit LLM files
+        run: npm run build
+
+      - name: Verify raw mirrors and LLM corpora
+        run: npm run verify:build
+
   # Smoke maintained support and runtime images independently before kind.
   image-smoke:
     name: Image smoke

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ review and safer to test than broad rewrites.
 Required tools:
 
 - Go 1.26.5
+- Node.js 22 for the hosted docs site
 - Docker with Buildx
 - kubectl
 - kind for end-to-end tests
@@ -39,12 +40,44 @@ make kind-install
 ./scripts/eval-kind.sh
 ```
 
+Run the focused mode and admission acceptance scripts against the same
+installed cluster:
+
+```bash
+./scripts/e2e-kind-task.sh
+./scripts/e2e-kind-scheduled.sh
+./scripts/e2e-kind-webhook.sh
+```
+
+The Task script covers sparse mutation, rejection classes, immutable
+snapshots, concurrent invocations, retained status, and ownership. The
+Scheduled script covers a real cron tick, status, `Forbid`, and ownership. The
+webhook script covers fresh TLS bootstrap, fail-closed matching, complete-run
+bypass, trust repair, renewal, restart reuse, and two-replica convergence.
+
 NetworkPolicy acceptance creates a separate disposable kind cluster with
 Calico:
 
 ```bash
 ./scripts/e2e-kind-network-policy.sh
 ```
+
+For documentation changes, use Node.js 22 and run the same docs-site checks as
+CI:
+
+```bash
+cd docs-site
+npm ci
+npm test
+npm run typecheck
+npm run build
+npm run verify:build
+```
+
+The build synchronizes repository Markdown into the hosted site and emits raw
+mirrors, `llms.txt`, and `llms-full.txt`. The verification checks byte
+identity between source Markdown and raw output plus required Task, Scheduled,
+API, and webhook terms in the generated corpus.
 
 ## Generated files
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ backward-compatible text projection. The full versioned contract is in
 ## Install a tagged release
 
 An existing Kubernetes cluster needs only kubectl and permission to create
-CRDs, cluster-scoped RBAC, a Namespace, and a Deployment. Install the published
+CRDs, cluster-scoped RBAC, a Namespace, a Deployment, a Service, a
+NetworkPolicy, and a MutatingWebhookConfiguration. Install the published
 `v0.1.0-alpha.1` release directly from GitHub:
 
 ```bash
@@ -55,7 +56,9 @@ kubectl rollout status deployment/controller-manager \
 ```
 
 The release manifest pins the operator and trusted reporter images by digest.
-It does not require Docker, kind, or a repository clone. See
+The controller creates and rotates the webhook TLS Secret and keeps the
+admission CA bundle synchronized; the manifest contains no private key. It
+does not require Docker, kind, or a repository clone. See
 [`docs/releases.md`](docs/releases.md) (also on [docs.kontext.run](https://docs.kontext.run/docs/releases))
 before upgrading or uninstalling because deleting the CRDs also deletes every
 `Agent` and `AgentRun`.
@@ -73,14 +76,18 @@ make kind-install       # build operator + echo images, load into kind, install 
 ./scripts/eval-kind.sh  # deterministic evals against the same cluster
 ```
 
-The e2e script proves four core behaviors:
+Pull-request CI proves these core behaviors across the keyless kind jobs:
 
 - a standalone `AgentRun` runs to completion and lands `.status.result`
 - unmodified images can expose last-line or structured stdout results
 - child exit codes and SIGTERM behavior survive reporter injection
 - a `Service`-mode `Agent` re-casts its run after the Pod is deleted
+- a Task Agent resolves sparse, concurrent invocations and retains owned status
+- a Scheduled Agent mints slot-derived one-shot runs and enforces `Forbid`
+- self-managed webhook TLS bootstraps, renews, repairs trust, and converges
+  across two replicas while matching requests fail closed
 
-### Run a one-shot task
+### Run a standalone one-shot AgentRun
 
 ```bash
 ./scripts/apply-example.sh deploy/examples/v1alpha1/echo-task-run.yaml
@@ -88,6 +95,21 @@ kubectl get agentrun echo-review -w
 kubectl logs -f run-echo-review
 kubectl get agentrun echo-review -o jsonpath='{.status.result}'
 ```
+
+A standalone `AgentRun` carries its complete execution spec and does not
+reference an Agent. A Task Agent is different: applying the Agent creates no
+run, and each sparse user-named `AgentRun` invokes its reusable template:
+
+```bash
+./scripts/apply-example.sh deploy/examples/v1alpha1/echo-task-agent.yaml
+./scripts/apply-example.sh deploy/examples/v1alpha1/echo-task-invocation.yaml
+kubectl get agentrun echo-task-docs -w
+kubectl get agent echo-task \
+  -o jsonpath='{.status.lastRunName}{"\n"}'
+```
+
+See the [Task workload guide](docs/task-workload.md) for template parameters,
+admission failures, retained-run status, and cleanup.
 
 ### Run a persistent service agent
 
@@ -239,7 +261,12 @@ make build             # compile operator binary to bin/manager
 make run               # run the controller locally against your kubeconfig
 ```
 
-Pull requests and pushes to `main` run validate (including `make vulncheck`), Dockerfile smoke for every shipped image, and keyless kind e2e via `.github/workflows/ci.yml`. After a failed local kind run, collect cluster state with `./scripts/collect-kind-diagnostics.sh`.
+Pull requests and pushes to `main` run Go validation (including
+`make vulncheck`), docs-site tests/typecheck/build and generated-corpus checks,
+Dockerfile smoke for every shipped image, focused Task/Scheduled/webhook
+acceptance, and keyless kind e2e via `.github/workflows/ci.yml`. After a failed
+local kind run, collect cluster state with
+`./scripts/collect-kind-diagnostics.sh`.
 
 ## Layout
 
@@ -262,6 +289,8 @@ scripts/                   kind install + e2e
 | Doc | Purpose |
 |---|---|
 | [`SPEC.md`](SPEC.md) | API and runtime-image contract |
+| [`docs/task-workload.md`](docs/task-workload.md) | Reusable Task templates, sparse invocation, and retained-run status |
+| [`docs/scheduled-workload.md`](docs/scheduled-workload.md) | Cron scheduling, overlap policy, history, and scheduler status |
 | [`docs/operations.md`](docs/operations.md) | Alpha support matrix, security boundaries, troubleshooting, and lifecycle |
 | [`docs/releases.md`](docs/releases.md) | Release tags, installation, upgrades, and uninstall |
 | [`docs/runtimes.md`](docs/runtimes.md) | Runtime roles, result paths, static context, and tools |

--- a/SPEC.md
+++ b/SPEC.md
@@ -75,8 +75,8 @@ The reusable definition. Cluster-namespaced. Has a status subresource.
 | -------------------- | ----------- | ------------------------------------ |
 | `conditions`         | []Condition | `Ready`, `Progressing`.              |
 | `currentRunName`     | string      | `Service`: the live run.             |
-| `lastRunName`        | string      | `Task`: most recent run. `Scheduled`: newest retained owned run; empty when all children are pruned. |
-| `runsCreated`        | int         | Mode-specific observed run count.   |
+| `lastRunName`        | string      | `Task`: newest retained owned run by creation time. `Scheduled`: newest retained owned run by slot; empty when no child is retained. |
+| `runsCreated`        | int         | `Task`: current retained owned-run count. `Scheduled`: monotonic creation sequence. `Service`: monotonic run suffix. |
 | `restarts`           | int         | `Service`: re-cast count.            |
 | `lastScheduleTime`   | timestamp   | `Scheduled`: latest observed slot that minted a run; retained after child pruning. |
 | `nextScheduleTime`   | timestamp   | `Scheduled`: next slot the controller will evaluate. |
@@ -108,6 +108,29 @@ history is pruned independently by outcome, active runs are never pruned, and
 Agent ownership gives all children normal Kubernetes deletion cascading.
 `currentRunName`, `restarts`, and Service backoff remain Service-only.
 
+Task and Scheduled status intentionally use different counting semantics. For
+Task, deleting an owned run immediately decreases `runsCreated`; deleting the
+newest run moves `lastRunName` to the next newest retained child, and deleting
+all owned runs clears it. Creation timestamp determines Task recency, with
+lexically greater run name as the deterministic tie-breaker. For Scheduled,
+each new run receives an increasing sequence. `runsCreated` never decreases
+when history pruning or a user deletes a child. `lastRunName` remains a live
+reference and can move or clear as retained history changes.
+
+### Agent condition reasons
+
+The controller publishes `Ready` and `Progressing` conditions with these
+mode-specific reasons:
+
+- Task: `TemplateReady` and `Idle` for a valid template;
+  `InvalidTemplate` when invocations are blocked by template validation.
+- Scheduled: `ScheduleInitialized`, `ScheduleUpdated`,
+  `WaitingForSchedule`, `RunCreated`, `Suspended`, `MissedDeadline`,
+  `OverlapSkipped`, and `InvalidSchedule`.
+- Service: `Recasting`, `RunActive`, and `MissingGoal`.
+- Unknown stored mode values: `InvalidMode`. The CRD enum rejects unknown
+  values on normal writes.
+
 
 ---
 
@@ -120,7 +143,7 @@ One bounded execution. Maps to exactly one Pod. **Spec is immutable after creati
 
 | Field                | Type     | Req | Notes                                            |
 | -------------------- | -------- | --- | ------------------------------------------------ |
-| `agentRef.name`      | string   | no  | Owning `Agent`. With Task CREATE admission installed, a user-created reference is an explicit execution trigger. Omitted = standalone ad-hoc run. |
+| `agentRef.name`      | string   | no  | Owning `Agent`. Task CREATE admission treats a sparse user-created reference as an explicit execution trigger. Omitted = standalone ad-hoc run. |
 | `parameters`         | map[string]string | no | Immutable Task invocation parameters retained with the resolved snapshot. Requires `agentRef`. |
 | `goal`               | string   | yes | Concrete, fully-resolved goal.                   |
 | `provider`           | string   | no  | Resolved from Agent at creation.                 |
@@ -191,6 +214,26 @@ webhook fetches the referenced same-namespace Agent through the API reader,
 rejects invalid requests, and returns the resolver's complete object as the
 admission patch. Complete standalone and controller-created runs do not match
 the sparse webhook and remain independent of Task admission.
+
+The installed `MutatingWebhookConfiguration` matches namespaced
+`kontext.dev/v1alpha1` `AgentRun` CREATE requests only when `agentRef` is
+present and at least one required execution field is absent. It uses
+`failurePolicy: Fail`, a five-second timeout, `matchPolicy: Equivalent`,
+`sideEffects: None`, and no reinvocation. Matching sparse requests therefore
+fail closed when admission is unavailable; complete requests bypass the
+webhook.
+
+Every rejected Task resolution includes one stable class:
+
+- `MissingAgent`: the same-namespace referenced Agent does not exist.
+- `WrongMode`: the reference names a non-Task Agent.
+- `InvalidTemplate`: the Task definition has invalid goal/template shape or
+  placeholder syntax.
+- `MissingParameters`: required placeholder names have no supplied value.
+- `UnusedParameters`: supplied names are unused, including any parameter map
+  on a static goal.
+- `ConflictingFields`: the invocation supplies one or more locked execution
+  fields.
 
 ### `status`
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,7 +20,8 @@ Bug reports are in scope when they reproduce against:
 - the latest published alpha release;
 - release-provided operator or reporter images;
 - the maintained reference and echo runtimes;
-- standalone `AgentRun` or `Agent` mode `Service`;
+- standalone `AgentRun` and `Agent` modes `Task`, `Scheduled`, and `Service`;
+- self-managed Task admission TLS and the narrow fail-closed webhook path;
 - the documented install and upgrade paths.
 
 The project can help identify whether a bring-your-own runtime follows the

--- a/docs-nav.json
+++ b/docs-nav.json
@@ -9,6 +9,8 @@
           "docs/index",
           "docs/quickstart",
           "docs/resources",
+          "docs/task-workload",
+          "docs/scheduled-workload",
           "docs/service-workload"
         ]
       },
@@ -23,10 +25,7 @@
       },
       {
         "group": "Reference",
-        "pages": [
-          "SPEC",
-          "docs/when-not-to-use-agents"
-        ]
+        "pages": ["SPEC", "docs/when-not-to-use-agents"]
       }
     ]
   }

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -10,8 +10,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build && node scripts/emit-llm-files.mjs",
     "preview": "vite preview",
+    "pretypecheck": "npm run sync",
     "typecheck": "tsc -b --noEmit",
-    "test": "node --test tests/*.test.mjs"
+    "test": "node --test tests/*.test.mjs",
+    "verify:build": "node scripts/verify-build.mjs"
   },
   "dependencies": {
     "highlight.js": "^11.11.1",

--- a/docs-site/scripts/verify-build.mjs
+++ b/docs-site/scripts/verify-build.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { pageMetadataById } from "../shared/docs.js";
+
+const docsSite = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const repoRoot = path.resolve(docsSite, "..");
+const dist = path.join(docsSite, "dist");
+
+for (const metadata of pageMetadataById.values()) {
+  const source = fs.readFileSync(path.join(repoRoot, metadata.srcFile));
+  const mirror = fs.readFileSync(
+    path.join(dist, metadata.rawPath.replace(/^\//, "")),
+  );
+  assert.deepEqual(
+    mirror,
+    source,
+    `${metadata.rawPath} does not byte-match ${metadata.srcFile}`,
+  );
+}
+
+const llmsIndex = fs.readFileSync(path.join(dist, "llms.txt"), "utf8");
+for (const page of ["task-workload", "scheduled-workload"]) {
+  assert.match(
+    llmsIndex,
+    new RegExp(`https://docs\\.kontext\\.run/raw/docs/${page}\\.md`),
+  );
+}
+
+const llmsFull = fs.readFileSync(path.join(dist, "llms-full.txt"), "utf8");
+for (const term of [
+  "Task",
+  "Scheduled",
+  "ScheduleSpec",
+  "goalTemplate",
+  "MutatingWebhookConfiguration",
+  "failurePolicy: Fail",
+]) {
+  assert.ok(llmsFull.includes(term), `llms-full.txt is missing ${term}`);
+}
+
+console.log(
+  `Verified ${pageMetadataById.size} raw mirrors and generated LLM corpora`,
+);

--- a/docs-site/shared/docs.js
+++ b/docs-site/shared/docs.js
@@ -39,6 +39,24 @@ const pageMetadataEntries = [
     },
   ],
   [
+    "docs/task-workload",
+    {
+      srcFile: "docs/task-workload.md",
+      routePath: "/docs/task-workload",
+      rawPath: "/raw/docs/task-workload.md",
+      githubPath: "docs/task-workload.md",
+    },
+  ],
+  [
+    "docs/scheduled-workload",
+    {
+      srcFile: "docs/scheduled-workload.md",
+      routePath: "/docs/scheduled-workload",
+      rawPath: "/raw/docs/scheduled-workload.md",
+      githubPath: "docs/scheduled-workload.md",
+    },
+  ],
+  [
     "docs/service-workload",
     {
       srcFile: "docs/service-workload.md",

--- a/docs-site/tests/content-integrity.test.mjs
+++ b/docs-site/tests/content-integrity.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { pageMetadataById } from "../shared/docs.js";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+function filesUnder(directory, extension, ignoredDirectories = new Set()) {
+  const files = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!ignoredDirectories.has(entry.name)) {
+        files.push(...filesUnder(absolute, extension, ignoredDirectories));
+      }
+    } else if (entry.name.endsWith(extension)) {
+      files.push(absolute);
+    }
+  }
+  return files;
+}
+
+const markdownFiles = filesUnder(
+  repoRoot,
+  ".md",
+  new Set([".git", "content", "dist", "node_modules"]),
+);
+
+const routeSources = new Map(
+  [...pageMetadataById.values()].map((metadata) => [
+    metadata.routePath,
+    metadata.srcFile,
+  ]),
+);
+
+test("public docs contain no stale mode language", () => {
+  const publicFiles = [
+    ...filesUnder(path.join(repoRoot, "docs"), ".md"),
+    ...[
+      "README.md",
+      "SPEC.md",
+      "SUPPORT.md",
+      "CONTRIBUTING.md",
+      "website/index.html",
+      ".github/ISSUE_TEMPLATE/bug_report.yml",
+    ].map((file) => path.join(repoRoot, file)),
+  ];
+  const forbidden = [
+    /\bUnsupportedMode\b/,
+    /\breserved\b/i,
+    /Until Task mutation ships/i,
+  ];
+
+  for (const file of publicFiles) {
+    const source = fs.readFileSync(file, "utf8");
+    for (const pattern of forbidden) {
+      assert.doesNotMatch(
+        source,
+        pattern,
+        `${path.relative(repoRoot, file)} contains stale public language`,
+      );
+    }
+  }
+});
+
+test("internal Markdown links resolve", () => {
+  const failures = [];
+  const linkPattern = /!?\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+
+  for (const file of markdownFiles) {
+    const source = fs.readFileSync(file, "utf8");
+    for (const match of source.matchAll(linkPattern)) {
+      const rawTarget = match[1].replace(/^<|>$/g, "");
+      if (rawTarget.startsWith("#") || /^[a-z][a-z0-9+.-]*:/i.test(rawTarget)) {
+        continue;
+      }
+
+      const pathname = decodeURIComponent(
+        rawTarget.split("#", 1)[0].split("?", 1)[0],
+      );
+      if (!pathname) {
+        continue;
+      }
+
+      let target;
+      if (pathname.startsWith("/")) {
+        const sourceFile = routeSources.get(pathname);
+        if (!sourceFile) {
+          failures.push(
+            `${path.relative(repoRoot, file)} -> unknown docs route ${pathname}`,
+          );
+          continue;
+        }
+        target = path.join(repoRoot, sourceFile);
+      } else {
+        target = path.resolve(path.dirname(file), pathname);
+      }
+
+      if (!fs.existsSync(target)) {
+        failures.push(`${path.relative(repoRoot, file)} -> ${rawTarget}`);
+      }
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});
+
+test("referenced example paths exist", () => {
+  const failures = [];
+  const examplePattern = /deploy\/examples\/v1alpha1\/[A-Za-z0-9._/-]+/g;
+
+  for (const file of markdownFiles) {
+    const source = fs.readFileSync(file, "utf8");
+    for (const match of source.matchAll(examplePattern)) {
+      const relative = match[0].replace(/[.,;:]+$/, "");
+      if (!fs.existsSync(path.join(repoRoot, relative))) {
+        failures.push(`${path.relative(repoRoot, file)} -> ${relative}`);
+      }
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});

--- a/docs-site/tests/content-integrity.test.mjs
+++ b/docs-site/tests/content-integrity.test.mjs
@@ -38,6 +38,66 @@ const routeSources = new Map(
   ]),
 );
 
+function decodeLinkPath(rawTarget) {
+  const encodedPathname = rawTarget.split("#", 1)[0].split("?", 1)[0];
+  try {
+    return { ok: true, pathname: decodeURIComponent(encodedPathname) };
+  } catch (error) {
+    if (!(error instanceof URIError)) {
+      throw error;
+    }
+    return {
+      ok: false,
+      reason: "malformed percent escape in link target",
+    };
+  }
+}
+
+function collectInternalLinkFailures({ documents, root, routes }) {
+  const failures = [];
+  const linkPattern = /!?\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+
+  for (const { file, source } of documents) {
+    for (const match of source.matchAll(linkPattern)) {
+      const rawTarget = match[1].replace(/^<|>$/g, "");
+      if (rawTarget.startsWith("#") || /^[a-z][a-z0-9+.-]*:/i.test(rawTarget)) {
+        continue;
+      }
+
+      const decoded = decodeLinkPath(rawTarget);
+      if (!decoded.ok) {
+        failures.push(
+          `${path.relative(root, file)} -> ${rawTarget}: ${decoded.reason}`,
+        );
+        continue;
+      }
+      if (!decoded.pathname) {
+        continue;
+      }
+
+      let target;
+      if (decoded.pathname.startsWith("/")) {
+        const sourceFile = routes.get(decoded.pathname);
+        if (!sourceFile) {
+          failures.push(
+            `${path.relative(root, file)} -> unknown docs route ${decoded.pathname}`,
+          );
+          continue;
+        }
+        target = path.join(root, sourceFile);
+      } else {
+        target = path.resolve(path.dirname(file), decoded.pathname);
+      }
+
+      if (!fs.existsSync(target)) {
+        failures.push(`${path.relative(root, file)} -> ${rawTarget}`);
+      }
+    }
+  }
+
+  return failures;
+}
+
 test("public docs contain no stale mode language", () => {
   const publicFiles = [
     ...filesUnder(path.join(repoRoot, "docs"), ".md"),
@@ -69,45 +129,73 @@ test("public docs contain no stale mode language", () => {
 });
 
 test("internal Markdown links resolve", () => {
-  const failures = [];
-  const linkPattern = /!?\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
-
-  for (const file of markdownFiles) {
-    const source = fs.readFileSync(file, "utf8");
-    for (const match of source.matchAll(linkPattern)) {
-      const rawTarget = match[1].replace(/^<|>$/g, "");
-      if (rawTarget.startsWith("#") || /^[a-z][a-z0-9+.-]*:/i.test(rawTarget)) {
-        continue;
-      }
-
-      const pathname = decodeURIComponent(
-        rawTarget.split("#", 1)[0].split("?", 1)[0],
-      );
-      if (!pathname) {
-        continue;
-      }
-
-      let target;
-      if (pathname.startsWith("/")) {
-        const sourceFile = routeSources.get(pathname);
-        if (!sourceFile) {
-          failures.push(
-            `${path.relative(repoRoot, file)} -> unknown docs route ${pathname}`,
-          );
-          continue;
-        }
-        target = path.join(repoRoot, sourceFile);
-      } else {
-        target = path.resolve(path.dirname(file), pathname);
-      }
-
-      if (!fs.existsSync(target)) {
-        failures.push(`${path.relative(repoRoot, file)} -> ${rawTarget}`);
-      }
-    }
-  }
+  const failures = collectInternalLinkFailures({
+    documents: markdownFiles.map((file) => ({
+      file,
+      source: fs.readFileSync(file, "utf8"),
+    })),
+    root: repoRoot,
+    routes: routeSources,
+  });
 
   assert.deepEqual(failures, []);
+});
+
+test("link target decoding preserves encoded path characters", () => {
+  assert.deepEqual(decodeLinkPath("notes%20complete.md?raw=1#summary"), {
+    ok: true,
+    pathname: "notes complete.md",
+  });
+  assert.deepEqual(decodeLinkPath("chapter%23one.md#heading"), {
+    ok: true,
+    pathname: "chapter#one.md",
+  });
+  assert.deepEqual(decodeLinkPath("query%3Fname.md?download=1"), {
+    ok: true,
+    pathname: "query?name.md",
+  });
+  assert.deepEqual(decodeLinkPath("notes-100%.md"), {
+    ok: false,
+    reason: "malformed percent escape in link target",
+  });
+});
+
+test("link failures aggregate malformed and missing targets", (context) => {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "links-"),
+  );
+  context.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  for (const file of ["notes complete.md", "chapter#one.md", "query?name.md"]) {
+    fs.writeFileSync(path.join(fixtureRoot, file), "");
+  }
+  const fixtureFile = path.join(fixtureRoot, "fixture.md");
+  const source = [
+    "[literal percent](notes-100%.md)",
+    "[valid encoded path](notes%20complete.md?raw=1#summary)",
+    "[encoded fragment marker](chapter%23one.md#heading)",
+    "[encoded query marker](query%3Fname.md?download=1)",
+    "[first missing](missing-one.md)",
+    "[second missing](missing-two.md)",
+    "[anchor](#local)",
+    "[external](https://example.com/notes-100%.md)",
+    "[mail](mailto:docs@example.com)",
+    "[raw mirror](https://docs.kontext.run/raw/docs/index.md)",
+    "[GitHub source](https://github.com/MFS-code/Kontext/blob/main/README.md)",
+  ].join("\n");
+
+  assert.deepEqual(
+    collectInternalLinkFailures({
+      documents: [{ file: fixtureFile, source }],
+      root: fixtureRoot,
+      routes: new Map(),
+    }),
+    [
+      "fixture.md -> notes-100%.md: malformed percent escape in link target",
+      "fixture.md -> missing-one.md",
+      "fixture.md -> missing-two.md",
+    ],
+  );
 });
 
 test("referenced example paths exist", () => {

--- a/docs-site/tests/shared-docs.test.mjs
+++ b/docs-site/tests/shared-docs.test.mjs
@@ -92,6 +92,18 @@ test("page metadata covers every navigation page with stable paths", () => {
       rawPath: "/raw/docs/resources.md",
       githubPath: "docs/resources.md",
     },
+    "docs/task-workload": {
+      srcFile: "docs/task-workload.md",
+      routePath: "/docs/task-workload",
+      rawPath: "/raw/docs/task-workload.md",
+      githubPath: "docs/task-workload.md",
+    },
+    "docs/scheduled-workload": {
+      srcFile: "docs/scheduled-workload.md",
+      routePath: "/docs/scheduled-workload",
+      rawPath: "/raw/docs/scheduled-workload.md",
+      githubPath: "docs/scheduled-workload.md",
+    },
     "docs/service-workload": {
       srcFile: "docs/service-workload.md",
       routePath: "/docs/service-workload",

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,5 +31,7 @@ for ad-hoc dispatch and demos.
 
 1. [Install without cloning](/docs/quickstart)
 2. Learn the [resource model](/docs/resources)
-3. Run a [Service-mode agent](/docs/service-workload)
-4. Read the [API spec](/SPEC)
+3. Invoke a reusable [Task workload](/docs/task-workload)
+4. Run a [Scheduled workload](/docs/scheduled-workload)
+5. Keep a [Service workload](/docs/service-workload) available
+6. Read the [API spec](/SPEC)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -96,7 +96,9 @@ keys live only in the namespaced `webhook-server-cert` Secret and controller
 memory; release YAML contains no key material. Every replica loads the shared
 Secret, verifies the Service DNS SANs, repairs the admission CA bundle, renews
 the serving certificate before expiry, and reloads it without a process
-restart.
+restart. TLS reconciliation runs on every replica rather than behind leader
+election. Conflicting Secret or registration updates retry until replicas
+converge.
 
 CA replacement uses a staged overlap. The admission registration trusts both
 the new and previous CA before any replica promotes the new serving
@@ -106,9 +108,13 @@ Secret, so replicas converge instead of replacing one another's keys.
 Readiness requires both a serving webhook listener and byte-for-byte agreement
 between the loaded CA bundle and the MutatingWebhookConfiguration. Liveness
 does not depend on admission trust, allowing a running replica to repair it.
-The webhook matches only sparse referenced AgentRun CREATE requests. Complete
-standalone and controller-created runs bypass it. Until Task mutation ships,
-the plumbing handler returns no patch and the CRD rejects sparse requests.
+The registration uses `failurePolicy: Fail`, `matchPolicy: Equivalent`,
+`sideEffects: None`, no reinvocation, and a five-second timeout. Its
+`matchConditions` expression selects namespaced `kontext.dev/v1alpha1`
+`AgentRun` CREATE requests that have `agentRef` and lack at least one required
+execution field. The webhook resolves those sparse Task invocations into
+complete immutable snapshots. Complete standalone and controller-created runs
+bypass it.
 
 ### Workload identity
 
@@ -157,6 +163,11 @@ Kontext does not create a default NetworkPolicy for workloads. Runtime Pods
 have whatever ingress and egress the cluster, namespace, and CNI allow. On many
 clusters that means unrestricted egress.
 
+The release does install `controller-manager-webhook`, an ingress-only policy
+in `kontext-system`. It selects controller Pods and allows only webhook port
+9443 and health port 8081. It does not select `AgentRun` Pods, restrict
+controller egress, or provide workload isolation.
+
 Tool declarations do not restrict network traffic. Apply an enforced
 NetworkPolicy when a runtime must reach only DNS, a provider endpoint, the
 Kubernetes API, or a named in-cluster service. kindnet does not enforce
@@ -201,9 +212,13 @@ repeating one-shot work is safe.
 
 - An `AgentRun` owns its Pod. Deleting the run removes the Pod through
   Kubernetes garbage collection.
-- A Service `Agent` owns its child runs. Deleting the Agent removes those runs
-  and their Pods.
-- Completed run history remains until a user or another controller deletes it.
+- Every `Agent` owns the runs created from it. Deleting the Agent removes
+  those runs and their Pods.
+- Task history remains until a user or another controller deletes it.
+  `runsCreated` counts retained owned runs and can decrease.
+- Scheduled history is pruned by its separate success and failure limits.
+  `runsCreated` remains monotonic even when children are pruned or deleted.
+- Service run history remains until a user or another controller deletes it.
 - Removing only the controller retains the CRDs and custom resources in other
   namespaces.
 - Deleting either CRD deletes every resource of that kind across the cluster.
@@ -270,11 +285,25 @@ kubectl describe agentrun <name> -n <namespace>
 
 Inspect `status.phase`, `status.message`, `status.conditions`, `status.podName`,
 and the completion timestamps. For an `Agent`, inspect `Ready` and
-`Progressing`. For Task admission failures, inspect the API error for the
-stable resolution class (`MissingAgent`, `WrongMode`, `InvalidTemplate`,
-`MissingParameters`, `UnusedParameters`, or `ConflictingFields`). A matching
-sparse request fails closed while the webhook is unavailable; complete
-standalone and controller-created runs do not depend on that webhook.
+`Progressing`.
+
+Agent condition reasons are mode-specific:
+
+- Task uses `TemplateReady`/`Idle`, or `InvalidTemplate` when invocation is
+  blocked.
+- Scheduled uses `ScheduleInitialized`, `ScheduleUpdated`,
+  `WaitingForSchedule`, `RunCreated`, `Suspended`, `MissedDeadline`,
+  `OverlapSkipped`, or `InvalidSchedule`.
+- Service uses `Recasting`, `RunActive`, or `MissingGoal`.
+- `InvalidMode` means an unknown mode reached reconciliation. Normal API
+  writes cannot create one because the CRD enum accepts only Task, Service,
+  and Scheduled.
+
+For Task admission failures, inspect the API error for the stable resolution
+class (`MissingAgent`, `WrongMode`, `InvalidTemplate`, `MissingParameters`,
+`UnusedParameters`, or `ConflictingFields`). A matching sparse request fails
+closed while the webhook is unavailable; complete standalone and
+controller-created runs do not depend on that webhook.
 
 ### Check the workload Pod
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,8 +8,9 @@ sidebarTitle: Quickstart
 
 Install a tagged release on an existing Kubernetes cluster, then run a keyless
 echo `AgentRun`. You need kubectl and permission to create CRDs, cluster-scoped
-RBAC, a Namespace, and a Deployment. You do not need Docker, kind, or a
-repository clone.
+RBAC, a Namespace, a Deployment, a Service, a NetworkPolicy, and a
+MutatingWebhookConfiguration. You do not need Docker, kind, or a repository
+clone.
 
 ## Install
 
@@ -23,7 +24,9 @@ kubectl rollout status deployment/controller-manager \
 ```
 
 The release manifest pins the operator and trusted reporter images by digest.
-See [Releases](/docs/releases) for upgrade and uninstall procedures.
+It installs the admission registration and webhook Service. The controller
+creates and rotates the namespaced TLS Secret and repairs the registration's
+CA bundle. See [Releases](/docs/releases) for upgrade and uninstall procedures.
 
 ## Run an echo AgentRun
 
@@ -90,11 +93,49 @@ admission to render the goal and copy the Agent's execution fields into one
 immutable, owned snapshot. Inspect the stored form with
 `kubectl get agentrun echo-task-release -o yaml`.
 
+## Run on a schedule
+
+Save this Scheduled Agent as `scheduled.yaml`. It runs on the next future
+minute:
+
+```yaml
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: echo-scheduled
+spec:
+  mode: Scheduled
+  goal: Emit one deterministic echo result for this scheduled slot.
+  provider: echo
+  model: echo-model
+  runtime:
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+    command: ["/entrypoint.sh"]
+  schedule:
+    expression: "* * * * *"
+    timeZone: Etc/UTC
+    concurrencyPolicy: Forbid
+    startingDeadlineSeconds: 60
+```
+
+```bash
+kubectl apply -f scheduled.yaml
+kubectl get agent echo-scheduled -w
+kubectl get agentruns -l kontext.dev/agent=echo-scheduled
+```
+
+Creating the Agent anchors scheduling at the current time, so the first run
+arrives on a future cron slot. The [Scheduled workload
+guide](/docs/scheduled-workload) covers suspension, history limits, overlap,
+and scheduler status.
+
 ## Clean up this demo
 
 ```bash
 kubectl delete agentrun review --ignore-not-found=true
+kubectl delete agentrun echo-task-release --ignore-not-found=true
 kubectl delete agent echo-task --ignore-not-found=true
+kubectl delete agent echo-scheduled --ignore-not-found=true
 ```
 
 Uninstalling the control plane is covered in [Releases](/docs/releases).
@@ -103,5 +144,7 @@ Deleting the CRDs also deletes every `Agent` and `AgentRun`.
 ## Next
 
 - [Core resource model](/docs/resources)
+- [Task workload](/docs/task-workload)
+- [Scheduled workload](/docs/scheduled-workload)
 - [First Service workload](/docs/service-workload)
 - [Runtime choices](/docs/runtimes)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -65,6 +65,20 @@ references use the immutable digests recorded in `image-digests.json`, while
 `app.kubernetes.io/version` and `kontext.dev/release` retain the human-readable
 release tag.
 
+The registration matches only sparse referenced `AgentRun` CREATE requests.
+It fails matching requests closed, uses a five-second timeout, and leaves
+complete standalone and controller-created runs outside the webhook. Every
+controller replica reconciles the shared TLS Secret and registration, reloads
+renewed serving certificates, and must agree with the registered CA bundle
+before becoming ready.
+
+Webhook permissions are split from controller reconciliation and leader
+election. A namespaced Role manages only the TLS Secret. A separate
+ClusterRole manages only the named `MutatingWebhookConfiguration`, except that
+Kubernetes RBAC cannot name-scope the create verb. The release NetworkPolicy
+is ingress-only and selects controller Pods for webhook port 9443 and health
+port 8081. It does not restrict `AgentRun` workloads or controller egress.
+
 Given a downloaded digest manifest, the release artifact is reproducible from
 the tagged source:
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -44,6 +44,9 @@ progress; `currentRunName`, `restarts`, and backoff apply only to Service mode.
 `status.lastRunName` points to the newest retained scheduled child and is
 cleared when history limits prune every child. `lastScheduleTime` remains the
 historical latest observed slot even after that child is pruned.
+`status.runsCreated` is a monotonic Scheduled creation sequence recovered from
+retained child metadata. Pruning or manually deleting children never decreases
+it.
 
 ### Task invocation requests
 
@@ -79,7 +82,9 @@ matching sparse request, creation fails closed with an actionable error.
 Task runs are user-named and can execute concurrently. For Task status,
 `lastRunName` means the newest retained owned run by creation time, while
 `runsCreated` is the number of currently retained owned runs. It is not a
-lifetime counter.
+lifetime counter. Deleting the newest run moves `lastRunName` to the next
+newest retained run; deleting every run clears it and resets `runsCreated` to
+zero. Lexically greater run name breaks equal creation-time ties.
 
 ## Status and logs
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -59,6 +59,20 @@ truncation metadata. Kubernetes RBAC, ServiceAccounts, mounts, container
 security, and enforced NetworkPolicy remain authoritative even when the
 runtime allows a tool.
 
+## Task and Scheduled workloads
+
+Task invocations and Scheduled slots both produce one-shot `AgentRun`s. Their
+images should perform the goal, emit any terminal result, and exit. Kontext
+sets the Pod restart policy to `Never`; it does not restart a failed process
+inside the same run.
+
+A Task `Agent` is a reusable template. Admission resolves each sparse,
+user-named invocation into a complete immutable run before storage. A
+Scheduled `Agent` builds the same complete one-shot snapshot in the
+controller, using a slot-derived run name. Runtime images receive a concrete
+`KONTEXT_GOAL` in both cases and do not need to know which path created the
+run.
+
 ## Service workloads
 
 A Service image must stay alive. Omit `budget.wallclock` when the service has

--- a/docs/scheduled-workload.md
+++ b/docs/scheduled-workload.md
@@ -1,0 +1,121 @@
+---
+title: Scheduled workload
+description: Run one-shot AgentRuns from cron slots with deadlines, overlap policy, suspension, and retained history.
+sidebarTitle: Scheduled workload
+---
+
+# Run a Scheduled workload
+
+Scheduled mode creates one-shot `AgentRun` children from a standard five-field
+cron expression. The controller derives each run name from its slot, so
+retries and leader changes converge on the same object.
+
+## Create a Scheduled Agent
+
+Save this as `echo-scheduled.yaml`:
+
+```yaml
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: echo-scheduled
+spec:
+  mode: Scheduled
+  goal: Emit one deterministic echo result for this scheduled slot.
+  provider: echo
+  model: echo-model
+  runtime:
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+    command: ["/entrypoint.sh"]
+  schedule:
+    expression: "* * * * *"
+    timeZone: Etc/UTC
+    concurrencyPolicy: Forbid
+    startingDeadlineSeconds: 60
+    suspend: false
+    successfulRunsHistoryLimit: 3
+    failedRunsHistoryLimit: 1
+```
+
+Apply it and watch the first future minute slot:
+
+```bash
+kubectl apply -f echo-scheduled.yaml
+kubectl get agent echo-scheduled -w
+kubectl get agentruns -l kontext.dev/agent=echo-scheduled -w
+```
+
+Creating or changing the Agent anchors the schedule at the current time. It
+waits for the next future slot instead of immediately running or backfilling.
+After the controller creates a run, inspect it with:
+
+```bash
+RUN_NAME="$(
+  kubectl get agent echo-scheduled \
+    -o jsonpath='{.status.lastRunName}'
+)"
+kubectl get agentrun "${RUN_NAME}" -w
+kubectl logs -f "run-${RUN_NAME}"
+kubectl get agentrun "${RUN_NAME}" \
+  -o jsonpath='{.status.result}{"\n"}'
+```
+
+## Scheduling behavior
+
+The expression has minute, hour, day-of-month, month, and day-of-week fields.
+Seconds and descriptors are rejected. `timeZone` accepts an IANA name and
+defaults to `Etc/UTC`.
+
+`Forbid`, the default concurrency policy, skips a due slot while any owned run
+is Pending or Running. `Allow` permits overlap. Skipped work is not queued.
+After controller downtime, Kontext considers only the latest due slot and
+creates it only when it remains inside `startingDeadlineSeconds`.
+
+Set `schedule.suspend: true` to stop new runs. Existing runs continue.
+Resuming waits for the next future slot.
+
+## Status and history
+
+Use these fields to inspect scheduler progress:
+
+- `lastScheduleTime` records the latest slot that minted a run and remains
+  after that child is pruned.
+- `nextScheduleTime` is the next slot the controller will evaluate.
+- `lastRunName` points to the newest retained owned child and clears when no
+  child remains.
+- `runsCreated` is a monotonic creation sequence. Pruning or deleting
+  Scheduled runs does not reduce it.
+
+Successful and failed history limits apply separately. `BudgetExceeded` counts
+as failed history, and active runs are never pruned.
+
+Common condition reasons are `ScheduleInitialized`, `ScheduleUpdated`,
+`WaitingForSchedule`, `RunCreated`, `Suspended`, `MissedDeadline`,
+`OverlapSkipped`, and `InvalidSchedule`.
+
+## Failure and cleanup
+
+If no run appears, inspect the Agent before the workload Pods:
+
+```bash
+kubectl get agent echo-scheduled -o yaml
+kubectl describe agent echo-scheduled
+kubectl get events --sort-by=.lastTimestamp
+```
+
+`InvalidSchedule` means the expression, time zone, or policy is invalid.
+`MissedDeadline` and `OverlapSkipped` are deliberate skips, not queued work.
+
+Delete the Agent to stop scheduling and garbage-collect its retained runs and
+Pods:
+
+```bash
+kubectl delete agent echo-scheduled --ignore-not-found=true
+```
+
+## Related
+
+- [Task workload](/docs/task-workload)
+- [Resource model](/docs/resources)
+- [Operations](/docs/operations)
+- [API specification](/SPEC)

--- a/docs/task-workload.md
+++ b/docs/task-workload.md
@@ -1,0 +1,122 @@
+---
+title: Task workload
+description: Create a reusable Task Agent and invoke it through a sparse, user-named AgentRun.
+sidebarTitle: Task workload
+---
+
+# Run a Task workload
+
+Task mode separates a reusable definition from each execution. Applying a Task
+`Agent` creates no Pod. Each sparse `AgentRun` invocation passes through
+Kontext admission, becomes a complete immutable snapshot, and starts one Pod.
+
+> **Note**
+> Task invocation requires the `MutatingWebhookConfiguration` installed with
+> Kontext. The controller manages the webhook certificate and CA bundle.
+
+## Create the Task Agent
+
+Save this as `echo-task.yaml`:
+
+```yaml
+apiVersion: kontext.dev/v1alpha1
+kind: Agent
+metadata:
+  name: echo-task
+spec:
+  mode: Task
+  goalTemplate: "Summarize ${subject}; preserve the literal $${subject}."
+  provider: echo
+  model: echo-model
+  runtime:
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+  budget:
+    wallclock: 2m
+```
+
+Apply it and wait for the template to become ready:
+
+```bash
+kubectl apply -f echo-task.yaml
+kubectl wait agent/echo-task \
+  --for=condition=Ready --timeout=60s
+kubectl get agentrun -l kontext.dev/agent=echo-task
+```
+
+The last command returns no runs. A Task Agent is a definition, not an
+execution.
+
+## Invoke the Task
+
+Save this as `echo-task-run.yaml`:
+
+```yaml
+apiVersion: kontext.dev/v1alpha1
+kind: AgentRun
+metadata:
+  name: echo-task-docs
+spec:
+  agentRef:
+    name: echo-task
+  parameters:
+    subject: Task admission
+```
+
+Create the invocation and inspect the stored snapshot:
+
+```bash
+kubectl create -f echo-task-run.yaml
+kubectl get agentrun echo-task-docs -o yaml
+kubectl get agentrun echo-task-docs -w
+kubectl logs -f run-echo-task-docs
+kubectl get agentrun echo-task-docs \
+  -o jsonpath='{.status.result}{"\n"}'
+```
+
+Admission renders `goalTemplate`, copies the Agent's execution fields, records
+the supplied parameters, and adds an owner reference. The stored
+`AgentRun.spec` is complete and immutable. Create another user-named
+`AgentRun` to invoke the template again; concurrent runs are allowed.
+
+## Status and retained runs
+
+The Task Agent reports `Ready=True` with reason `TemplateReady` when the
+template can accept invocations. `Progressing=False` with reason `Idle` means
+that Task work starts only when a caller creates an `AgentRun`.
+
+`status.lastRunName` points to the newest retained owned run by creation time.
+`status.runsCreated` is the number of retained owned Task runs, not a lifetime
+counter. Deleting a run can decrease the count and move or clear
+`lastRunName`.
+
+## Admission failures
+
+Rejected invocations include one stable resolution class in the API error:
+
+- `MissingAgent`: the referenced Agent does not exist in the namespace.
+- `WrongMode`: the reference names a Service or Scheduled Agent.
+- `InvalidTemplate`: the Task Agent has invalid template syntax.
+- `MissingParameters`: one or more placeholders have no value.
+- `UnusedParameters`: the request supplies values the goal does not consume.
+- `ConflictingFields`: the sparse request tries to override an execution field.
+
+Matching sparse requests fail closed if the webhook is unavailable or its TLS
+trust is unhealthy. Complete standalone `AgentRun` requests do not match the
+webhook.
+
+## Clean up
+
+```bash
+kubectl delete agent echo-task --ignore-not-found=true
+```
+
+The Agent owns its resolved runs, so Kubernetes garbage collection removes
+`echo-task-docs` and its Pod. Delete a run directly when you want to discard
+only that invocation.
+
+## Related
+
+- [Scheduled workload](/docs/scheduled-workload)
+- [Resource model](/docs/resources)
+- [Operations](/docs/operations)
+- [API specification](/SPEC)

--- a/website/index.html
+++ b/website/index.html
@@ -57,9 +57,11 @@
     <p>
       Scheduling, secrets, RBAC, budgets, logs, restarts: agents need what
       Kubernetes already does. Kontext adds two resources, <code>Agent</code> and
-      <code>AgentRun</code>, and leaves the rest to the cluster. Service agents are
-      re-cast automatically when they die. Wallclock budgets are enforced by the
-      controller. Results live in <code>status</code>, queryable like any other object.
+      <code>AgentRun</code>, and leaves the rest to the cluster. Task agents are
+      reusable one-shot templates. Scheduled agents mint one-shot runs from cron
+      slots. Service agents are re-cast automatically when they die. Wallclock
+      budgets are enforced by the controller. Results live in <code>status</code>,
+      queryable like any other object.
     </p>
   </section>
 


### PR DESCRIPTION
## Summary
- document shipped Task invocation, Scheduled reconciliation, retained-run status, condition reasons, and self-managed webhook TLS behavior across public docs
- add dedicated hosted Task and Scheduled workload guides with navigation, search metadata, raw mirrors, edit links, and LLM corpus coverage
- add a Node 22 docs-site CI job plus stale-language, internal-link, example-path, generated mirror, and LLM content checks

GitHub Markdown and the hosted documentation use the same source files. The generated raw Markdown mirrors are verified byte-for-byte against those sources.

## Test evidence
- `cd docs-site && npm ci`
- `npm test` (7 tests, including public stale-language, all internal Markdown links, and referenced example paths)
- `npm run typecheck`
- `npm run build` (12 raw Markdown mirrors plus `llms.txt` and `llms-full.txt`)
- `npm run verify:build` (all mirrors byte-match; Task, Scheduled, ScheduleSpec, goalTemplate, and webhook terms present)
- Prettier check for changed docs-site, workflow, issue-form, and navigation files
- static website HTML parse and Task/Scheduled capability-copy assertions
- `make verify`
- `make test`

## Post-merge checks
- confirm the docs deployment serves `/docs/task-workload` and `/docs/scheduled-workload`
- fetch both `/raw/` mirrors plus `/llms.txt` and `/llms-full.txt` from docs.kontext.run
- confirm the marketing-site deployment includes the Task/Scheduled capability copy