### PR TITLE
Prefix operator resources to prevent install collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ NetworkPolicy, and a MutatingWebhookConfiguration. Install the published
 VERSION=v0.1.0-alpha.1
 kubectl apply -f \
   "https://github.com/MFS-code/Kontext/releases/download/${VERSION}/install.yaml"
-kubectl rollout status deployment/controller-manager \
+kubectl rollout status deployment/kontext-controller-manager \
   --namespace kontext-system \
   --timeout=120s
 ```

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,4 +6,6 @@ resources:
   - ../rbac
   - ../manager
 
+namePrefix: kontext-
+
 namespace: kontext-system

--- a/config/manager/mutating_webhook_configuration.yaml
+++ b/config/manager/mutating_webhook_configuration.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: kontext
     app.kubernetes.io/managed-by: kontext
 webhooks:
-  - name: task-agentrun-mutator.kontext.dev
+  - name: kontext-task-agentrun-mutator.kontext.dev
     admissionReviewVersions:
       - v1
     clientConfig:

--- a/config/overlays/dev/manager_patch.yaml
+++ b/config/overlays/dev/manager_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: kontext-controller-manager
   namespace: kontext-system
 spec:
   template:

--- a/config/overlays/release/manager_patch.yaml
+++ b/config/overlays/release/manager_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: kontext-controller-manager
   namespace: kontext-system
 spec:
   template:

--- a/config/rbac/rbac_test.go
+++ b/config/rbac/rbac_test.go
@@ -23,7 +23,8 @@ type document struct {
 }
 
 type kustomization struct {
-	Resources []string `json:"resources"`
+	NamePrefix string   `json:"namePrefix"`
+	Resources  []string `json:"resources"`
 }
 
 func TestLeaderElectionRBACIsSeparatedFromWebhookCertificates(t *testing.T) {
@@ -34,6 +35,19 @@ func TestLeaderElectionRBACIsSeparatedFromWebhookCertificates(t *testing.T) {
 			slices.Contains(rule.Resources, "leases") {
 			t.Fatal("webhook certificate Role absorbed leader-election permissions")
 		}
+	}
+	registrationRole := requireDocument(
+		t,
+		webhookDocuments,
+		"ClusterRole",
+		"webhook-registration-manager",
+	)
+	if len(registrationRole.Rules) != 2 ||
+		!slices.Equal(
+			registrationRole.Rules[1].ResourceNames,
+			[]string{"kontext-task-agentrun-mutator.kontext.dev"},
+		) {
+		t.Fatalf("webhook registration resource names = %#v", registrationRole.Rules)
 	}
 
 	leaderDocuments := readDocuments(t, "leader_election_role.yaml")
@@ -65,6 +79,20 @@ func TestLeaderElectionRBACIsSeparatedFromWebhookCertificates(t *testing.T) {
 	}
 	if !slices.Contains(config.Resources, "leader_election_role.yaml") {
 		t.Fatal("RBAC kustomization omits the dedicated leader-election Role")
+	}
+}
+
+func TestDefaultKustomizationPrefixesResourceNames(t *testing.T) {
+	data, err := os.ReadFile("../default/kustomization.yaml")
+	if err != nil {
+		t.Fatalf("read default kustomization: %v", err)
+	}
+	var config kustomization
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("decode default kustomization: %v", err)
+	}
+	if config.NamePrefix != "kontext-" {
+		t.Fatalf("default namePrefix = %q, want kontext-", config.NamePrefix)
 	}
 }
 

--- a/config/rbac/webhook_role.yaml
+++ b/config/rbac/webhook_role.yaml
@@ -50,7 +50,7 @@ rules:
     resources:
       - mutatingwebhookconfigurations
     resourceNames:
-      - task-agentrun-mutator.kontext.dev
+      - kontext-task-agentrun-mutator.kontext.dev
     verbs:
       - get
       - update

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -67,9 +67,9 @@ They are not part of the supported installation path.
 
 ### Operator identity
 
-The controller runs as the `controller-manager` ServiceAccount in the
-`kontext-system` Namespace. The installed `manager-role` ClusterRole permits
-it to:
+The controller runs as the `kontext-controller-manager` ServiceAccount in the
+`kontext-system` Namespace. The installed `kontext-manager-role` ClusterRole
+permits it to:
 
 - create and patch Events;
 - create, read, watch, update, patch, and delete Pods;
@@ -81,13 +81,14 @@ These permissions are cluster-wide because Kontext reconciles namespaced
 resources in every namespace. Runtime Pods do not inherit the controller's
 ServiceAccount or RBAC permissions.
 
-The separate `webhook-certificate-manager` Role can create Secrets only in
-`kontext-system` and can read or update only `webhook-server-cert`. The
-`webhook-registration-manager` ClusterRole can read or update only
-`task-agentrun-mutator.kontext.dev`; Kubernetes authorization cannot constrain
-the name of a create request, so its create permission is resource-scoped but
-not name-scoped. Leader-election Lease access is isolated in the namespaced
-`leader-election-manager` Role and is not part of either webhook Role.
+The separate `kontext-webhook-certificate-manager` Role can create Secrets
+only in `kontext-system` and can read or update only `webhook-server-cert`.
+The `kontext-webhook-registration-manager` ClusterRole can read or update only
+`kontext-task-agentrun-mutator.kontext.dev`; Kubernetes authorization cannot
+constrain the name of a create request, so its create permission is
+resource-scoped but not name-scoped. Leader-election Lease access is isolated
+in the namespaced `kontext-leader-election-manager` Role and is not part of
+either webhook Role.
 
 ### Admission webhook TLS
 
@@ -163,9 +164,9 @@ Kontext does not create a default NetworkPolicy for workloads. Runtime Pods
 have whatever ingress and egress the cluster, namespace, and CNI allow. On many
 clusters that means unrestricted egress.
 
-The release does install `controller-manager-webhook`, an ingress-only policy
-in `kontext-system`. It selects controller Pods and allows only webhook port
-9443 and health port 8081. It does not select `AgentRun` Pods, restrict
+The release does install `kontext-controller-manager-webhook`, an ingress-only
+policy in `kontext-system`. It selects controller Pods and allows only webhook
+port 9443 and health port 8081. It does not select `AgentRun` Pods, restrict
 controller egress, or provide workload isolation.
 
 Tool declarations do not restrict network traffic. Apply an enforced
@@ -227,15 +228,15 @@ To remove the controller while retaining CRDs and resources outside
 `kontext-system`:
 
 ```bash
