### PR TITLE
Fix release-gate blockers in public surfaces and grading

### DIFF
--- a/deploy/examples/v1alpha1/echo-task-run.yaml
+++ b/deploy/examples/v1alpha1/echo-task-run.yaml
@@ -3,7 +3,7 @@ kind: AgentRun
 metadata:
   name: echo-review
 spec:
-  goal: Summarize the conventions for the owned files.
+  goal: Summarize the failure modes in this release.
   provider: echo
   model: echo-model
   runtime:

--- a/docs-site/tests/content-integrity.test.mjs
+++ b/docs-site/tests/content-integrity.test.mjs
@@ -67,6 +67,19 @@ const routeSources = new Map(
   ]),
 );
 
+function embeddedKontextManifests(source) {
+  const manifests = [];
+  for (const match of source.matchAll(/<pre\b[^>]*>([\s\S]*?)<\/pre>/g)) {
+    const plainText = match[1].replace(/<\/?span\b[^>]*>/g, "");
+    for (const section of plainText.split(/\n\s*\n|^---\s*$/m)) {
+      if (/^apiVersion:\s*kontext\.dev\//m.test(section)) {
+        manifests.push(section.trim());
+      }
+    }
+  }
+  return manifests;
+}
+
 function decodeLinkPath(rawTarget) {
   const encodedPathname = rawTarget.split("#", 1)[0].split("?", 1)[0];
   try {
@@ -143,6 +156,8 @@ test("public docs contain no stale mode language", () => {
     /\bUnsupportedMode\b/,
     /\breserved\b/i,
     /Until Task mutation ships/i,
+    /\bowned files\b/i,
+    /\bcode owners?\b/i,
   ];
 
   for (const file of publicFiles) {
@@ -154,6 +169,26 @@ test("public docs contain no stale mode language", () => {
         `${path.relative(repoRoot, file)} contains stale public language`,
       );
     }
+  }
+});
+
+test("website AgentRun manifests include required execution fields", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "website/index.html"),
+    "utf8",
+  );
+  const agentRuns = embeddedKontextManifests(source).filter((manifest) =>
+    /^kind:\s*AgentRun\s*$/m.test(manifest),
+  );
+
+  assert.ok(agentRuns.length > 0, "website embeds at least one AgentRun manifest");
+  for (const manifest of agentRuns) {
+    assert.match(manifest, /^  goal:\s+\S.*$/m);
+    assert.match(manifest, /^  provider:\s+\S.*$/m);
+    assert.match(manifest, /^  model:\s+\S.*$/m);
+    const runtime = manifest.match(/^  runtime:\s*\n((?: {4}.*(?:\n|$))*)/m);
+    assert.ok(runtime, "AgentRun spec includes runtime");
+    assert.match(runtime[1], /^    image:\s+\S.*$/m);
   }
 });
 

--- a/internal/eval/grader.go
+++ b/internal/eval/grader.go
@@ -12,6 +12,9 @@ func grade(record *Record, grader Grader) Grade {
 	if err != nil {
 		return Grade{Type: grader.Type, Message: err.Error()}
 	}
+	if err := spec.validate(grader); err != nil {
+		return Grade{Type: grader.Type, Message: "invalid grader: " + err.Error()}
+	}
 	result := spec.grade(record, grader)
 	if !result.Pass && result.Message == "" {
 		result.Message = "observed value did not match expectation"

--- a/internal/eval/observe_grader_test.go
+++ b/internal/eval/observe_grader_test.go
@@ -367,3 +367,32 @@ func TestGradeRecordRejectsUnsupportedGraderType(t *testing.T) {
 		t.Fatalf("unsupported grader was not rejected clearly: %#v", record.Grades)
 	}
 }
+
+func TestGradeRecordRejectsInvalidGradersWithoutPanicking(t *testing.T) {
+	graderTypes := []GraderType{
+		GraderTerminalPhase,
+		GraderStatusResult,
+		GraderStructuredOutput,
+		GraderUsageFields,
+		GraderEnvelopeError,
+		GraderEnvelopeOutcome,
+		GraderExecutionModel,
+		GraderEnvelopeTurns,
+		GraderEnvelopeTools,
+		GraderEventCount,
+		GraderToolEvents,
+		GraderDuration,
+		GraderPodExitCode,
+	}
+	for _, graderType := range graderTypes {
+		t.Run(string(graderType), func(t *testing.T) {
+			record := Record{}
+			GradeRecord(&record, []Grader{{Type: graderType}})
+			if len(record.Grades) != 1 ||
+				record.Grades[0].Pass ||
+				!strings.Contains(record.Grades[0].Message, "invalid grader") {
+				t.Fatalf("invalid grader was not rejected clearly: %#v", record.Grades)
+			}
+		})
+	}
+}

--- a/runtimes/reference/internal/mcpclient/redact.go
+++ b/runtimes/reference/internal/mcpclient/redact.go
@@ -18,7 +18,6 @@ const (
 )
 
 type redactor struct {
-	values         []string
 	sensitiveForms []string
 }
 
@@ -39,7 +38,10 @@ func newRedactor(values []string) redactor {
 			forms = append(forms, escaped)
 		}
 	}
