### PR TITLE
Prevent AgentRuns from adopting foreign Pods

### DIFF
--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -49,7 +49,26 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if podErr != nil && !podMissing {
 		return ctrl.Result{}, podErr
 	}
+	if podMissing && run.Status.PodName == "" {
+		legacyPodName := podbuilder.LegacyPodNameForRun(run.Name)
+		if legacyPodName != podName {
+			legacyPod := &corev1.Pod{}
+			legacyPodKey := client.ObjectKey{Namespace: run.Namespace, Name: legacyPodName}
+			legacyPodErr := r.Get(ctx, legacyPodKey, legacyPod)
+			switch {
+			case legacyPodErr == nil && metav1.IsControlledBy(legacyPod, &run):
+				pod = legacyPod
+				podName = legacyPodName
+				podMissing = false
+			case legacyPodErr != nil && !apierrors.IsNotFound(legacyPodErr):
+				return ctrl.Result{}, legacyPodErr
+			}
+		}
+	}
 	if !podMissing && !metav1.IsControlledBy(pod, &run) {
+		if status.IsTerminalPhase(run.Status.Phase) {
+			return ctrl.Result{}, nil
+		}
 		return r.failPodNameCollision(ctx, &run, pod)
 	}
 

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +49,9 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if podErr != nil && !podMissing {
 		return ctrl.Result{}, podErr
 	}
+	if !podMissing && !metav1.IsControlledBy(pod, &run) {
+		return r.failPodNameCollision(ctx, &run, pod)
+	}
 
 	var wallclockLimit *time.Duration
 	if !status.IsTerminalPhase(run.Status.Phase) {
@@ -75,6 +79,37 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return wallclockResult, nil
 	}
 	return observationResult, nil
+}
+
+func (r *AgentRunReconciler) failPodNameCollision(
+	ctx context.Context,
+	run *kontextv1alpha1.AgentRun,
+	pod *corev1.Pod,
+) (ctrl.Result, error) {
+	message := fmt.Sprintf(
+		"Pod name collision: Pod %s/%s is not controlled by AgentRun %s/%s.",
+		pod.Namespace,
+		pod.Name,
+		run.Namespace,
+		run.Name,
+	)
+	return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
+		next.Phase = kontextv1alpha1.AgentRunPhaseFailed
+		next.PodName = pod.Name
+		next.Result = ""
+		next.Output = nil
+		next.Usage = nil
+		next.StartTime = nil
+		if next.Message != message || next.CompletionTime == nil {
+			next.CompletionTime = nowPtr()
+		}
+		next.Message = message
+		setStatusConditions(
+			&next.Conditions,
+			run.Generation,
+			conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhaseFailed)...,
+		)
+	})
 }
 
 func (r *AgentRunReconciler) reconcileMissingPod(ctx context.Context, run *kontextv1alpha1.AgentRun, podName string) (ctrl.Result, error) {

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -381,6 +381,99 @@ func TestAgentRunReconcilerRejectsPodNameCollision(t *testing.T) {
 	}
 }
 