-kubectl delete clusterrolebinding manager-rolebinding \
+kubectl delete clusterrolebinding kontext-manager-rolebinding \
   --ignore-not-found=true
-kubectl delete clusterrole manager-role \
+kubectl delete clusterrole kontext-manager-role \
   --ignore-not-found=true
 kubectl delete mutatingwebhookconfiguration \
-  task-agentrun-mutator.kontext.dev --ignore-not-found=true
-kubectl delete clusterrolebinding webhook-registration-manager \
+  kontext-task-agentrun-mutator.kontext.dev --ignore-not-found=true
+kubectl delete clusterrolebinding kontext-webhook-registration-manager \
   --ignore-not-found=true
-kubectl delete clusterrole webhook-registration-manager \
+kubectl delete clusterrole kontext-webhook-registration-manager \
   --ignore-not-found=true
 kubectl delete namespace kontext-system \
   --ignore-not-found=true --wait=true
@@ -259,9 +260,9 @@ upgrade procedure.
 
 ```bash
 kubectl get deployment,pods -n kontext-system
-kubectl rollout status deployment/controller-manager \
+kubectl rollout status deployment/kontext-controller-manager \
   -n kontext-system --timeout=180s
-kubectl logs deployment/controller-manager -n kontext-system
+kubectl logs deployment/kontext-controller-manager -n kontext-system
 ```
 
 If the Deployment is unavailable, describe its Pod and inspect recent events:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -238,6 +238,13 @@ kubectl delete clusterrolebinding kontext-webhook-registration-manager \
   --ignore-not-found=true
 kubectl delete clusterrole kontext-webhook-registration-manager \
   --ignore-not-found=true
+# Also clean identities used before the kontext- prefix.
+kubectl delete mutatingwebhookconfiguration \
+  task-agentrun-mutator.kontext.dev --ignore-not-found=true
+kubectl delete clusterrolebinding manager-rolebinding \
+  webhook-registration-manager --ignore-not-found=true
+kubectl delete clusterrole manager-role \
+  webhook-registration-manager --ignore-not-found=true
 kubectl delete namespace kontext-system \
   --ignore-not-found=true --wait=true
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ clone.
 VERSION=v0.1.0-alpha.1
 kubectl apply -f \
   "https://github.com/MFS-code/Kontext/releases/download/${VERSION}/install.yaml"
-kubectl rollout status deployment/controller-manager \
+kubectl rollout status deployment/kontext-controller-manager \
   --namespace kontext-system \
   --timeout=120s
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -104,7 +104,7 @@ controller rollout:
 NEW_VERSION="<target-release-tag>"
 kubectl apply -f \
   "https://github.com/MFS-code/Kontext/releases/download/${NEW_VERSION}/install.yaml"
-kubectl rollout status deployment/controller-manager \
+kubectl rollout status deployment/kontext-controller-manager \
   --namespace kontext-system \
   --timeout=180s
 ```
@@ -125,15 +125,15 @@ To remove only the Kontext control plane while retaining the CRDs and custom
 resources in other namespaces:
 
 ```bash
