### PR TITLE
Split Agent controller tests by mode

### DIFF
--- a/internal/controller/agent_controller_test.go
+++ b/internal/controller/agent_controller_test.go
@@ -13,7 +13,6 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
 	"github.com/MFS-code/Kontext/internal/conditions"
@@ -283,19 +282,7 @@ func TestAgentReconcilerServiceRunMatchesLegacyBuildOutput(t *testing.T) {
 
 func TestAgentReconcilerRequeuesWhenCachedListMissesOwnedRun(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "stale-list-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-		},
-	}
+	agent := newServiceAgent("stale-list-owner", nil)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -368,19 +355,7 @@ func TestAgentReconcilerRequeuesWhenCachedListMissesOwnedRun(t *testing.T) {
 
 func TestAgentReconcilerRejectsUnrelatedRunNameCollision(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "collision-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-		},
-	}
+	agent := newServiceAgent("collision-owner", nil)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -428,19 +403,7 @@ func TestAgentReconcilerRejectsUnrelatedRunNameCollision(t *testing.T) {
 
 func TestAgentReconcilerNoopsWhenRunActive(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "active-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-		},
-	}
+	agent := newServiceAgent("active-owner", nil)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -485,19 +448,7 @@ func TestAgentReconcilerNoopsWhenRunActive(t *testing.T) {
 
 func TestAgentReconcilerObservesOwnedServiceRunWithoutLabel(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "unlabeled-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-		},
-	}
+	agent := newServiceAgent("unlabeled-owner", nil)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -559,20 +510,10 @@ func TestAgentReconcilerObservesOwnedServiceRunWithoutLabel(t *testing.T) {
 
 func TestAgentReconcilerRecastsTerminalRunWithStaleStatus(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "recast-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-			Backoff:  &kontextv1alpha1.BackoffSpec{InitialSeconds: 1, MaxSeconds: 1},
-		},
-	}
+	agent := newServiceAgent(
+		"recast-owner",
+		&kontextv1alpha1.BackoffSpec{InitialSeconds: 1, MaxSeconds: 1},
+	)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -641,19 +582,7 @@ func TestAgentReconcilerRecastsTerminalRunWithStaleStatus(t *testing.T) {
 
 func TestAgentReconcilerRecastsTerminalRunWithoutCompletionTime(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "missing-completion-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-		},
-	}
+	agent := newServiceAgent("missing-completion-owner", nil)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -708,20 +637,10 @@ func TestAgentReconcilerRecastsTerminalRunWithoutCompletionTime(t *testing.T) {
 
 func TestAgentReconcilerBacksOffFromObservedTerminalRun(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backoff-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-			Backoff:  &kontextv1alpha1.BackoffSpec{InitialSeconds: 30, MaxSeconds: 30},
-		},
-	}
+	agent := newServiceAgent(
+		"backoff-owner",
+		&kontextv1alpha1.BackoffSpec{InitialSeconds: 30, MaxSeconds: 30},
+	)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -777,19 +696,7 @@ func TestAgentReconcilerBacksOffFromObservedTerminalRun(t *testing.T) {
 
 func TestAgentReconcilerIgnoresStaleStatusWhenNoChildrenExist(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "missing-run-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-		},
-	}
+	agent := newServiceAgent("missing-run-owner", nil)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -821,19 +728,7 @@ func TestAgentReconcilerIgnoresStaleStatusWhenNoChildrenExist(t *testing.T) {
 
 func TestAgentReconcilerRecoversStatusFromObservedChildren(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "exists-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-		},
-	}
+	agent := newServiceAgent("exists-owner", nil)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -879,20 +774,10 @@ func TestAgentReconcilerRecoversStatusFromObservedChildren(t *testing.T) {
 
 func TestAgentReconcilerUsesOwnedCanonicalRunSequence(t *testing.T) {
 	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sequence-owner",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:     kontextv1alpha1.AgentModeService,
-			Goal:     "stay ready",
-			Provider: "echo",
-			Model:    "echo-model",
-			Runtime:  echoRuntimeSpec(),
-			Backoff:  &kontextv1alpha1.BackoffSpec{InitialSeconds: 1, MaxSeconds: 1},
-		},
-	}
+	agent := newServiceAgent(
+		"sequence-owner",
+		&kontextv1alpha1.BackoffSpec{InitialSeconds: 1, MaxSeconds: 1},
+	)
 	if err := k8sClient.Create(ctx, agent); err != nil {
 		t.Fatalf("create agent: %v", err)
 	}
@@ -955,185 +840,19 @@ func TestAgentReconcilerUsesOwnedCanonicalRunSequence(t *testing.T) {
 	}
 }
 
-func TestAgentReconcilerProjectsTaskReadinessAndRetainedChildren(t *testing.T) {
-	ctx := context.Background()
-	agent := &kontextv1alpha1.Agent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "task-agent",
-			Namespace: "default",
-		},
-		Spec: kontextv1alpha1.AgentSpec{
-			Mode:         kontextv1alpha1.AgentModeTask,
-			GoalTemplate: "Review ${area}.",
-			Model:        "echo-model",
-			Runtime:      echoRuntimeSpec(),
-		},
-	}
-	if err := k8sClient.Create(ctx, agent); err != nil {
-		t.Fatalf("create agent: %v", err)
-	}
-
-	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
-
-	var updated kontextv1alpha1.Agent
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
-		t.Fatalf("get agent: %v", err)
-	}
-	if updated.Status.RunsCreated != 0 ||
-		updated.Status.LastRunName != "" ||
-		updated.Status.CurrentRunName != "" ||
-		updated.Status.Restarts != 0 ||
-		updated.Status.ObservedGeneration != updated.Generation {
-		t.Fatalf("new Task Agent minted or projected a run: %#v", updated.Status)
-	}
-	ready := false
-	for _, condition := range updated.Status.Conditions {
-		if condition.Type == conditions.Ready &&
-			condition.Status == metav1.ConditionTrue &&
-			condition.Reason == "TemplateReady" &&
-			condition.ObservedGeneration == updated.Generation {
-			ready = true
-		}
-	}
-	if !ready {
-		t.Fatalf("expected ready Task template, got %#v", updated.Status.Conditions)
-	}
-
-	first := taskRunForAgent(agent, "z-first")
-	createOwnedAgentRun(ctx, t, agent, first)
-	time.Sleep(1100 * time.Millisecond)
-	second := taskRunForAgent(agent, "a-second")
-	createOwnedAgentRun(ctx, t, agent, second)
-
-	ownedWithoutLabel := taskRunForAgent(agent, "owned-without-label")
-	ownedWithoutLabel.Labels = nil
-	time.Sleep(1100 * time.Millisecond)
-	createOwnedAgentRun(ctx, t, agent, ownedWithoutLabel)
-
-	unrelated := taskRunForAgent(agent, "unrelated-same-label")
-	if err := k8sClient.Create(ctx, unrelated); err != nil {
-		t.Fatalf("create unrelated same-label run: %v", err)
-	}
-
-	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
-		t.Fatalf("get projected Task Agent: %v", err)
-	}
-	if updated.Status.RunsCreated != 3 ||
-		updated.Status.LastRunName != ownedWithoutLabel.Name ||
-		updated.Status.CurrentRunName != "" ||
-		updated.Status.Restarts != 0 {
-		t.Fatalf("unexpected concurrent Task projection: %#v", updated.Status)
-	}
-
-	if err := k8sClient.Delete(ctx, ownedWithoutLabel); err != nil {
-		t.Fatalf("delete newest retained Task run: %v", err)
-	}
-	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
-		t.Fatalf("get Task Agent after retained deletion: %v", err)
-	}
-	if updated.Status.RunsCreated != 2 || updated.Status.LastRunName != second.Name {
-		t.Fatalf("retained Task projection did not decrease exactly: %#v", updated.Status)
-	}
-
-	updated.Spec.GoalTemplate = "Review ${area} for ${"
-	if err := k8sClient.Update(ctx, &updated); err != nil {
-		t.Fatalf("update Task template: %v", err)
-	}
-	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
-		t.Fatalf("get invalid Task Agent status: %v", err)
-	}
-	if updated.Status.ObservedGeneration != updated.Generation {
-		t.Fatalf(
-			"observed generation = %d, want %d",
-			updated.Status.ObservedGeneration,
-			updated.Generation,
-		)
-	}
-	for _, condition := range updated.Status.Conditions {
-		if condition.Type == conditions.Ready &&
-			condition.Status == metav1.ConditionFalse &&
-			condition.Reason == "InvalidTemplate" {
-			return
-		}
-	}
-	t.Fatalf("malformed Task template remained Ready: %#v", updated.Status.Conditions)
-}
-
-func taskRunForAgent(
-	agent *kontextv1alpha1.Agent,
+func newServiceAgent(
 	name string,
-) *kontextv1alpha1.AgentRun {
-	return &kontextv1alpha1.AgentRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: agent.Namespace,
-			Labels: map[string]string{
-				podbuilder.LabelAgentName: agent.Name,
-			},
-		},
-		Spec: kontextv1alpha1.AgentRunSpec{
-			AgentRef:   &kontextv1alpha1.AgentRef{Name: agent.Name},
-			Parameters: map[string]string{"area": name},
-			Goal:       "Review " + name + ".",
-			Model:      agent.Spec.Model,
-			Runtime:    agent.Spec.Runtime,
+	backoff *kontextv1alpha1.BackoffSpec,
+) *kontextv1alpha1.Agent {
+	return &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:     kontextv1alpha1.AgentModeService,
+			Goal:     "stay ready",
+			Provider: "echo",
+			Model:    "echo-model",
+			Runtime:  echoRuntimeSpec(),
+			Backoff:  backoff,
 		},
 	}
