### PR TITLE
Make AgentRun terminal states immutable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -94,6 +94,7 @@ func main() {
 
 	if err := (&controller.AgentRunReconciler{
 		Client:        mgr.GetClient(),
+		APIReader:     mgr.GetAPIReader(),
 		Scheme:        mgr.GetScheme(),
 		ReporterImage: reporterImage,
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controller/agentrun_controller.go
+++ b/internal/controller/agentrun_controller.go
@@ -22,6 +22,7 @@ import (
 // AgentRunReconciler reconciles an AgentRun object.
 type AgentRunReconciler struct {
 	client.Client
+	APIReader     client.Reader
 	Scheme        *runtime.Scheme
 	ReporterImage string
 }
@@ -35,6 +36,13 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	var run kontextv1alpha1.AgentRun
 	if err := r.Get(ctx, req.NamespacedName, &run); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if status.IsTerminalPhase(run.Status.Phase) {
+		if run.Status.Phase == kontextv1alpha1.AgentRunPhaseBudgetExceeded {
+			return ctrl.Result{}, r.deleteBudgetExceededPod(ctx, &run)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	podName := run.Status.PodName
@@ -65,39 +73,76 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 		}
 	}
-	if !podMissing && !metav1.IsControlledBy(pod, &run) {
-		if status.IsTerminalPhase(run.Status.Phase) {
-			return ctrl.Result{}, nil
+	if podMissing && run.Status.PodName != "" {
+		if r.APIReader == nil {
+			return ctrl.Result{}, fmt.Errorf(
+				"cannot verify missing Pod %s/%s: APIReader is not configured",
+				run.Namespace,
+				podName,
+			)
 		}
+		livePod := &corev1.Pod{}
+		if err := r.APIReader.Get(ctx, podKey, livePod); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+		} else {
+			pod = livePod
+			podMissing = false
+		}
+	}
+	if !podMissing && !metav1.IsControlledBy(pod, &run) {
 		return r.failPodNameCollision(ctx, &run, pod)
 	}
 
-	var wallclockLimit *time.Duration
-	if !status.IsTerminalPhase(run.Status.Phase) {
-		parsedLimit, budgetErr := parseWallclockBudget(run.Spec.Budget)
-		if budgetErr != nil {
-			return r.failInvalidWallclock(ctx, &run, pod, !podMissing, budgetErr)
-		}
-		wallclockLimit = parsedLimit
+	wallclockLimit, budgetErr := parseWallclockBudget(run.Spec.Budget)
+	if budgetErr != nil {
+		return r.failInvalidWallclock(ctx, &run, pod, !podMissing, budgetErr)
 	}
 
 	if podMissing {
 		return r.reconcileMissingPod(ctx, &run, podName)
 	}
 
-	wallclockResult, done, err := r.enforceWallclock(ctx, &run, pod, wallclockLimit)
-	if err != nil || done {
+	wallclockResult, err := r.enforceWallclock(ctx, &run, pod, wallclockLimit)
+	if err != nil || status.IsTerminalPhase(run.Status.Phase) {
 		return wallclockResult, err
 	}
 
-	observationResult, err := r.syncPodObservation(ctx, &run, pod, podName)
-	if err != nil {
+	if err := r.syncPodObservation(ctx, &run, pod, podName); err != nil {
 		return ctrl.Result{}, err
 	}
-	if wallclockResult.RequeueAfter > 0 {
-		return wallclockResult, nil
+	return wallclockResult, nil
+}
+
+func (r *AgentRunReconciler) deleteBudgetExceededPod(
+	ctx context.Context,
+	run *kontextv1alpha1.AgentRun,
+) error {
+	if r.APIReader == nil {
+		return fmt.Errorf(
+			"cannot delete Pod for budget-exceeded AgentRun %s/%s: APIReader is not configured",
+			run.Namespace,
+			run.Name,
+		)
 	}
-	return observationResult, nil
+
+	podName := run.Status.PodName
+	if podName == "" {
+		podName = podbuilder.PodNameForRun(run.Name)
+	}
+	pod := &corev1.Pod{}
+	podKey := client.ObjectKey{Namespace: run.Namespace, Name: podName}
+	if err := r.APIReader.Get(ctx, podKey, pod); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !metav1.IsControlledBy(pod, run) {
+		return nil
+	}
+	if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 func (r *AgentRunReconciler) failPodNameCollision(
@@ -112,58 +157,45 @@ func (r *AgentRunReconciler) failPodNameCollision(
 		run.Namespace,
 		run.Name,
 	)
-	return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
-		next.Phase = kontextv1alpha1.AgentRunPhaseFailed
-		next.PodName = pod.Name
-		next.Result = ""
-		next.Output = nil
-		next.Usage = nil
-		next.StartTime = nil
-		if next.Message != message || next.CompletionTime == nil {
-			next.CompletionTime = nowPtr()
-		}
-		next.Message = message
-		setStatusConditions(
-			&next.Conditions,
-			run.Generation,
-			conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhaseFailed)...,
-		)
-	})
+	return ctrl.Result{}, r.transitionRun(
+		ctx,
+		run,
+		kontextv1alpha1.AgentRunPhaseFailed,
+		message,
+		func(next *kontextv1alpha1.AgentRunStatus) {
+			next.PodName = pod.Name
+			next.Result = ""
+			next.Output = nil
+			next.Usage = nil
+			next.StartTime = nil
+		},
+	)
 }
 
 func (r *AgentRunReconciler) reconcileMissingPod(ctx context.Context, run *kontextv1alpha1.AgentRun, podName string) (ctrl.Result, error) {
-	if status.IsTerminalPhase(run.Status.Phase) {
-		return ctrl.Result{}, nil
-	}
-
 	if run.Status.PodName != "" {
-		return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
-			next.Phase = kontextv1alpha1.AgentRunPhaseFailed
-			next.PodName = podName
-			next.Message = "Pod lost before run completed."
-			next.CompletionTime = nowPtr()
-			setStatusConditions(
-				&next.Conditions,
-				run.Generation,
-				conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhaseFailed)...,
-			)
-		})
+		return ctrl.Result{}, r.transitionRun(
+			ctx,
+			run,
+			kontextv1alpha1.AgentRunPhaseFailed,
+			"Pod lost before run completed.",
+			func(next *kontextv1alpha1.AgentRunStatus) {
+				next.PodName = podName
+			},
+		)
 	}
 
 	pod, err := podbuilder.BuildPodWithConfig(run, podbuilder.Config{
 		ReporterImage: r.ReporterImage,
 	})
 	if err != nil {
-		return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
-			next.Phase = kontextv1alpha1.AgentRunPhaseFailed
-			next.Message = fmt.Sprintf("Agent run configuration is invalid: %v.", err)
-			next.CompletionTime = nowPtr()
-			setStatusConditions(
-				&next.Conditions,
-				run.Generation,
-				conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhaseFailed)...,
-			)
-		})
+		return ctrl.Result{}, r.transitionRun(
+			ctx,
+			run,
+			kontextv1alpha1.AgentRunPhaseFailed,
+			fmt.Sprintf("Agent run configuration is invalid: %v.", err),
+			nil,
+		)
 	}
 	if err := controllerutil.SetControllerReference(run, pod, r.Scheme); err != nil {
 		return ctrl.Result{}, err
@@ -172,19 +204,18 @@ func (r *AgentRunReconciler) reconcileMissingPod(ctx context.Context, run *konte
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
-		next.Phase = kontextv1alpha1.AgentRunPhasePending
-		next.PodName = podName
-		next.Message = "Agent run pod requested."
-		setStatusConditions(
-			&next.Conditions,
-			run.Generation,
-			conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhasePending)...,
-		)
-	})
+	return ctrl.Result{}, r.transitionRun(
+		ctx,
+		run,
+		kontextv1alpha1.AgentRunPhasePending,
+		"Agent run pod requested.",
+		func(next *kontextv1alpha1.AgentRunStatus) {
+			next.PodName = podName
+		},
+	)
 }
 