-kubectl delete clusterrolebinding manager-rolebinding \
+kubectl delete clusterrolebinding kontext-manager-rolebinding \
   --ignore-not-found=true
-kubectl delete clusterrole manager-role \
+kubectl delete clusterrole kontext-manager-role \
   --ignore-not-found=true
 kubectl delete mutatingwebhookconfiguration \
-  task-agentrun-mutator.kontext.dev --ignore-not-found=true
-kubectl delete clusterrolebinding webhook-registration-manager \
+  kontext-task-agentrun-mutator.kontext.dev --ignore-not-found=true
+kubectl delete clusterrolebinding kontext-webhook-registration-manager \
   --ignore-not-found=true
-kubectl delete clusterrole webhook-registration-manager \
+kubectl delete clusterrole kontext-webhook-registration-manager \
   --ignore-not-found=true
 kubectl delete namespace kontext-system \
   --ignore-not-found=true --wait=true

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -104,20 +104,42 @@ controller rollout:
 NEW_VERSION="<target-release-tag>"
 kubectl apply -f \
   "https://github.com/MFS-code/Kontext/releases/download/${NEW_VERSION}/install.yaml"
+
+# Remove identities used by releases before the kontext- name prefix.
+kubectl delete deployment/controller-manager \
+  -n kontext-system --ignore-not-found=true --wait=true
+kubectl delete \
+  mutatingwebhookconfiguration/task-agentrun-mutator.kontext.dev \
+  clusterrolebinding/manager-rolebinding \
+  clusterrolebinding/webhook-registration-manager \
+  clusterrole/manager-role \
+  clusterrole/webhook-registration-manager \
+  --ignore-not-found=true
+kubectl delete \
+  service/webhook-service \
+  serviceaccount/controller-manager \
+  rolebinding/leader-election-manager \
+  rolebinding/webhook-certificate-manager \
+  role/leader-election-manager \
+  role/webhook-certificate-manager \
+  networkpolicy/controller-manager-webhook \
+  -n kontext-system --ignore-not-found=true
+
 kubectl rollout status deployment/kontext-controller-manager \
   --namespace kontext-system \
   --timeout=180s
 ```
 
-Kubernetes updates the CRDs, RBAC, Deployment, and webhook registration
-declaratively; existing `Agent`, `AgentRun`, and valid webhook TLS Secret
-remain. Downgrades are not supported as an API compatibility guarantee. Release
-CI nevertheless applies the previous manifest after the candidate as a
-rollback safety check, verifies baseline workloads remain available, and then
-restores the candidate. Applying an older manifest does not prune newer
-webhook objects; its narrow match keeps complete AgentRuns independent, while
-sparse Task requests remain fail closed until the current controller is
-restored.
+The explicit cleanup is idempotent. It stops an unprefixed controller from
+retaining the shared leader-election Lease and removes its fail-closed webhook
+before the old Service disappears. The namespaced TLS Secret remains and is
+renewed for the prefixed webhook Service.
+
+Kubernetes updates the CRDs and current resources declaratively; existing
+`Agent` and `AgentRun` resources remain. Downgrades are not supported as an API
+compatibility guarantee. Release CI nevertheless migrates in both directions,
+applies the previous manifest after the candidate as a rollback safety check,
+verifies baseline workloads remain available, and then restores the candidate.
 
 ## Uninstall
 
@@ -135,6 +157,12 @@ kubectl delete clusterrolebinding kontext-webhook-registration-manager \
   --ignore-not-found=true
 kubectl delete clusterrole kontext-webhook-registration-manager \
   --ignore-not-found=true
+kubectl delete mutatingwebhookconfiguration \
+  task-agentrun-mutator.kontext.dev --ignore-not-found=true
+kubectl delete clusterrolebinding manager-rolebinding \
+  webhook-registration-manager --ignore-not-found=true
+kubectl delete clusterrole manager-role \
+  webhook-registration-manager --ignore-not-found=true
 kubectl delete namespace kontext-system \
   --ignore-not-found=true --wait=true
 ```

