### PR TITLE
Converge webhook registration with server-side apply

### DIFF
--- a/config/rbac/rbac_test.go
+++ b/config/rbac/rbac_test.go
@@ -46,7 +46,8 @@ func TestLeaderElectionRBACIsSeparatedFromWebhookCertificates(t *testing.T) {
 		!slices.Equal(
 			registrationRole.Rules[1].ResourceNames,
 			[]string{"kontext-task-agentrun-mutator.kontext.dev"},
-		) {
+		) ||
+		!slices.Equal(registrationRole.Rules[1].Verbs, []string{"get", "patch", "update"}) {
 		t.Fatalf("webhook registration resource names = %#v", registrationRole.Rules)
 	}
 

--- a/config/rbac/webhook_role.yaml
+++ b/config/rbac/webhook_role.yaml
@@ -53,6 +53,7 @@ rules:
       - kontext-task-agentrun-mutator.kontext.dev
     verbs:
       - get
+      - patch
       - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/internal/webhooktls/envtest_test.go
+++ b/internal/webhooktls/envtest_test.go
@@ -71,6 +71,24 @@ func TestEnvtestRealTLSAndNarrowAdmissionBypass(t *testing.T) {
 	if err := lifecycle.Ensure(ctx); err != nil {
 		t.Fatalf("bootstrap self-managed TLS: %v", err)
 	}
+	var registration admissionv1.MutatingWebhookConfiguration
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: DefaultWebhookName}, &registration); err != nil {
+		t.Fatalf("get converged registration: %v", err)
+	}
+	resourceVersion := registration.ResourceVersion
+	if err := lifecycle.Ensure(ctx); err != nil {
+		t.Fatalf("repeat self-managed TLS reconciliation: %v", err)
+	}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: DefaultWebhookName}, &registration); err != nil {
+		t.Fatalf("get registration after repeated reconciliation: %v", err)
+	}
+	if registration.ResourceVersion != resourceVersion {
+		t.Fatalf(
+			"unchanged registration was written again: resourceVersion %s became %s",
+			resourceVersion,
+			registration.ResourceVersion,
+		)
+	}
 
 	server := webhook.NewServer(webhook.Options{
 		Host: testEnvironment.WebhookInstallOptions.LocalServingHost,
@@ -88,7 +106,6 @@ func TestEnvtestRealTLSAndNarrowAdmissionBypass(t *testing.T) {
 	}()
 	waitForWebhookServer(t, server)
 
-	var registration admissionv1.MutatingWebhookConfiguration
 	if err := k8sClient.Get(ctx, client.ObjectKey{Name: DefaultWebhookName}, &registration); err != nil {
 		t.Fatalf("get registration: %v", err)
 	}

--- a/internal/webhooktls/lifecycle.go
+++ b/internal/webhooktls/lifecycle.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"time"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -28,6 +27,7 @@ const (
 	DefaultServiceName       = "kontext-webhook-service"
 	DefaultWebhookPath       = "/mutate-kontext-dev-v1alpha1-agentrun"
 	DefaultReconcileInterval = 30 * time.Second
+	registrationFieldOwner   = "kontext-webhooktls"
 
 	nextCAKey     = "next-ca.crt"
 	nextCAKeyPEM  = "next-ca.key"
@@ -327,37 +327,13 @@ func (l *Lifecycle) clearNext(ctx context.Context, secret *corev1.Secret) error 
 
 func (l *Lifecycle) reconcileRegistration(ctx context.Context, caBundle []byte) error {
 	desired := l.desiredRegistration(caBundle)
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		var existing admissionv1.MutatingWebhookConfiguration
-		err := l.client.Get(ctx, client.ObjectKey{Name: l.opts.WebhookName}, &existing)
-		if apierrors.IsNotFound(err) {
-			if createErr := l.client.Create(ctx, desired.DeepCopy()); apierrors.IsAlreadyExists(createErr) {
-				return apierrors.NewConflict(
-					admissionv1.Resource("mutatingwebhookconfigurations"),
-					l.opts.WebhookName,
-					createErr,
-				)
-			} else {
-				return createErr
-			}
-		}
-		if err != nil {
-			return err
-		}
-		if reflect.DeepEqual(existing.Webhooks, desired.Webhooks) &&
-			existing.Labels["app.kubernetes.io/name"] == "kontext" &&
-			existing.Labels["app.kubernetes.io/managed-by"] == "kontext" {
-			return nil
-		}
-		desired.ObjectMeta = *existing.ObjectMeta.DeepCopy()
-		if desired.Labels == nil {
-			desired.Labels = map[string]string{}
-		}
-		for key, value := range managedLabels() {
-			desired.Labels[key] = value
-		}
-		return l.client.Update(ctx, desired.DeepCopy())
-	})
+	return l.client.Patch(
+		ctx,
+		desired,
+		client.Apply,
+		client.FieldOwner(registrationFieldOwner),
+		client.ForceOwnership,
+	)
 }
 
 func (l *Lifecycle) desiredRegistration(caBundle []byte) *admissionv1.MutatingWebhookConfiguration {
@@ -369,6 +345,10 @@ func (l *Lifecycle) desiredRegistration(caBundle []byte) *admissionv1.MutatingWe
 	never := admissionv1.NeverReinvocationPolicy
 	timeout := int32(5)
 	return &admissionv1.MutatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: admissionv1.SchemeGroupVersion.String(),
+			Kind:       "MutatingWebhookConfiguration",
+		},
 		ObjectMeta: metav1.ObjectMeta{Name: l.opts.WebhookName, Labels: managedLabels()},
 		Webhooks: []admissionv1.MutatingWebhook{{
 			Name: l.opts.WebhookName,

--- a/internal/webhooktls/lifecycle_test.go
+++ b/internal/webhooktls/lifecycle_test.go
@@ -4,16 +4,23 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/yaml"
 )
 
 type testClock struct {
@@ -178,6 +185,39 @@ func TestPromotionRetriesWhenRegistrationChanges(t *testing.T) {
 	}
 }
 
+func TestDesiredRegistrationMatchesManagerManifest(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(
+		"..", "..", "config", "manager", "mutating_webhook_configuration.yaml",
+	))
+	if err != nil {
+		t.Fatalf("read webhook registration manifest: %v", err)
+	}
+	var manifest admissionv1.MutatingWebhookConfiguration
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse webhook registration manifest: %v", err)
+	}
+
+	// config/default applies this prefix to resource names and service references.
+	const namePrefix = "kontext-"
+	manifest.Name = namePrefix + manifest.Name
+	for index := range manifest.Webhooks {
+		service := manifest.Webhooks[index].ClientConfig.Service
+		if service != nil {
+			service.Name = namePrefix + service.Name
+		}
+	}
+
+	lifecycle := NewLifecycle(nil, nil, DefaultOptions())
+	desired := lifecycle.desiredRegistration(nil)
+	if !reflect.DeepEqual(manifest, *desired) {
+		t.Fatalf(
+			"manager manifest and runtime webhook registration differ:\nmanifest: %#v\ndesired:  %#v",
+			manifest,
+			*desired,
+		)
+	}
+}
+
 func TestServingRenewalPreservesStagedCARotation(t *testing.T) {
 	ctx := context.Background()
 	clock := &testClock{now: time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC)}