-}
-
-func updateAgentStatus(ctx context.Context, agent *kontextv1alpha1.Agent, next kontextv1alpha1.AgentStatus) error {
-	agent.Status = next
-	return k8sClient.Status().Update(ctx, agent)
-}
-
-func createOwnedAgentRun(
-	ctx context.Context,
-	t *testing.T,
-	agent *kontextv1alpha1.Agent,
-	run *kontextv1alpha1.AgentRun,
-) {
-	t.Helper()
-	if err := controllerutil.SetControllerReference(agent, run, scheme); err != nil {
-		t.Fatalf("set AgentRun owner: %v", err)
-	}
-	if err := k8sClient.Create(ctx, run); err != nil {
-		t.Fatalf("create run: %v", err)
-	}
-}
-
-type staleAgentRunListClient struct {
-	client.Client
-	omitName types.NamespacedName
-}
-
-func (c *staleAgentRunListClient) List(
-	ctx context.Context,
-	list client.ObjectList,
-	opts ...client.ListOption,
-) error {
-	runs, ok := list.(*kontextv1alpha1.AgentRunList)
-	if !ok || c.omitName.Name == "" {
-		return c.Client.List(ctx, list, opts...)
-	}
-	if err := c.Client.List(ctx, runs, opts...); err != nil {
-		return err
-	}
-	filtered := runs.Items[:0]
-	for i := range runs.Items {
-		run := runs.Items[i]
-		if run.Name == c.omitName.Name && run.Namespace == c.omitName.Namespace {
-			continue
-		}
-		filtered = append(filtered, run)
-	}
-	runs.Items = filtered
-	c.omitName = types.NamespacedName{}
-	return nil
-}
-
-func testPtr[T any](value T) *T {
-	return &value
 }