--- a/internal/webhooktls/lifecycle.go
+++ b/internal/webhooktls/lifecycle.go
@@ -24,8 +24,8 @@ import (
 const (
 	DefaultNamespace         = "kontext-system"
 	DefaultSecretName        = "webhook-server-cert"
-	DefaultWebhookName       = "task-agentrun-mutator.kontext.dev"
-	DefaultServiceName       = "webhook-service"
+	DefaultWebhookName       = "kontext-task-agentrun-mutator.kontext.dev"
+	DefaultServiceName       = "kontext-webhook-service"
 	DefaultWebhookPath       = "/mutate-kontext-dev-v1alpha1-agentrun"
 	DefaultReconcileInterval = 30 * time.Second
 

--- a/scripts/collect-kind-diagnostics.sh
+++ b/scripts/collect-kind-diagnostics.sh
@@ -52,14 +52,14 @@ echo "==> collecting kind diagnostics into ${OUT_DIR}"
 } >"${OUT_DIR}/workload-overview.txt" 2>&1 || true
 
 {
-  echo "# controller-manager deployment"
-  kubectl get deploy -n "${NAMESPACE}" controller-manager -o yaml || true
+  echo "# kontext-controller-manager deployment"
+  kubectl get deploy -n "${NAMESPACE}" kontext-controller-manager -o yaml || true
   echo
-  echo "# controller-manager pods"
+  echo "# kontext-controller-manager pods"
   kubectl get pods -n "${NAMESPACE}" -l control-plane=controller-manager -o wide || true
   echo
-  echo "# controller-manager describe"
-  kubectl describe deploy -n "${NAMESPACE}" controller-manager || true
+  echo "# kontext-controller-manager describe"
+  kubectl describe deploy -n "${NAMESPACE}" kontext-controller-manager || true
   kubectl describe pods -n "${NAMESPACE}" -l control-plane=controller-manager || true
 } >"${OUT_DIR}/controller.txt" 2>&1 || true
 

--- a/scripts/e2e-kind-webhook.sh
+++ b/scripts/e2e-kind-webhook.sh
@@ -6,9 +6,10 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
 
 NAMESPACE="kontext-system"
-DEPLOYMENT="controller-manager"
+DEPLOYMENT="kontext-controller-manager"
 SECRET="webhook-server-cert"
-WEBHOOK="task-agentrun-mutator.kontext.dev"
+WEBHOOK="kontext-task-agentrun-mutator.kontext.dev"
+WEBHOOK_SERVICE="kontext-webhook-service"
 ECHO_IMAGE="${KONTEXT_ECHO_IMAGE:-kontext-echo:dev}"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kontext-webhook-e2e.XXXXXX")"
 PORT_FORWARD_PIDS=()
@@ -88,13 +89,14 @@ create_task_invocation_retry() {
 
 echo "==> verifying fresh trusted bootstrap"
 kubectl rollout status deployment/"${DEPLOYMENT}" -n "${NAMESPACE}" --timeout=180s
-kubectl get service webhook-service -n "${NAMESPACE}" >/dev/null
+kubectl get service "${WEBHOOK_SERVICE}" -n "${NAMESPACE}" >/dev/null
 kubectl get mutatingwebhookconfiguration "${WEBHOOK}" >/dev/null
 kubectl get secret "${SECRET}" -n "${NAMESPACE}" >/dev/null
 secret_value 'ca\.crt' >"${TMP_DIR}/ca.crt"
 secret_value 'tls\.crt' >"${TMP_DIR}/tls.crt"
 openssl verify -CAfile "${TMP_DIR}/ca.crt" "${TMP_DIR}/tls.crt"
-openssl x509 -in "${TMP_DIR}/tls.crt" -noout -checkhost webhook-service.kontext-system.svc
+openssl x509 -in "${TMP_DIR}/tls.crt" -noout \
+  -checkhost "${WEBHOOK_SERVICE}.${NAMESPACE}.svc"
 secret_ca="$(kubectl get secret "${SECRET}" -n "${NAMESPACE}" -o jsonpath='{.data.ca\.crt}')"
 registered_ca="$(kubectl get mutatingwebhookconfiguration "${WEBHOOK}" -o jsonpath='{.webhooks[0].clientConfig.caBundle}')"
 if [[ "${secret_ca}" != "${registered_ca}" ]]; then
@@ -219,9 +221,9 @@ old_fingerprint="$(leaf_fingerprint)"
 secret_value 'ca\.key' >"${TMP_DIR}/ca.key"
 openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
   -keyout "${TMP_DIR}/near.key" -out "${TMP_DIR}/near.csr" \
-  -subj '/CN=webhook-service.kontext-system.svc' >/dev/null 2>&1
-cat >"${TMP_DIR}/san.ext" <<'EOF'
-subjectAltName=DNS:webhook-service,DNS:webhook-service.kontext-system,DNS:webhook-service.kontext-system.svc,DNS:webhook-service.kontext-system.svc.cluster.local
+  -subj "/CN=${WEBHOOK_SERVICE}.${NAMESPACE}.svc" >/dev/null 2>&1
+cat >"${TMP_DIR}/san.ext" <<EOF
+subjectAltName=DNS:${WEBHOOK_SERVICE},DNS:${WEBHOOK_SERVICE}.${NAMESPACE},DNS:${WEBHOOK_SERVICE}.${NAMESPACE}.svc,DNS:${WEBHOOK_SERVICE}.${NAMESPACE}.svc.cluster.local
 extendedKeyUsage=serverAuth
 keyUsage=digitalSignature
 EOF
@@ -284,7 +286,7 @@ for index in 0 1; do
   for _ in $(seq 1 50); do
     if fingerprint="$(
       openssl s_client -connect "127.0.0.1:${port}" \
-        -servername webhook-service.kontext-system.svc </dev/null 2>/dev/null |
+        -servername "${WEBHOOK_SERVICE}.${NAMESPACE}.svc" </dev/null 2>/dev/null |
         openssl x509 -noout -fingerprint -sha256 2>/dev/null
     )"; then
       fingerprints+=("${fingerprint}")

--- a/scripts/install-go-kind.sh
+++ b/scripts/install-go-kind.sh
@@ -81,7 +81,7 @@ CONTROLLER_POD_UID_BEFORE="$(
     -o jsonpath='{.items[0].metadata.uid}' 2>/dev/null || true
 )"
 DEPLOYED_IMAGE_ID_BEFORE="$(