@@ -269,7 +309,48 @@ func newFakeClient(t *testing.T, objects ...client.Object) client.Client {
 	if err := admissionv1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add admission scheme: %v", err)
 	}
-	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	var applyMu sync.Mutex
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(
+				ctx context.Context,
+				k8sClient client.WithWatch,
+				obj client.Object,
+				patch client.Patch,
+				_ ...client.PatchOption,
+			) error {
+				if patch.Type() != types.ApplyPatchType {
+					return k8sClient.Patch(ctx, obj, patch)
+				}
+				desired, ok := obj.(*admissionv1.MutatingWebhookConfiguration)
+				if !ok {
+					t.Fatalf("unexpected apply object type %T", obj)
+				}
+
+				applyMu.Lock()
+				defer applyMu.Unlock()
+				var existing admissionv1.MutatingWebhookConfiguration
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(desired), &existing)
+				if apierrors.IsNotFound(err) {
+					return k8sClient.Create(ctx, desired.DeepCopy())
+				}
+				if err != nil {
+					return err
+				}
+				existing.TypeMeta = desired.TypeMeta
+				if existing.Labels == nil {
+					existing.Labels = map[string]string{}
+				}
+				for key, value := range desired.Labels {
+					existing.Labels[key] = value
+				}
+				existing.Webhooks = desired.DeepCopy().Webhooks
+				return k8sClient.Update(ctx, &existing)
+			},
+		}).
+		Build()
 }
 
 func getSecret(t *testing.T, k8sClient client.Client) *corev1.Secret {


### PR DESCRIPTION
## Summary
- reconcile the webhook registration with one server-side apply operation
- preserve independently owned metadata while eliminating periodic no-op updates
- guard runtime and manifest registration parity and verify envtest convergence

## Test plan
- `make test`