+func TestAgentRunReconcilerPreservesTerminalStatusOnForeignPodReuse(t *testing.T) {
+	ctx := context.Background()
+	run := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "terminal-pod-reuse",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			Goal:     "hello",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	completed := metav1.NewTime(time.Now().Truncate(time.Second))
+	if err := updateAgentRunStatus(ctx, run, kontextv1alpha1.AgentRunStatus{
+		Phase:          kontextv1alpha1.AgentRunPhaseSucceeded,
+		PodName:        podbuilder.PodNameForRun(run.Name),
+		Result:         "owned result",
+		CompletionTime: &completed,
+	}); err != nil {
+		t.Fatalf("update run status: %v", err)
+	}
+
+	unrelatedPod := testsupport.BuildPod(run)
+	if err := k8sClient.Create(ctx, unrelatedPod); err != nil {
+		t.Fatalf("create unrelated pod: %v", err)
+	}
+
+	reconcileAgentRun(ctx, t, types.NamespacedName{Name: run.Name, Namespace: run.Namespace})
+
+	var updated kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(run), &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if updated.Status.Phase != kontextv1alpha1.AgentRunPhaseSucceeded ||
+		updated.Status.Result != "owned result" ||
+		updated.Status.CompletionTime == nil ||
+		!updated.Status.CompletionTime.Equal(&completed) {
+		t.Fatalf("terminal status changed after foreign Pod reuse: %#v", updated.Status)
+	}
+}
+
+func TestAgentRunReconcilerContinuesOwnedLegacyNamedPod(t *testing.T) {
+	ctx := context.Background()
+	run := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 56) + "-legacy",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			Goal:     "hello",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	legacyPodName := podbuilder.LegacyPodNameForRun(run.Name)
+	hashedPodName := podbuilder.PodNameForRun(run.Name)
+	if legacyPodName == hashedPodName {
+		t.Fatalf("test requires distinct legacy and hashed Pod names: %s", legacyPodName)
+	}
+	legacyPod := buildOwnedPod(t, run)
+	legacyPod.Name = legacyPodName
+	if err := k8sClient.Create(ctx, legacyPod); err != nil {
+		t.Fatalf("create legacy Pod: %v", err)
+	}
+
+	reconcileAgentRun(ctx, t, types.NamespacedName{Name: run.Name, Namespace: run.Namespace})
+
+	var updated kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(run), &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if updated.Status.PodName != legacyPodName {
+		t.Fatalf("expected legacy Pod %q to remain authoritative, got %q", legacyPodName, updated.Status.PodName)
+	}
+	if err := k8sClient.Get(
+		ctx,
+		types.NamespacedName{Name: hashedPodName, Namespace: run.Namespace},
+		&corev1.Pod{},
+	); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected no duplicate hashed Pod, got %v", err)
+	}
+}
+
 func TestAgentRunReconcilerDeletesLegacyPodWithInvalidWallclock(t *testing.T) {
 	ctx := context.Background()
 	run := &kontextv1alpha1.AgentRun{

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 	"github.com/MFS-code/Kontext/internal/podbuilder"
@@ -61,6 +62,9 @@ func TestAgentRunReconcilerCreatesPod(t *testing.T) {
 	pod := &corev1.Pod{}
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: podName, Namespace: run.Namespace}, pod); err != nil {
 		t.Fatalf("expected pod %s: %v", podName, err)
+	}
+	if !metav1.IsControlledBy(pod, &updated) {
+		t.Fatalf("expected pod to be controlled by AgentRun %s", updated.Name)
 	}
 }
 
@@ -310,6 +314,73 @@ func TestAgentRunReconcilerFailsWhenPodLost(t *testing.T) {
 	}
 }
 