-  kubectl get deployment controller-manager -n kontext-system \
+  kubectl get deployment kontext-controller-manager -n kontext-system \
     -o jsonpath='{.spec.template.metadata.annotations.kontext\.dev/local-operator-image-id}' \
     2>/dev/null || true
 )"
@@ -89,7 +89,7 @@ kubectl kustomize "${KIND_OVERLAY_DIR}" |
   kubectl apply -f -
 
 echo "==> waiting for controller rollout"
-kubectl rollout status deployment/controller-manager -n kontext-system --timeout=120s
+kubectl rollout status deployment/kontext-controller-manager -n kontext-system --timeout=120s
 
 if [[ -n "${CONTROLLER_POD_UID_BEFORE}" &&
   "${DEPLOYED_IMAGE_ID_BEFORE}" != "${OPERATOR_IMAGE_ID}" ]]; then
@@ -114,7 +114,7 @@ fi
 
 echo "==> ready"
 kubectl get crd agents.kontext.dev agentruns.kontext.dev
-kubectl get deploy -n kontext-system controller-manager
+kubectl get deploy -n kontext-system kontext-controller-manager
 echo "controller local image identity: ${OPERATOR_IMAGE_ID}"
 kubectl get pods -n kontext-system -l control-plane=controller-manager \
   -o custom-columns='NAME:.metadata.name,IMAGE:.spec.containers[0].image,IMAGE_ID:.status.containerStatuses[0].imageID,READY:.status.containerStatuses[0].ready'

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -102,7 +102,7 @@ EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: kontext-controller-manager
   namespace: kontext-system
 spec:
   template:

--- a/scripts/render-release-manifest.sh
+++ b/scripts/render-release-manifest.sh
@@ -85,7 +85,7 @@ cat >"${overlay_dir}/manager_patch.yaml" <<EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: kontext-controller-manager
   namespace: kontext-system
   labels:
     app.kubernetes.io/version: "${release_tag}"

--- a/scripts/test-release-identity.sh
+++ b/scripts/test-release-identity.sh
@@ -94,6 +94,8 @@ grep -Fq "$(kontext_image kontext-operator)@sha256:" "${tmp_dir}/install.yaml" |
   fail "rendered manifest lacks canonical operator image"
 grep -Fq "$(kontext_image kontext-reporter)@sha256:" "${tmp_dir}/install.yaml" ||
   fail "rendered manifest lacks canonical reporter image"
+grep -Fq "name: kontext-controller-manager" "${tmp_dir}/install.yaml" ||
+  fail "release renderer targets the unprefixed manager Deployment"
 
 jq --arg wrong_repository "ghcr.io/other-owner" \
   '(.images[] | select(.name == "operator").immutableReference) |=

--- a/scripts/test-shell-common.sh
+++ b/scripts/test-shell-common.sh
@@ -82,6 +82,8 @@ grep -Fq 'image: "operator:test"' "${overlay}/manager_patch.yaml" ||
   fail "development overlay omitted the operator image"
 grep -Fq 'value: "reporter:test"' "${overlay}/manager_patch.yaml" ||
   fail "development overlay omitted the reporter image"
+grep -Fq 'name: kontext-controller-manager' "${overlay}/manager_patch.yaml" ||
+  fail "development overlay targets the unprefixed manager Deployment"
 
 overlay_with_id="${tmp_dir}/overlay-with-id"
 mkdir "${overlay_with_id}"

--- a/scripts/verify-release-install.sh
+++ b/scripts/verify-release-install.sh
@@ -24,18 +24,18 @@ install_release() {
   local manifest="$1"
   local expect_webhook="${2:-true}"
   kubectl apply -f "${manifest}"
-  kubectl rollout status deployment/controller-manager \
+  kubectl rollout status deployment/kontext-controller-manager \
     --namespace kontext-system \
     --timeout=180s
 
   local operator_image=""
   local reporter_image=""
   operator_image="$(
-    kubectl get deployment controller-manager -n kontext-system \
+    kubectl get deployment kontext-controller-manager -n kontext-system \
       -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].image}'
   )"
   reporter_image="$(
