### PR TITLE
Index AgentRuns by controlling Agent UID

### DIFF
--- a/internal/controller/agent_controller.go
+++ b/internal/controller/agent_controller.go
@@ -16,7 +16,6 @@ import (
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 	"github.com/MFS-code/Kontext/internal/conditions"
-	"github.com/MFS-code/Kontext/internal/podbuilder"
 	"github.com/MFS-code/Kontext/internal/runfactory"
 	"github.com/MFS-code/Kontext/internal/scheduler"
 	"github.com/MFS-code/Kontext/internal/status"
@@ -26,6 +25,8 @@ const (
 	defaultBackoffInitial = 5
 	defaultBackoffMax     = 60
 	maxRunSuffix          = int32(1<<31 - 1)
+	// AgentRunOwnerUIDField is the cache index for controlling Agent UIDs.
+	AgentRunOwnerUIDField = ".metadata.controller"
 )
 
 // AgentReconciler reconciles an Agent object.
@@ -62,18 +63,15 @@ func (r *AgentReconciler) reconcileTask(
 	ctx context.Context,
 	agent *kontextv1alpha1.Agent,
 ) (ctrl.Result, error) {
-	var children kontextv1alpha1.AgentRunList
-	if err := r.List(ctx, &children, client.InNamespace(agent.Namespace)); err != nil {
+	children, err := r.ownedRuns(ctx, agent)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	var newest *kontextv1alpha1.AgentRun
 	var retained int32
-	for i := range children.Items {
-		run := &children.Items[i]
-		if !metav1.IsControlledBy(run, agent) {
-			continue
-		}
+	for i := range children {
+		run := &children[i]
 		if retained == maxRunSuffix {
 			return ctrl.Result{}, fmt.Errorf(
 				"Task Agent %s/%s owns more than %d retained AgentRuns",
@@ -251,23 +249,15 @@ func (r *AgentReconciler) observeServiceRuns(
 	ctx context.Context,
 	agent *kontextv1alpha1.Agent,
 ) (observedServiceRuns, error) {
-	var children kontextv1alpha1.AgentRunList
-	if err := r.List(
-		ctx,
-		&children,
-		client.InNamespace(agent.Namespace),
-		client.MatchingLabels{podbuilder.LabelAgentName: agent.Name},
-	); err != nil {
+	children, err := r.ownedRuns(ctx, agent)
+	if err != nil {
 		return observedServiceRuns{}, err
 	}
 
 	var observed observedServiceRuns
 	var previousSuffix int32
-	for i := range children.Items {
-		run := &children.Items[i]
-		if !metav1.IsControlledBy(run, agent) {
-			continue
-		}
+	for i := range children {
+		run := &children[i]
 		suffix, ok := serviceRunSuffix(agent.Name, run.Name)
 		if !ok {
 			continue
@@ -377,8 +367,53 @@ func (r *AgentReconciler) now() time.Time {
 	return time.Now()
 }
 
+func (r *AgentReconciler) ownedRuns(
+	ctx context.Context,
+	agent *kontextv1alpha1.Agent,
+) ([]kontextv1alpha1.AgentRun, error) {
+	if agent.UID == "" {
+		return nil, fmt.Errorf("Agent %s/%s has no UID", agent.Namespace, agent.Name)
+	}
+	var runs kontextv1alpha1.AgentRunList
+	if err := r.List(
+		ctx,
+		&runs,
+		client.InNamespace(agent.Namespace),
+		client.MatchingFields{AgentRunOwnerUIDField: string(agent.UID)},
+	); err != nil {
+		return nil, err
+	}
+	return runs.Items, nil
+}
+
+// RegisterAgentRunOwnerIndex indexes AgentRuns by their controlling Agent UID.
+func RegisterAgentRunOwnerIndex(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(
+		ctx,
+		&kontextv1alpha1.AgentRun{},
+		AgentRunOwnerUIDField,
+		func(object client.Object) []string {
+			run, ok := object.(*kontextv1alpha1.AgentRun)
+			if !ok {
+				return nil
+			}
+			owner := metav1.GetControllerOf(run)
+			if owner == nil ||
+				owner.APIVersion != kontextv1alpha1.GroupVersion.String() ||
+				owner.Kind != "Agent" ||
+				owner.UID == "" {
+				return nil
+			}
+			return []string{string(owner.UID)}
+		},
+	)
+}
+
 // SetupWithManager sets up the Manager.
 func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := RegisterAgentRunOwnerIndex(context.Background(), mgr.GetFieldIndexer()); err != nil {
+		return fmt.Errorf("index AgentRuns by owner UID: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kontextv1alpha1.Agent{}).
 		Owns(&kontextv1alpha1.AgentRun{}).

--- a/internal/controller/agent_controller_test.go
+++ b/internal/controller/agent_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -316,12 +317,12 @@ func TestAgentReconcilerRequeuesWhenCachedListMissesOwnedRun(t *testing.T) {
 	createOwnedAgentRun(ctx, t, agent, run)
 
 	staleClient := &staleAgentRunListClient{
-		Client:   k8sClient,
+		Client:   newOwnerIndexedClient(),
 		omitName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace},
 	}
 	reconciler := &controller.AgentReconciler{
 		Client:    staleClient,
-		APIReader: k8sClient,
+		APIReader: apiReader,
 		Scheme:    scheme,
 	}
 	result, err := reconciler.Reconcile(ctx, ctrl.Request{
@@ -479,6 +480,80 @@ func TestAgentReconcilerNoopsWhenRunActive(t *testing.T) {
 	}
 	if len(runs.Items) != 1 {
 		t.Fatalf("expected one run, got %d", len(runs.Items))
+	}
+}
+
+func TestAgentReconcilerObservesOwnedServiceRunWithoutLabel(t *testing.T) {
+	ctx := context.Background()
+	agent := &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unlabeled-owner",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:     kontextv1alpha1.AgentModeService,
+			Goal:     "stay ready",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	run := &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unlabeled-owner-1",
+			Namespace: agent.Namespace,
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			AgentRef: &kontextv1alpha1.AgentRef{Name: agent.Name},
+			Goal:     agent.Spec.Goal,
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+		},
+	}
+	createOwnedAgentRun(ctx, t, agent, run)
+
+	reconciler := newAgentReconciler()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace},
+		})
+		if err != nil {
+			t.Fatalf("reconcile unlabeled owned run: %v", err)
+		}
+		if !result.Requeue {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("unlabeled owned run caused a hot requeue loop")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	var duplicate kontextv1alpha1.AgentRun
+	err := apiReader.Get(ctx, types.NamespacedName{
+		Name:      "unlabeled-owner-2",
+		Namespace: agent.Namespace,
+	}, &duplicate)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("unexpected duplicate service run: %v", err)
+	}
+
+	var updated kontextv1alpha1.Agent
+	if err := apiReader.Get(
+		ctx,
+		types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace},
+		&updated,
+	); err != nil {
+		t.Fatalf("get reconciled agent: %v", err)
+	}
+	if updated.Status.CurrentRunName != run.Name || updated.Status.RunsCreated != 1 {
+		t.Fatalf("unlabeled owned run was not observed: %#v", updated.Status)
 	}
 }
 

--- a/internal/controller/agent_scheduled.go
+++ b/internal/controller/agent_scheduled.go
@@ -13,7 +13,6 @@ import (
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 	"github.com/MFS-code/Kontext/internal/conditions"
-	"github.com/MFS-code/Kontext/internal/podbuilder"
 	"github.com/MFS-code/Kontext/internal/runfactory"
 	"github.com/MFS-code/Kontext/internal/scheduledrun"
 	"github.com/MFS-code/Kontext/internal/scheduler"
@@ -195,25 +194,12 @@ func (r *AgentReconciler) observeScheduledRuns(
 	ctx context.Context,
 	agent *kontextv1alpha1.Agent,
 ) (observedScheduledRuns, error) {
-	var children kontextv1alpha1.AgentRunList
-	if err := r.List(
-		ctx,
-		&children,
-		client.InNamespace(agent.Namespace),
-		client.MatchingLabels{podbuilder.LabelAgentName: agent.Name},
-	); err != nil {
+	children, err := r.ownedRuns(ctx, agent)
+	if err != nil {
 		return observedScheduledRuns{}, err
 	}
 
-	owned := make([]kontextv1alpha1.AgentRun, 0, len(children.Items))
-	for i := range children.Items {
-		run := &children.Items[i]
-		if !metav1.IsControlledBy(run, agent) {
-			continue
-		}
-		owned = append(owned, *run.DeepCopy())
-	}
-	return summarizeScheduledRuns(owned), nil
+	return summarizeScheduledRuns(children), nil
 }
 
 func summarizeScheduledRuns(items []kontextv1alpha1.AgentRun) observedScheduledRuns {

--- a/internal/controller/agent_scheduled_test.go
+++ b/internal/controller/agent_scheduled_test.go
@@ -280,12 +280,12 @@ func TestScheduledRecoversCreateSuccessStatusFailure(t *testing.T) {
 	reconcileScheduled(ctx, t, reconciler, agent)
 
 	clock.Set(time.Date(2026, time.July, 20, 12, 1, 5, 0, time.UTC))
-	failingClient := &failAgentStatusPatchOnceClient{Client: k8sClient, fail: true}
+	failingClient := &failAgentStatusPatchOnceClient{Client: newOwnerIndexedClient(), fail: true}
 	reconciler.Client = failingClient
 	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(agent)}); err == nil {
 		t.Fatal("expected injected status failure")
 	}
-	reconciler.Client = k8sClient
+	reconciler.Client = newOwnerIndexedClient()
 	reconcileScheduled(ctx, t, reconciler, agent)
 
 	runs := listOwnedRuns(ctx, t, agent)
@@ -311,7 +311,7 @@ func TestScheduledStaleCacheAndUnrelatedCollision(t *testing.T) {
 
 		clock.Set(time.Date(2026, time.July, 20, 12, 1, 5, 0, time.UTC))
 		reconciler.Client = &staleAgentRunListClient{
-			Client:   k8sClient,
+			Client:   newOwnerIndexedClient(),
 			omitName: types.NamespacedName{Name: runName, Namespace: agent.Namespace},
 		}
 		reconcileScheduled(ctx, t, reconciler, agent)
@@ -594,8 +594,8 @@ func (w *failAgentStatusWriter) Patch(
 
 func newScheduledReconciler(clock scheduler.Clock) *controller.AgentReconciler {
 	return &controller.AgentReconciler{
-		Client:    k8sClient,
-		APIReader: k8sClient,
+		Client:    newOwnerIndexedClient(),
+		APIReader: apiReader,
 		Scheme:    scheme,
 		Clock:     clock,
 	}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -64,7 +64,11 @@ func TestMain(m *testing.M) {
 	go func() {
 		cacheErrors <- manager.GetCache().Start(ctx)
 	}()
-	if !manager.GetCache().WaitForCacheSync(ctx) {
+	syncCtx, cancelSync := context.WithTimeout(ctx, 10*time.Second)
+	cacheSynced := manager.GetCache().WaitForCacheSync(syncCtx)
+	cancelSync()
+	if !cacheSynced {
+		cancelCache()
 		panic("controller test cache did not sync")
 	}
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -2,10 +2,13 @@ package controller_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -22,10 +25,12 @@ import (
 )
 
 var (
-	testEnv   *envtest.Environment
-	cfg       *rest.Config
-	k8sClient client.Client
-	scheme    *runtime.Scheme
+	testEnv       *envtest.Environment
+	cfg           *rest.Config
+	k8sClient     client.Client
+	apiReader     client.Reader
+	indexedReader client.Reader
+	scheme        *runtime.Scheme
 )
 
 func TestMain(m *testing.M) {
@@ -47,12 +52,33 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(kontextv1alpha1.AddToScheme(scheme))
 
+	manager, err := ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme})
+	if err != nil {
+		panic(err)
+	}
+	ctx, cancelCache := context.WithCancel(context.Background())
+	if err := controller.RegisterAgentRunOwnerIndex(ctx, manager.GetFieldIndexer()); err != nil {
+		panic(err)
+	}
+	cacheErrors := make(chan error, 1)
+	go func() {
+		cacheErrors <- manager.GetCache().Start(ctx)
+	}()
+	if !manager.GetCache().WaitForCacheSync(ctx) {
+		panic("controller test cache did not sync")
+	}
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		panic(err)
 	}
+	apiReader = manager.GetAPIReader()
+	indexedReader = manager.GetClient()
 
 	code := m.Run()
+	cancelCache()
+	if cacheErr := <-cacheErrors; cacheErr != nil {
+		panic(cacheErr)
+	}
 	if stopErr := testEnv.Stop(); stopErr != nil {
 		panic(stopErr)
 	}
@@ -62,7 +88,7 @@ func TestMain(m *testing.M) {
 func newAgentRunReconciler() *controller.AgentRunReconciler {
 	return &controller.AgentRunReconciler{
 		Client:        k8sClient,
-		APIReader:     k8sClient,
+		APIReader:     apiReader,
 		Scheme:        scheme,
 		ReporterImage: "kontext-reporter:dev",
 	}
@@ -70,10 +96,87 @@ func newAgentRunReconciler() *controller.AgentRunReconciler {
 
 func newAgentReconciler() *controller.AgentReconciler {
 	return &controller.AgentReconciler{
-		Client:    k8sClient,
-		APIReader: k8sClient,
+		Client:    newOwnerIndexedClient(),
+		APIReader: apiReader,
 		Scheme:    scheme,
 	}
+}
+
+type ownerIndexedClient struct {
+	client.Client
+	indexedReader client.Reader
+}
+
+func newOwnerIndexedClient() client.Client {
+	return &ownerIndexedClient{Client: k8sClient, indexedReader: indexedReader}
+}
+
+func (c *ownerIndexedClient) List(
+	ctx context.Context,
+	list client.ObjectList,
+	opts ...client.ListOption,
+) error {
+	runs, isAgentRunList := list.(*kontextv1alpha1.AgentRunList)
+	options := (&client.ListOptions{}).ApplyOptions(opts)
+	if !isAgentRunList || options.FieldSelector == nil {
+		return c.Client.List(ctx, list, opts...)
+	}
+	ownerUID, indexed := options.FieldSelector.RequiresExactMatch(controller.AgentRunOwnerUIDField)
+	if !indexed {
+		return c.Client.List(ctx, list, opts...)
+	}
+
+	var liveRuns kontextv1alpha1.AgentRunList
+	if err := c.Client.List(
+		ctx,
+		&liveRuns,
+		client.InNamespace(options.Namespace),
+	); err != nil {
+		return err
+	}
+	expected := make(map[string]struct{})
+	for i := range liveRuns.Items {
+		owner := metav1.GetControllerOf(&liveRuns.Items[i])
+		if owner != nil &&
+			owner.APIVersion == kontextv1alpha1.GroupVersion.String() &&
+			owner.Kind == "Agent" &&
+			string(owner.UID) == ownerUID {
+			expected[liveRuns.Items[i].Name] = struct{}{}
+		}
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := c.indexedReader.List(ctx, runs, opts...); err != nil {
+			return err
+		}
+		if indexedRunNamesMatch(runs.Items, expected) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("AgentRun owner index did not converge for UID %s", ownerUID)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+func indexedRunNamesMatch(
+	actual []kontextv1alpha1.AgentRun,
+	expected map[string]struct{},
+) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for i := range actual {
+		if _, ok := expected[actual[i].Name]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func reconcileAgentRun(ctx context.Context, t *testing.T, name types.NamespacedName) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -138,14 +138,14 @@ func (c *ownerIndexedClient) List(
 	); err != nil {
 		return err
 	}
-	expected := make(map[string]struct{})
+	expected := make(map[string]string)
 	for i := range liveRuns.Items {
 		owner := metav1.GetControllerOf(&liveRuns.Items[i])
 		if owner != nil &&
 			owner.APIVersion == kontextv1alpha1.GroupVersion.String() &&
 			owner.Kind == "Agent" &&
 			string(owner.UID) == ownerUID {
-			expected[liveRuns.Items[i].Name] = struct{}{}
+			expected[liveRuns.Items[i].Name] = liveRuns.Items[i].ResourceVersion
 		}
 	}
 
@@ -154,7 +154,7 @@ func (c *ownerIndexedClient) List(
 		if err := c.indexedReader.List(ctx, runs, opts...); err != nil {
 			return err
 		}
-		if indexedRunNamesMatch(runs.Items, expected) {
+		if indexedRunsMatch(runs.Items, expected) {
 			return nil
 		}
 		if time.Now().After(deadline) {
@@ -168,15 +168,16 @@ func (c *ownerIndexedClient) List(
 	}
 }
 
-func indexedRunNamesMatch(
+func indexedRunsMatch(
 	actual []kontextv1alpha1.AgentRun,
-	expected map[string]struct{},
+	expected map[string]string,
 ) bool {
 	if len(actual) != len(expected) {
 		return false
 	}
 	for i := range actual {
-		if _, ok := expected[actual[i].Name]; !ok {
+		resourceVersion, ok := expected[actual[i].Name]
+		if !ok || actual[i].ResourceVersion != resourceVersion {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary
- define ownership through the controlling Agent UID for every Agent mode
- replace namespace and label scans with one indexed owned-run query
- prevent unlabeled Service children from triggering duplicate-create requeue loops

## Test plan
- `make test`