-func (r *AgentRunReconciler) syncPodObservation(ctx context.Context, run *kontextv1alpha1.AgentRun, pod *corev1.Pod, podName string) (ctrl.Result, error) {
+func (r *AgentRunReconciler) syncPodObservation(ctx context.Context, run *kontextv1alpha1.AgentRun, pod *corev1.Pod, podName string) error {
 	observation := status.ObservePod(pod)
 
 	err := r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
@@ -214,10 +245,10 @@ func (r *AgentRunReconciler) syncPodObservation(ctx context.Context, run *kontex
 		)
 	})
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
-	return ctrl.Result{}, nil
+	return nil
 }
 
 func parseWallclockBudget(budget *kontextv1alpha1.BudgetSpec) (*time.Duration, error) {
@@ -251,19 +282,17 @@ func (r *AgentRunReconciler) failInvalidWallclock(
 		}
 	}
 
-	return ctrl.Result{}, r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
-		next.Phase = kontextv1alpha1.AgentRunPhaseFailed
-		if podExists {
-			next.PodName = pod.Name
-		}
-		next.Message = fmt.Sprintf("Agent run configuration is invalid: %v.", cause)
-		next.CompletionTime = nowPtr()
-		setStatusConditions(
-			&next.Conditions,
-			run.Generation,
-			conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhaseFailed)...,
-		)
-	})
+	return ctrl.Result{}, r.transitionRun(
+		ctx,
+		run,
+		kontextv1alpha1.AgentRunPhaseFailed,
+		fmt.Sprintf("Agent run configuration is invalid: %v.", cause),
+		func(next *kontextv1alpha1.AgentRunStatus) {
+			if podExists {
+				next.PodName = pod.Name
+			}
+		},
+	)
 }
 
 func (r *AgentRunReconciler) enforceWallclock(
@@ -271,22 +300,13 @@ func (r *AgentRunReconciler) enforceWallclock(
 	run *kontextv1alpha1.AgentRun,
 	pod *corev1.Pod,
 	limit *time.Duration,
-) (ctrl.Result, bool, error) {
-	if run.Status.Phase == kontextv1alpha1.AgentRunPhaseBudgetExceeded {
-		if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, true, err
-		}
-		return ctrl.Result{}, true, nil
-	}
+) (ctrl.Result, error) {
 	if limit == nil {
-		return ctrl.Result{}, false, nil
-	}
-	if status.IsTerminalPhase(run.Status.Phase) {
-		return ctrl.Result{}, false, nil
+		return ctrl.Result{}, nil
 	}
 
 	if pod.Status.Phase != corev1.PodRunning {
-		return ctrl.Result{}, false, nil
+		return ctrl.Result{}, nil
 	}
 
 	startedAt := status.ObservePod(pod).StartedAt
@@ -294,35 +314,61 @@ func (r *AgentRunReconciler) enforceWallclock(
 		startedAt = run.Status.StartTime
 	}
 	if startedAt == nil {
-		return ctrl.Result{}, false, nil
+		return ctrl.Result{}, nil
 	}
 
 	elapsed := time.Since(startedAt.Time)
 	if elapsed <= *limit {
 		remaining := *limit - elapsed
-		return ctrl.Result{RequeueAfter: remaining + time.Second}, false, nil
+		return ctrl.Result{RequeueAfter: remaining + time.Second}, nil
 	}
 
-	err := r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
-		next.Phase = kontextv1alpha1.AgentRunPhaseBudgetExceeded
-		next.PodName = pod.Name
-		next.Message = fmt.Sprintf("Wallclock budget exceeded after %s.", *limit)
-		recordedStart := *startedAt
-		next.StartTime = &recordedStart
-		next.CompletionTime = nowPtr()
+	err := r.transitionRun(
+		ctx,
+		run,
+		kontextv1alpha1.AgentRunPhaseBudgetExceeded,
+		fmt.Sprintf("Wallclock budget exceeded after %s.", *limit),
+		func(next *kontextv1alpha1.AgentRunStatus) {
+			next.PodName = pod.Name
+			recordedStart := *startedAt
+			next.StartTime = &recordedStart
+		},
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *AgentRunReconciler) transitionRun(
+	ctx context.Context,
+	run *kontextv1alpha1.AgentRun,
+	phase kontextv1alpha1.AgentRunPhase,
+	message string,
+	update func(*kontextv1alpha1.AgentRunStatus),
+) error {
+	return r.patchRunStatus(ctx, run, func(next *kontextv1alpha1.AgentRunStatus) {
+		next.Phase = phase
+		next.Message = message
+		if update != nil {
+			update(next)
+		}
+		if status.IsTerminalPhase(phase) {
+			if next.CompletionTime == nil {
+				next.CompletionTime = nowPtr()
+			}
+		} else {
+			next.CompletionTime = nil
+		}
 		setStatusConditions(
 			&next.Conditions,
 			run.Generation,
-			conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhaseBudgetExceeded)...,
+			conditions.ForAgentRunPhase(phase)...,
 		)
 	})
-	if err != nil {
-		return ctrl.Result{}, false, err
-	}
-	if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
-		return ctrl.Result{}, true, err
-	}
-	return ctrl.Result{}, true, nil
 }
 
 func (r *AgentRunReconciler) patchRunStatus(ctx context.Context, run *kontextv1alpha1.AgentRun, mutate func(*kontextv1alpha1.AgentRunStatus)) error {

--- a/internal/controller/agentrun_controller_test.go
+++ b/internal/controller/agentrun_controller_test.go
@@ -10,12 +10,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/conditions"
 	"github.com/MFS-code/Kontext/internal/podbuilder"
 	"github.com/MFS-code/Kontext/internal/testsupport"
 )