-    kubectl get deployment controller-manager -n kontext-system \
+    kubectl get deployment kontext-controller-manager -n kontext-system \
       -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].env[?(@.name=="KONTEXT_REPORTER_IMAGE")].value}'
   )"
   if [[ "${operator_image}" != *@sha256:* || "${reporter_image}" != *@sha256:* ]]; then
@@ -47,12 +47,13 @@ install_release() {
     return 0
   fi
 
-  kubectl get service webhook-service -n kontext-system >/dev/null
+  kubectl get service kontext-webhook-service -n kontext-system >/dev/null
   kubectl get secret webhook-server-cert -n kontext-system >/dev/null
-  kubectl get mutatingwebhookconfiguration task-agentrun-mutator.kontext.dev >/dev/null
-  kubectl get role webhook-certificate-manager -n kontext-system >/dev/null
-  kubectl get role leader-election-manager -n kontext-system >/dev/null
-  kubectl get clusterrole webhook-registration-manager >/dev/null
+  kubectl get mutatingwebhookconfiguration \
+    kontext-task-agentrun-mutator.kontext.dev >/dev/null
+  kubectl get role kontext-webhook-certificate-manager -n kontext-system >/dev/null
+  kubectl get role kontext-leader-election-manager -n kontext-system >/dev/null
+  kubectl get clusterrole kontext-webhook-registration-manager >/dev/null
 
   local secret_ca=""
   local registered_ca=""
@@ -61,7 +62,8 @@ install_release() {
       -o jsonpath='{.data.ca\.crt}'
   )"
   registered_ca="$(
-    kubectl get mutatingwebhookconfiguration task-agentrun-mutator.kontext.dev \
+    kubectl get mutatingwebhookconfiguration \
+      kontext-task-agentrun-mutator.kontext.dev \
       -o jsonpath='{.webhooks[0].clientConfig.caBundle}'
   )"
   if [[ -z "${secret_ca}" || "${secret_ca}" != "${registered_ca}" ]]; then