--- a/internal/controller/agent_task_test.go
+++ b/internal/controller/agent_task_test.go
@@ -1,0 +1,143 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+	"github.com/MFS-code/Kontext/internal/conditions"
+	"github.com/MFS-code/Kontext/internal/podbuilder"
+)
+
+func TestAgentReconcilerProjectsTaskReadinessAndRetainedChildren(t *testing.T) {
+	ctx := context.Background()
+	agent := &kontextv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "task-agent",
+			Namespace: "default",
+		},
+		Spec: kontextv1alpha1.AgentSpec{
+			Mode:         kontextv1alpha1.AgentModeTask,
+			GoalTemplate: "Review ${area}.",
+			Model:        "echo-model",
+			Runtime:      echoRuntimeSpec(),
+		},
+	}
+	if err := k8sClient.Create(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
+
+	var updated kontextv1alpha1.Agent
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	if updated.Status.RunsCreated != 0 ||
+		updated.Status.LastRunName != "" ||
+		updated.Status.CurrentRunName != "" ||
+		updated.Status.Restarts != 0 ||
+		updated.Status.ObservedGeneration != updated.Generation {
+		t.Fatalf("new Task Agent minted or projected a run: %#v", updated.Status)
+	}
+	ready := false
+	for _, condition := range updated.Status.Conditions {
+		if condition.Type == conditions.Ready &&
+			condition.Status == metav1.ConditionTrue &&
+			condition.Reason == "TemplateReady" &&
+			condition.ObservedGeneration == updated.Generation {
+			ready = true
+		}
+	}
+	if !ready {
+		t.Fatalf("expected ready Task template, got %#v", updated.Status.Conditions)
+	}
+
+	first := taskRunForAgent(agent, "z-first")
+	createOwnedAgentRun(ctx, t, agent, first)
+	time.Sleep(1100 * time.Millisecond)
+	second := taskRunForAgent(agent, "a-second")
+	createOwnedAgentRun(ctx, t, agent, second)
+
+	ownedWithoutLabel := taskRunForAgent(agent, "owned-without-label")
+	ownedWithoutLabel.Labels = nil
+	time.Sleep(1100 * time.Millisecond)
+	createOwnedAgentRun(ctx, t, agent, ownedWithoutLabel)
+
+	unrelated := taskRunForAgent(agent, "unrelated-same-label")
+	if err := k8sClient.Create(ctx, unrelated); err != nil {
+		t.Fatalf("create unrelated same-label run: %v", err)
+	}
+
+	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get projected Task Agent: %v", err)
+	}
+	if updated.Status.RunsCreated != 3 ||
+		updated.Status.LastRunName != ownedWithoutLabel.Name ||
+		updated.Status.CurrentRunName != "" ||
+		updated.Status.Restarts != 0 {
+		t.Fatalf("unexpected concurrent Task projection: %#v", updated.Status)
+	}
+
+	if err := k8sClient.Delete(ctx, ownedWithoutLabel); err != nil {
+		t.Fatalf("delete newest retained Task run: %v", err)
+	}
+	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get Task Agent after retained deletion: %v", err)
+	}
+	if updated.Status.RunsCreated != 2 || updated.Status.LastRunName != second.Name {
+		t.Fatalf("retained Task projection did not decrease exactly: %#v", updated.Status)
+	}
+
+	updated.Spec.GoalTemplate = "Review ${area} for ${"
+	if err := k8sClient.Update(ctx, &updated); err != nil {
+		t.Fatalf("update Task template: %v", err)
+	}
+	reconcileAgent(ctx, t, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, &updated); err != nil {
+		t.Fatalf("get invalid Task Agent status: %v", err)
+	}
+	if updated.Status.ObservedGeneration != updated.Generation {
+		t.Fatalf(
+			"observed generation = %d, want %d",
+			updated.Status.ObservedGeneration,
+			updated.Generation,
+		)
+	}
+	for _, condition := range updated.Status.Conditions {
+		if condition.Type == conditions.Ready &&
+			condition.Status == metav1.ConditionFalse &&
+			condition.Reason == "InvalidTemplate" {
+			return
+		}
+	}
+	t.Fatalf("malformed Task template remained Ready: %#v", updated.Status.Conditions)
+}
+
+func taskRunForAgent(
+	agent *kontextv1alpha1.Agent,
+	name string,
+) *kontextv1alpha1.AgentRun {
+	return &kontextv1alpha1.AgentRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: agent.Namespace,
+			Labels: map[string]string{
+				podbuilder.LabelAgentName: agent.Name,
+			},
+		},
+		Spec: kontextv1alpha1.AgentRunSpec{
+			AgentRef:   &kontextv1alpha1.AgentRef{Name: agent.Name},
+			Parameters: map[string]string{"area": name},
+			Goal:       "Review " + name + ".",
+			Model:      agent.Spec.Model,
+			Runtime:    agent.Spec.Runtime,
+		},
+	}
+}

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -1,0 +1,70 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kontextv1alpha1 "github.com/MFS-code/Kontext/api/v1alpha1"
+)
+
+func updateAgentStatus(
+	ctx context.Context,
+	agent *kontextv1alpha1.Agent,
+	next kontextv1alpha1.AgentStatus,
+) error {
+	agent.Status = next
+	return k8sClient.Status().Update(ctx, agent)
+}
+
+func createOwnedAgentRun(
+	ctx context.Context,
+	t *testing.T,
+	agent *kontextv1alpha1.Agent,
+	run *kontextv1alpha1.AgentRun,
+) {
+	t.Helper()
+	if err := controllerutil.SetControllerReference(agent, run, scheme); err != nil {
+		t.Fatalf("set AgentRun owner: %v", err)
+	}
+	if err := k8sClient.Create(ctx, run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+}
+
+type staleAgentRunListClient struct {
+	client.Client
+	omitName types.NamespacedName
+}
+
+func (c *staleAgentRunListClient) List(
+	ctx context.Context,
+	list client.ObjectList,
+	opts ...client.ListOption,
+) error {
+	runs, ok := list.(*kontextv1alpha1.AgentRunList)
+	if !ok || c.omitName.Name == "" {
+		return c.Client.List(ctx, list, opts...)
+	}
+	if err := c.Client.List(ctx, runs, opts...); err != nil {
+		return err
+	}
+	filtered := runs.Items[:0]
+	for i := range runs.Items {
+		run := runs.Items[i]
+		if run.Name == c.omitName.Name && run.Namespace == c.omitName.Namespace {
+			continue
+		}
+		filtered = append(filtered, run)
+	}
+	runs.Items = filtered
+	c.omitName = types.NamespacedName{}
+	return nil
+}
+
+func testPtr[T any](value T) *T {
+	return &value
+}


### PR DESCRIPTION
## Summary
- move Task-mode coverage into its own test file
- centralize shared controller test helpers
- replace repeated Service Agent specs with one factory

## Test plan
- `go test ./internal/controller/...`
- `make test`