@@ -314,6 +316,72 @@ func TestAgentRunReconcilerFailsWhenPodLost(t *testing.T) {
 	}
 }
 
+func TestAgentRunReconcilerDoesNotFailWhenCachedPodReadIsStale(t *testing.T) {
+	ctx := context.Background()
+	runName := "stale-pod-read"
+	podName := podbuilder.PodNameForRun(runName)
+	run := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{Name: runName, Namespace: "default"},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			Goal:     "hello",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := updateAgentRunStatus(ctx, run, kontextv1alpha1.AgentRunStatus{
+		Phase:   kontextv1alpha1.AgentRunPhasePending,
+		PodName: podName,
+	}); err != nil {
+		t.Fatalf("update run status: %v", err)
+	}
+
+	pod := buildOwnedPod(t, run)
+	if err := k8sClient.Create(ctx, pod); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+	podKey := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
+	if err := k8sClient.Get(ctx, podKey, pod); err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	started := metav1.Now()
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: podbuilder.RuntimeContainerName,
+		State: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{StartedAt: started},
+		},
+	}}
+	if err := k8sClient.Status().Update(ctx, pod); err != nil {
+		t.Fatalf("update pod status: %v", err)
+	}
+
+	reconciler := newAgentRunReconciler()
+	reconciler.Client = &stalePodGetClient{
+		Client:   k8sClient,
+		omitName: podKey,
+	}
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile with stale Pod read: %v", err)
+	}
+
+	var updated kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(run), &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if updated.Status.Phase != kontextv1alpha1.AgentRunPhaseRunning {
+		t.Fatalf("expected live Pod to keep run healthy, got %s", updated.Status.Phase)
+	}
+	if updated.Status.CompletionTime != nil {
+		t.Fatalf("healthy run was marked complete: %#v", updated.Status)
+	}
+}
+
 func TestAgentRunReconcilerRejectsPodNameCollision(t *testing.T) {
 	ctx := context.Background()
 	run := &kontextv1alpha1.AgentRun{
@@ -424,6 +492,78 @@ func TestAgentRunReconcilerPreservesTerminalStatusOnForeignPodReuse(t *testing.T
 		updated.Status.CompletionTime == nil ||
 		!updated.Status.CompletionTime.Equal(&completed) {
 		t.Fatalf("terminal status changed after foreign Pod reuse: %#v", updated.Status)
+	}
+}
+
+func TestAgentRunReconcilerPreservesTerminalStatusWithRunningPod(t *testing.T) {
+	ctx := context.Background()
+	run := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "terminal-running-pod",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			Goal:     "hello",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	completed := metav1.NewTime(time.Now().Truncate(time.Second))
+	terminalConditions := conditions.ForAgentRunPhase(kontextv1alpha1.AgentRunPhaseSucceeded)
+	for i := range terminalConditions {
+		terminalConditions[i].LastTransitionTime = completed
+		terminalConditions[i].ObservedGeneration = run.Generation
+	}
+	if err := updateAgentRunStatus(ctx, run, kontextv1alpha1.AgentRunStatus{
+		Phase:          kontextv1alpha1.AgentRunPhaseSucceeded,
+		PodName:        podbuilder.PodNameForRun(run.Name),
+		Result:         "final result",
+		Message:        "Run completed successfully.",
+		CompletionTime: &completed,
+		Conditions:     terminalConditions,
+	}); err != nil {
+		t.Fatalf("update run status: %v", err)
+	}
+
+	pod := buildOwnedPod(t, run)
+	if err := k8sClient.Create(ctx, pod); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: podbuilder.RuntimeContainerName,
+		State: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()},
+		},
+	}}
+	if err := k8sClient.Status().Update(ctx, pod); err != nil {
+		t.Fatalf("update pod status: %v", err)
+	}
+
+	reconcileAgentRun(ctx, t, client.ObjectKeyFromObject(run))
+
+	var updated kontextv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(run), &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if updated.Status.Phase != kontextv1alpha1.AgentRunPhaseSucceeded ||
+		updated.Status.Result != "final result" ||
+		updated.Status.Message != "Run completed successfully." ||
+		updated.Status.CompletionTime == nil ||
+		!updated.Status.CompletionTime.Equal(&completed) {
+		t.Fatalf("terminal status regressed from stale Pod state: %#v", updated.Status)
+	}
+	for _, condition := range updated.Status.Conditions {
+		if condition.Type == conditions.Complete && condition.Status != metav1.ConditionTrue {
+			t.Fatalf("terminal Complete condition regressed: %#v", updated.Status.Conditions)
+		}
 	}
 }
 