@@ -157,11 +159,14 @@ if [[ "${retained_result}" != *"Verify custom-resource retention during control-
   exit 1
 fi
 
-kubectl delete clusterrolebinding manager-rolebinding --ignore-not-found=true
-kubectl delete clusterrole manager-role --ignore-not-found=true
-kubectl delete mutatingwebhookconfiguration task-agentrun-mutator.kontext.dev --ignore-not-found=true
-kubectl delete clusterrolebinding webhook-registration-manager --ignore-not-found=true
-kubectl delete clusterrole webhook-registration-manager --ignore-not-found=true
+kubectl delete clusterrolebinding kontext-manager-rolebinding --ignore-not-found=true
+kubectl delete clusterrole kontext-manager-role --ignore-not-found=true
+kubectl delete mutatingwebhookconfiguration \
+  kontext-task-agentrun-mutator.kontext.dev --ignore-not-found=true
+kubectl delete clusterrolebinding \
+  kontext-webhook-registration-manager --ignore-not-found=true
+kubectl delete clusterrole \
+  kontext-webhook-registration-manager --ignore-not-found=true
 kubectl delete namespace kontext-system --ignore-not-found=true --wait=true
 
 kubectl get crd agents.kontext.dev agentruns.kontext.dev >/dev/null
@@ -190,11 +195,13 @@ kubectl delete -f "${CURRENT_MANIFEST}" --ignore-not-found=true --wait=true
 if kubectl get crd agents.kontext.dev >/dev/null 2>&1 ||
   kubectl get crd agentruns.kontext.dev >/dev/null 2>&1 ||
   kubectl get namespace kontext-system >/dev/null 2>&1 ||
-  kubectl get clusterrole manager-role >/dev/null 2>&1 ||
-  kubectl get clusterrolebinding manager-rolebinding >/dev/null 2>&1 ||
-  kubectl get mutatingwebhookconfiguration task-agentrun-mutator.kontext.dev >/dev/null 2>&1 ||
-  kubectl get clusterrole webhook-registration-manager >/dev/null 2>&1 ||
-  kubectl get clusterrolebinding webhook-registration-manager >/dev/null 2>&1; then
+  kubectl get clusterrole kontext-manager-role >/dev/null 2>&1 ||
+  kubectl get clusterrolebinding kontext-manager-rolebinding >/dev/null 2>&1 ||
+  kubectl get mutatingwebhookconfiguration \
+    kontext-task-agentrun-mutator.kontext.dev >/dev/null 2>&1 ||
+  kubectl get clusterrole kontext-webhook-registration-manager >/dev/null 2>&1 ||
+  kubectl get clusterrolebinding \
+    kontext-webhook-registration-manager >/dev/null 2>&1; then
   echo "complete uninstall left Kontext resources behind" >&2
   exit 1
 fi

--- a/scripts/verify-release-install.sh
+++ b/scripts/verify-release-install.sh
@@ -20,22 +20,93 @@ if [[ -n "${PREVIOUS_MANIFEST}" && (! -f "${PREVIOUS_MANIFEST}" || -z "${PREVIOU
   exit 2
 fi
 
+remove_legacy_control_plane() {
+  kubectl delete deployment/controller-manager \
+    -n kontext-system --ignore-not-found=true --wait=true
+  kubectl delete \
+    mutatingwebhookconfiguration/task-agentrun-mutator.kontext.dev \
+    clusterrolebinding/manager-rolebinding \
+    clusterrolebinding/webhook-registration-manager \
+    clusterrole/manager-role \
+    clusterrole/webhook-registration-manager \
+    --ignore-not-found=true
+  kubectl delete \
+    service/webhook-service \
+    serviceaccount/controller-manager \
+    rolebinding/leader-election-manager \
+    rolebinding/webhook-certificate-manager \
+    role/leader-election-manager \
+    role/webhook-certificate-manager \
+    networkpolicy/controller-manager-webhook \
+    -n kontext-system --ignore-not-found=true
+}
+
+remove_prefixed_control_plane() {
+  kubectl delete deployment/kontext-controller-manager \
+    -n kontext-system --ignore-not-found=true --wait=true
+  kubectl delete \
+    mutatingwebhookconfiguration/kontext-task-agentrun-mutator.kontext.dev \
+    clusterrolebinding/kontext-manager-rolebinding \
+    clusterrolebinding/kontext-webhook-registration-manager \
+    clusterrole/kontext-manager-role \
+    clusterrole/kontext-webhook-registration-manager \
+    --ignore-not-found=true
+  kubectl delete \
+    service/kontext-webhook-service \
+    serviceaccount/kontext-controller-manager \
+    rolebinding/kontext-leader-election-manager \
+    rolebinding/kontext-webhook-certificate-manager \
+    role/kontext-leader-election-manager \
+    role/kontext-webhook-certificate-manager \
+    networkpolicy/kontext-controller-manager-webhook \
+    -n kontext-system --ignore-not-found=true
+}
+
+manifest_identity() {
+  local manifest="$1"
+  if grep -Fxq "  name: kontext-controller-manager" "${manifest}"; then
+    printf '%s\n' current
+  elif grep -Fxq "  name: controller-manager" "${manifest}"; then
+    printf '%s\n' legacy
+  else
+    echo "manifest does not contain a recognized controller Deployment: ${manifest}" >&2
+    return 1
+  fi
+}
+
 install_release() {
   local manifest="$1"
   local expect_webhook="${2:-true}"
+  local identity="${3:-current}"
+  local deployment=""
+
+  case "${identity}" in
+    current) deployment="kontext-controller-manager" ;;
+    legacy) deployment="controller-manager" ;;
+    *)
+      echo "unsupported control-plane identity: ${identity}" >&2
+      return 2
+      ;;
+  esac
+
   kubectl apply -f "${manifest}"
-  kubectl rollout status deployment/kontext-controller-manager \
+  if [[ "${identity}" == "current" ]]; then
+    remove_legacy_control_plane
+  else
+    remove_prefixed_control_plane
+  fi
+  kubectl rollout status "deployment/${deployment}" \
     --namespace kontext-system \
     --timeout=180s
 
   local operator_image=""
   local reporter_image=""
   operator_image="$(
-    kubectl get deployment kontext-controller-manager -n kontext-system \
+    kubectl get deployment "${deployment}" -n kontext-system \
       -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].image}'
   )"
   reporter_image="$(
-    kubectl get deployment kontext-controller-manager -n kontext-system \
+    kubectl get deployment "${deployment}" -n kontext-system \
       -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].env[?(@.name=="KONTEXT_REPORTER_IMAGE")].value}'
   )"
   if [[ "${operator_image}" != *@sha256:* || "${reporter_image}" != *@sha256:* ]]; then
@@ -89,23 +160,33 @@ smoke_release_runtime() {
   kubectl delete agentrun echo-review --wait=true
 }
 