+func TestAgentRunReconcilerRejectsPodNameCollision(t *testing.T) {
+	ctx := context.Background()
+	run := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-name-collision-run",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			Goal:     "hello",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	unrelatedPod := testsupport.BuildPod(run)
+	if err := k8sClient.Create(ctx, unrelatedPod); err != nil {
+		t.Fatalf("create unrelated pod: %v", err)
+	}
+	podKey := types.NamespacedName{Name: unrelatedPod.Name, Namespace: unrelatedPod.Namespace}
+	if err := k8sClient.Get(ctx, podKey, unrelatedPod); err != nil {
+		t.Fatalf("get unrelated pod: %v", err)
+	}
+	unrelatedPod.Status.Phase = corev1.PodSucceeded
+	unrelatedPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: podbuilder.RuntimeContainerName,
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Message:  `{"apiVersion":"kontext.dev/result/v1alpha1","outcome":"Succeeded","output":{"mediaType":"text/plain","value":"foreign result"},"usage":{"totalTokens":42}}`,
+			},
+		},
+	}}
+	if err := k8sClient.Status().Update(ctx, unrelatedPod); err != nil {
+		t.Fatalf("update unrelated pod status: %v", err)
+	}
+
+	reconcileAgentRun(ctx, t, types.NamespacedName{Name: run.Name, Namespace: run.Namespace})
+
+	var updated kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: run.Name, Namespace: run.Namespace}, &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if updated.Status.Phase != kontextv1alpha1.AgentRunPhaseFailed {
+		t.Fatalf("expected Failed, got %s", updated.Status.Phase)
+	}
+	if !strings.Contains(updated.Status.Message, "Pod name collision") ||
+		!strings.Contains(updated.Status.Message, "is not controlled by AgentRun") {
+		t.Fatalf("expected clear collision status, got %q", updated.Status.Message)
+	}
+	if updated.Status.Result != "" || updated.Status.Output != nil || updated.Status.Usage != nil {
+		t.Fatalf("run adopted unrelated pod results: %#v", updated.Status)
+	}
+	if updated.Status.CompletionTime == nil {
+		t.Fatal("expected completion time")
+	}
+	if err := k8sClient.Get(ctx, podKey, unrelatedPod); err != nil {
+		t.Fatalf("get unrelated pod after reconcile: %v", err)
+	}
+	if len(unrelatedPod.OwnerReferences) != 0 {
+		t.Fatalf("unrelated pod was adopted: %#v", unrelatedPod.OwnerReferences)
+	}
+}
+
 func TestAgentRunReconcilerDeletesLegacyPodWithInvalidWallclock(t *testing.T) {
 	ctx := context.Background()
 	run := &kontextv1alpha1.AgentRun{
@@ -328,7 +399,7 @@ func TestAgentRunReconcilerDeletesLegacyPodWithInvalidWallclock(t *testing.T) {
 		t.Fatalf("create run: %v", err)
 	}
 
-	pod := testsupport.BuildPod(run)
+	pod := buildOwnedPod(t, run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -392,7 +463,7 @@ func TestAgentRunReconcilerObservesSucceededPod(t *testing.T) {
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := testsupport.BuildPod(run)
+	pod := buildOwnedPod(t, run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -464,7 +535,7 @@ func TestAgentRunReconcilerObservesRunningPodWithinWallclockBudget(t *testing.T)
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := testsupport.BuildPod(run)
+	pod := buildOwnedPod(t, run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -529,7 +600,7 @@ func TestAgentRunReconcilerEnforcesWallclockBudget(t *testing.T) {
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := testsupport.BuildPod(run)
+	pod := buildOwnedPod(t, run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -591,7 +662,7 @@ func TestAgentRunReconcilerKeepsWallclockBudgetExceededAuthoritative(t *testing.
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := testsupport.BuildPod(run)
+	pod := buildOwnedPod(t, run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -702,7 +773,7 @@ func TestAgentRunReconcilerPreservesRuntimeCancellationBeforeWallclockEnforcemen
 		t.Fatalf("update run status: %v", err)
 	}
 
-	pod := testsupport.BuildPod(run)
+	pod := buildOwnedPod(t, run)
 	if err := k8sClient.Create(ctx, pod); err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
@@ -775,4 +846,13 @@ func (c *legacyWallclockClient) Get(
 func updateAgentRunStatus(ctx context.Context, run *kontextv1alpha1.AgentRun, next kontextv1alpha1.AgentRunStatus) error {
 	run.Status = next
 	return k8sClient.Status().Update(ctx, run)
+}
+
+func buildOwnedPod(t *testing.T, run *kontextv1alpha1.AgentRun) *corev1.Pod {
+	t.Helper()
+	pod := testsupport.BuildPod(run)
+	if err := controllerutil.SetControllerReference(run, pod, scheme); err != nil {
+		t.Fatalf("set pod owner reference: %v", err)
+	}
+	return pod
 }

--- a/internal/podbuilder/podbuilder.go
+++ b/internal/podbuilder/podbuilder.go
@@ -1,6 +1,8 @@
 package podbuilder
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"slices"
@@ -25,6 +27,10 @@ const (
 	ReporterBinaryPath        = ReporterMountPath + "/" + ReporterBinaryName
 	reporterImageBinaryPath   = "/kontext-reporter"
 	reporterInstallFlag       = "--install-to"
+	podNamePrefix             = "run-"
+	maxPodNameLength          = 63
+	maxUnhashedRunNameLength  = 56
+	truncatedRunNameHashChars = 8
 )
 
 var invalidNameChars = regexp.MustCompile(`[^a-z0-9-]+`)
@@ -351,14 +357,15 @@ func PodNameForRun(runName string) string {
 	if safe == "" {
 		safe = "run"
 	}
-	if len(safe) > 56 {
-		safe = safe[:56]
+	if len(safe) <= maxUnhashedRunNameLength {
+		return podNamePrefix + safe
 	}
-	safe = strings.Trim(safe, "-")
-	if safe == "" {
-		safe = "run"
-	}
-	return fmt.Sprintf("run-%s", safe)
+
+	sum := sha256.Sum256([]byte(runName))
+	hash := hex.EncodeToString(sum[:])[:truncatedRunNameHashChars]
+	prefixLength := maxPodNameLength - len(podNamePrefix) - 1 - len(hash)
+	prefix := strings.TrimRight(safe[:prefixLength], "-")
+	return fmt.Sprintf("%s%s-%s", podNamePrefix, prefix, hash)
 }
 
 func resourceQuantity(value string) resource.Quantity {

--- a/internal/podbuilder/podbuilder.go
+++ b/internal/podbuilder/podbuilder.go
@@ -352,11 +352,7 @@ func budgetDollars(budget *kontextv1alpha1.BudgetSpec) string {
 
 // PodNameForRun returns a deterministic Pod name for an AgentRun.
 func PodNameForRun(runName string) string {
-	safe := invalidNameChars.ReplaceAllString(strings.ToLower(runName), "-")
-	safe = strings.Trim(safe, "-")
-	if safe == "" {
-		safe = "run"
-	}
+	safe := sanitizedRunName(runName)
 	if len(safe) <= maxUnhashedRunNameLength {
 		return podNamePrefix + safe
 	}
@@ -366,6 +362,29 @@ func PodNameForRun(runName string) string {
 	prefixLength := maxPodNameLength - len(podNamePrefix) - 1 - len(hash)
 	prefix := strings.TrimRight(safe[:prefixLength], "-")
 	return fmt.Sprintf("%s%s-%s", podNamePrefix, prefix, hash)
+}
+
+// LegacyPodNameForRun returns the Pod name used before truncated names gained
+// a hash suffix. It supports adopting an already-owned Pod during upgrades.
+func LegacyPodNameForRun(runName string) string {
+	safe := sanitizedRunName(runName)
+	if len(safe) > maxUnhashedRunNameLength {
+		safe = safe[:maxUnhashedRunNameLength]
+	}
+	safe = strings.Trim(safe, "-")
+	if safe == "" {
+		safe = "run"
+	}
+	return podNamePrefix + safe
+}
+
+func sanitizedRunName(runName string) string {
+	safe := invalidNameChars.ReplaceAllString(strings.ToLower(runName), "-")
+	safe = strings.Trim(safe, "-")
+	if safe == "" {
+		safe = "run"
+	}
+	return safe
 }
 
 func resourceQuantity(value string) resource.Quantity {

--- a/internal/podbuilder/podbuilder_test.go
+++ b/internal/podbuilder/podbuilder_test.go
@@ -345,9 +345,13 @@ func TestPodNameForRunDistinguishesLongNamesWithSharedPrefix(t *testing.T) {
 	sharedPrefix := strings.Repeat("a", 56)
 	first := podbuilder.PodNameForRun(sharedPrefix + "-first")
 	second := podbuilder.PodNameForRun(sharedPrefix + "-second")
+	legacy := podbuilder.LegacyPodNameForRun(sharedPrefix + "-first")
 
 	if first == second {
 		t.Fatalf("long run names produced the same pod name: %s", first)
+	}
+	if legacy != "run-"+sharedPrefix {
+		t.Fatalf("unexpected legacy pod name: %s", legacy)
 	}
 	for _, name := range []string{first, second} {
 		if len(name) > 63 {

--- a/internal/podbuilder/podbuilder_test.go
+++ b/internal/podbuilder/podbuilder_test.go
@@ -341,6 +341,24 @@ func TestPodNameForRunTrimsHyphenAfterTruncation(t *testing.T) {
 	}
 }
 
+func TestPodNameForRunDistinguishesLongNamesWithSharedPrefix(t *testing.T) {
+	sharedPrefix := strings.Repeat("a", 56)
+	first := podbuilder.PodNameForRun(sharedPrefix + "-first")
+	second := podbuilder.PodNameForRun(sharedPrefix + "-second")
+
+	if first == second {
+		t.Fatalf("long run names produced the same pod name: %s", first)
+	}
+	for _, name := range []string{first, second} {
+		if len(name) > 63 {
+			t.Fatalf("pod name exceeds DNS label limit: %d", len(name))
+		}
+		if strings.HasSuffix(name, "-") {
+			t.Fatalf("pod name must not end in a hyphen: %s", name)
+		}
+	}
+}
+
 func TestBuildPodPopulatesBudgetEnv(t *testing.T) {
 	tokens := int32(1000)
 	dollars := 2.5


### PR DESCRIPTION
## Summary
- fail an AgentRun with a clear collision status when its Pod name is occupied by a Pod it does not control
- add an eight-character deterministic hash when long run names require truncation while preserving existing short Pod names
- cover long-name uniqueness, controller ownership, and rejection of foreign Pod results

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/podbuilder/... ./internal/controller/...`