@@ -910,6 +1050,24 @@ type deleteErrorClient struct {
 
 func (c *deleteErrorClient) Delete(context.Context, client.Object, ...client.DeleteOption) error {
 	return c.err
+}
+
+type stalePodGetClient struct {
+	client.Client
+	omitName types.NamespacedName
+}
+
+func (c *stalePodGetClient) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	if _, isPod := obj.(*corev1.Pod); isPod && key == c.omitName {
+		c.omitName = types.NamespacedName{}
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, key.Name)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
 }
 
 // legacyWallclockClient simulates a persisted object created before CRD

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -112,7 +112,7 @@ func TestEnforceWallclockTreatsOmissionAsNoDeadline(t *testing.T) {
 	}
 
 	for _, run := range runs {
-		result, done, err := reconciler.enforceWallclock(
+		result, err := reconciler.enforceWallclock(
 			context.Background(),
 			run,
 			&corev1.Pod{},
@@ -121,8 +121,8 @@ func TestEnforceWallclockTreatsOmissionAsNoDeadline(t *testing.T) {
 		if err != nil {
 			t.Fatalf("omitted wallclock returned error: %v", err)
 		}
-		if done || result.Requeue || result.RequeueAfter != 0 {
-			t.Fatalf("omitted wallclock scheduled enforcement: result=%#v done=%t", result, done)
+		if result.Requeue || result.RequeueAfter != 0 {
+			t.Fatalf("omitted wallclock scheduled enforcement: result=%#v", result)
 		}
 		if len(run.Status.Conditions) != 0 {
 			t.Fatalf("omitted wallclock wrote conditions: %#v", run.Status.Conditions)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -62,6 +62,7 @@ func TestMain(m *testing.M) {
 func newAgentRunReconciler() *controller.AgentRunReconciler {
 	return &controller.AgentRunReconciler{
 		Client:        k8sClient,
+		APIReader:     k8sClient,
 		Scheme:        scheme,
 		ReporterImage: "kontext-reporter:dev",
 	}


### PR DESCRIPTION
## Summary
- return immediately for terminal AgentRuns while preserving BudgetExceeded Pod cleanup
- confirm cached Pod misses with the direct API reader before marking a run failed
- centralize phase transitions and simplify wallclock enforcement flow
- add regressions for stale running Pods and stale cache NotFound reads

## Test plan
- `make verify`
- `go build ./...`
- `go vet ./...`
- `KUBEBUILDER_ASSETS=\"$(./bin/setup-envtest use 1.32.0 -p path)\" go test ./...`