+CURRENT_IDENTITY="$(manifest_identity "${CURRENT_MANIFEST}")"
+if [[ "${CURRENT_IDENTITY}" != "current" ]]; then
+  echo "current manifest does not use the prefixed control-plane identity" >&2
+  exit 1
+fi
+PREVIOUS_IDENTITY=""
+if [[ -n "${PREVIOUS_MANIFEST}" ]]; then
+  PREVIOUS_IDENTITY="$(manifest_identity "${PREVIOUS_MANIFEST}")"
+fi
+
 if [[ -n "${PREVIOUS_MANIFEST}" ]]; then
   echo "==> installing previous release ${PREVIOUS_VERSION}"
-  install_release "${PREVIOUS_MANIFEST}" false
+  install_release "${PREVIOUS_MANIFEST}" false "${PREVIOUS_IDENTITY}"
   smoke_release_runtime "${PREVIOUS_VERSION}"
 fi
 
 echo "==> installing current release ${CURRENT_VERSION}"
-install_release "${CURRENT_MANIFEST}" true
+install_release "${CURRENT_MANIFEST}" true current
 smoke_release_runtime "${CURRENT_VERSION}"
 
 if [[ -n "${PREVIOUS_MANIFEST}" ]]; then
   echo "==> rolling back to previous release ${PREVIOUS_VERSION}"
-  install_release "${PREVIOUS_MANIFEST}" false
+  install_release "${PREVIOUS_MANIFEST}" false "${PREVIOUS_IDENTITY}"
   smoke_release_runtime "${PREVIOUS_VERSION}"
 
   echo "==> restoring current release ${CURRENT_VERSION}"
-  install_release "${CURRENT_MANIFEST}" true
+  install_release "${CURRENT_MANIFEST}" true current
   smoke_release_runtime "${CURRENT_VERSION}"
 fi
 
@@ -159,14 +240,8 @@ if [[ "${retained_result}" != *"Verify custom-resource retention during control-
   exit 1
 fi
 
-kubectl delete clusterrolebinding kontext-manager-rolebinding --ignore-not-found=true
-kubectl delete clusterrole kontext-manager-role --ignore-not-found=true
-kubectl delete mutatingwebhookconfiguration \
-  kontext-task-agentrun-mutator.kontext.dev --ignore-not-found=true
-kubectl delete clusterrolebinding \
-  kontext-webhook-registration-manager --ignore-not-found=true
-kubectl delete clusterrole \
-  kontext-webhook-registration-manager --ignore-not-found=true
+remove_prefixed_control_plane
+remove_legacy_control_plane
 kubectl delete namespace kontext-system --ignore-not-found=true --wait=true
 
 kubectl get crd agents.kontext.dev agentruns.kontext.dev >/dev/null
@@ -174,7 +249,7 @@ kubectl get agent retained-install-check -n default >/dev/null
 kubectl get agentrun retained-install-invocation -n default >/dev/null
 
 echo "==> reinstalling after retained-CRD removal"
-install_release "${CURRENT_MANIFEST}" true
+install_release "${CURRENT_MANIFEST}" true current
 kubectl get agent retained-install-check -n default >/dev/null
 kubectl get agentrun retained-install-invocation -n default >/dev/null
 kubectl delete agent retained-install-check -n default --wait=true
@@ -201,7 +276,14 @@ if kubectl get crd agents.kontext.dev >/dev/null 2>&1 ||
     kontext-task-agentrun-mutator.kontext.dev >/dev/null 2>&1 ||
   kubectl get clusterrole kontext-webhook-registration-manager >/dev/null 2>&1 ||
   kubectl get clusterrolebinding \
-    kontext-webhook-registration-manager >/dev/null 2>&1; then
+    kontext-webhook-registration-manager >/dev/null 2>&1 ||
+  kubectl get deployment controller-manager -n kontext-system >/dev/null 2>&1 ||
+  kubectl get clusterrole manager-role >/dev/null 2>&1 ||
+  kubectl get clusterrolebinding manager-rolebinding >/dev/null 2>&1 ||
+  kubectl get mutatingwebhookconfiguration \
+    task-agentrun-mutator.kontext.dev >/dev/null 2>&1 ||
+  kubectl get clusterrole webhook-registration-manager >/dev/null 2>&1 ||
+  kubectl get clusterrolebinding webhook-registration-manager >/dev/null 2>&1; then
   echo "complete uninstall left Kontext resources behind" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- apply the standard `kontext-` Kustomize prefix so cluster-scoped install resources cannot collide with other kubebuilder operators
- carry renamed resources through overlays, webhook TLS/RBAC configuration, scripts, diagnostics, and public install documentation
- add regression assertions for the prefix, webhook registration identity, and generated manager patches

## Test plan
- [x] Render `config/default`, `config/overlays/release`, and `config/overlays/dev`; verify resource names and references
- [x] Render the release manifest from `scripts/testdata/release-image-digests.json`
- [x] `make verify`
- [x] `make test`
- [x] `bash -n scripts/*.sh scripts/lib/*.sh`
- [x] Docs site typecheck, build, and generated-content verification