### PR TITLE
Tighten legacy result classification

### DIFF
--- a/pkg/result/v1alpha1/parse.go
+++ b/pkg/result/v1alpha1/parse.go
@@ -66,9 +66,11 @@ func Parse(message string) (Envelope, bool, error) {
 }
 
 func hasLegacyField(fields map[string]json.RawMessage) bool {
-	for _, key := range [...]string{"result", "tokensUsed", "dollarsUsed", "error"} {
-		if _, ok := fields[key]; ok {
-			return true
+	for field := range fields {
+		for _, key := range [...]string{"result", "tokensUsed", "dollarsUsed", "error"} {
+			if strings.EqualFold(field, key) {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/result/v1alpha1/parse.go
+++ b/pkg/result/v1alpha1/parse.go
@@ -48,6 +48,9 @@ func Parse(message string) (Envelope, bool, error) {
 		}
 		return envelope, false, nil
 	}
+	if !hasLegacyField(fields) {
+		return Envelope{}, false, errors.New("decode termination payload: unrecognized JSON object")
+	}
 
 	var legacy LegacyPayload
 	if err := json.Unmarshal([]byte(message), &legacy); err != nil {
@@ -60,6 +63,15 @@ func Parse(message string) (Envelope, bool, error) {
 		envelope.Error = &ErrorInfo{Message: legacy.Error}
 	}
 	return envelope, true, nil
+}
+
+func hasLegacyField(fields map[string]json.RawMessage) bool {
+	for _, key := range [...]string{"result", "tokensUsed", "dollarsUsed", "error"} {
+		if _, ok := fields[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseVersioned decodes a termination message only when the wire payload

--- a/pkg/result/v1alpha1/result_test.go
+++ b/pkg/result/v1alpha1/result_test.go
@@ -63,9 +63,10 @@ func TestParseLegacyPayload(t *testing.T) {
 
 func TestParseClassifiesLegacyPayloadsByKnownKeys(t *testing.T) {
 	tests := []struct {
-		name      string
-		message   string
-		wantError bool
+		name       string
+		message    string
+		wantError  bool
+		wantResult string
 	}{
 		{
 			name:      "typoed envelope",
@@ -78,8 +79,9 @@ func TestParseClassifiesLegacyPayloadsByKnownKeys(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name:    "result only",
-			message: `{"result":"done"}`,
+			name:       "result only",
+			message:    `{"result":"done"}`,
+			wantResult: "done",
 		},
 		{
 			name:    "tokens used only",
@@ -94,14 +96,20 @@ func TestParseClassifiesLegacyPayloadsByKnownKeys(t *testing.T) {
 			message: `{"error":"diagnostic"}`,
 		},
 		{
-			name:    "existing legacy payload",
-			message: `{"result":"done","tokensUsed":12,"dollarsUsed":1.5,"error":"diagnostic"}`,
+			name:       "existing legacy payload",
+			message:    `{"result":"done","tokensUsed":12,"dollarsUsed":1.5,"error":"diagnostic"}`,
+			wantResult: "done",
+		},
+		{
+			name:       "case folded legacy key",
+			message:    `{"Result":"done"}`,
+			wantResult: "done",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, legacy, err := resultv1alpha1.Parse(test.message)
+			envelope, legacy, err := resultv1alpha1.Parse(test.message)
 			if test.wantError {
 				if err == nil {
 					t.Fatal("expected unrecognized payload error")
@@ -116,6 +124,9 @@ func TestParseClassifiesLegacyPayloadsByKnownKeys(t *testing.T) {
 			}
 			if !legacy {
 				t.Fatal("expected legacy wire format")
+			}
+			if got := resultv1alpha1.ProjectLegacyResult(envelope.Output); got != test.wantResult {
+				t.Fatalf("expected legacy result %q, got %q", test.wantResult, got)
 			}
 		})
 	}

--- a/pkg/result/v1alpha1/result_test.go
+++ b/pkg/result/v1alpha1/result_test.go
@@ -61,6 +61,66 @@ func TestParseLegacyPayload(t *testing.T) {
 	}
 }
 
+func TestParseClassifiesLegacyPayloadsByKnownKeys(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   string
+		wantError bool
+	}{
+		{
+			name:      "typoed envelope",
+			message:   `{"Outcome":"Failed"}`,
+			wantError: true,
+		},
+		{
+			name:      "unrelated object",
+			message:   `{"message":"done"}`,
+			wantError: true,
+		},
+		{
+			name:    "result only",
+			message: `{"result":"done"}`,
+		},
+		{
+			name:    "tokens used only",
+			message: `{"tokensUsed":12}`,
+		},
+		{
+			name:    "dollars used only",
+			message: `{"dollarsUsed":1.5}`,
+		},
+		{
+			name:    "error only",
+			message: `{"error":"diagnostic"}`,
+		},
+		{
+			name:    "existing legacy payload",
+			message: `{"result":"done","tokensUsed":12,"dollarsUsed":1.5,"error":"diagnostic"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, legacy, err := resultv1alpha1.Parse(test.message)
+			if test.wantError {
+				if err == nil {
+					t.Fatal("expected unrecognized payload error")
+				}
+				if legacy {
+					t.Fatal("unrecognized payload must not be classified as legacy")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse legacy payload: %v", err)
+			}
+			if !legacy {
+				t.Fatal("expected legacy wire format")
+			}
+		})
+	}
+}
+
 func TestParseLegacyPayloadWithoutUsageLeavesUsageAbsent(t *testing.T) {
 	parsed, legacy, err := resultv1alpha1.Parse(`{"result":"done"}`)
 	if err != nil {


### PR DESCRIPTION
## Summary
- recognize legacy result JSON only when a known legacy key is present
- reject typoed envelopes and unrelated JSON objects as actionable payload errors
- cover every legacy key and existing payload shapes with table-driven tests

## Test plan
- `go test ./pkg/... ./internal/status/...`
- `make test`