-	return redactor{values: cloned, sensitiveForms: forms}
+	sort.Slice(forms, func(left int, right int) bool {
+		return len(forms[left]) > len(forms[right])
+	})
+	return redactor{sensitiveForms: forms}
 }
 
 func (redactor redactor) clean(value string) string {
@@ -47,10 +49,8 @@ func (redactor redactor) clean(value string) string {
 }
 
 func (redactor redactor) replace(value string) string {
-	for _, sensitive := range redactor.values {
-		if sensitive != "" {
-			value = strings.ReplaceAll(value, sensitive, "[REDACTED]")
-		}
+	for _, sensitive := range redactor.sensitiveForms {
+		value = strings.ReplaceAll(value, sensitive, "[REDACTED]")
 	}
 	return value
 }

--- a/runtimes/reference/internal/mcpclient/redact_test.go
+++ b/runtimes/reference/internal/mcpclient/redact_test.go
@@ -20,6 +20,15 @@ func TestRedactorDetectsRawAndJSONEscapedSensitiveValues(t *testing.T) {
 	}
 }
 
+func TestRedactorReplacesJSONEscapedSensitiveValues(t *testing.T) {
+	const secret = "quote\"\nsecret"
+	redactor := newRedactor([]string{secret})
+	got := redactor.clean(`server error: schema="quote\"\nsecret"`)
+	if got != `server error: schema="[REDACTED]"` {
+		t.Fatalf("escaped sensitive value was not redacted: %q", got)
+	}
+}
+
 func TestRedactingLineWriterBoundsBeforeWriting(t *testing.T) {
 	var output bytes.Buffer
 	writer := newRedactingLineWriter(&output, newRedactor([]string{"secret"}))

--- a/website/index.html
+++ b/website/index.html
@@ -38,6 +38,8 @@
   <span class="tok-key">name</span>: <span class="tok-str">review</span>
 <span class="tok-key">spec</span>:
   <span class="tok-key">goal</span>: <span class="tok-str">"Summarize the failure modes in this release"</span>
+  <span class="tok-key">provider</span>: <span class="tok-str">echo</span>
+  <span class="tok-key">model</span>: <span class="tok-str">echo-model</span>
   <span class="tok-key">runtime</span>:
     <span class="tok-key">image</span>: <span class="tok-str">ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1</span>
 


### PR DESCRIPTION
## Summary
- make the website AgentRun example schema-valid and keep public examples consumer-neutral
- validate grader configurations before dispatch so exported grading fails instead of panicking
- redact both raw and JSON-escaped secret forms, longest first
- add regression coverage for embedded manifests, invalid graders, and escaped secrets

## Test plan
- `make verify`
- `make test`
- `make build`
- `go build ./...`
- `go test ./internal/eval/... ./runtimes/reference/internal/mcpclient/...`
- `cd docs-site && npm ci && npm test && npm run typecheck && npm run build && npm run verify:build`