### PR TITLE
Consolidate e2e polling, CI pinning, and docs-site metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build reusable reporter image
         uses: ./.github/actions/build-image
@@ -206,7 +206,7 @@ jobs:
           cache: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build kind images
         uses: ./.github/actions/build-core-images
@@ -215,7 +215,7 @@ jobs:
           cache-scope: ""
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s
@@ -275,7 +275,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build webhook acceptance images
         uses: ./.github/actions/build-core-images
@@ -284,7 +284,7 @@ jobs:
           cache-scope: webhook-
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s
@@ -325,7 +325,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build NetworkPolicy images
         uses: ./.github/actions/build-core-images

--- a/.github/workflows/provider-acceptance.yml
+++ b/.github/workflows/provider-acceptance.yml
@@ -71,7 +71,7 @@ jobs:
           esac
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build maintained images
         uses: ./.github/actions/build-core-images
@@ -80,7 +80,7 @@ jobs:
           cache-scope: provider-acceptance-
 
       - name: Create ephemeral kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/docs-site/shared/docs.js
+++ b/docs-site/shared/docs.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import docsConfig from "../../docs-nav.json" with { type: "json" };
+
 /**
  * @typedef {Readonly<{
  *   srcFile: string;
@@ -9,120 +11,26 @@
  * }>} PageMetadata
  */
 
-/** @type {Array<[string, PageMetadata]>} */
-const pageMetadataEntries = [
-  [
-    "docs/index",
-    {
-      srcFile: "docs/index.md",
-      routePath: "/docs",
-      rawPath: "/raw/docs/index.md",
-      githubPath: "docs/index.md",
-    },
-  ],
-  [
-    "docs/quickstart",
-    {
-      srcFile: "docs/quickstart.md",
-      routePath: "/docs/quickstart",
-      rawPath: "/raw/docs/quickstart.md",
-      githubPath: "docs/quickstart.md",
-    },
-  ],
-  [
-    "docs/resources",
-    {
-      srcFile: "docs/resources.md",
-      routePath: "/docs/resources",
-      rawPath: "/raw/docs/resources.md",
-      githubPath: "docs/resources.md",
-    },
-  ],
-  [
-    "docs/task-workload",
-    {
-      srcFile: "docs/task-workload.md",
-      routePath: "/docs/task-workload",
-      rawPath: "/raw/docs/task-workload.md",
-      githubPath: "docs/task-workload.md",
-    },
-  ],
-  [
-    "docs/scheduled-workload",
-    {
-      srcFile: "docs/scheduled-workload.md",
-      routePath: "/docs/scheduled-workload",
-      rawPath: "/raw/docs/scheduled-workload.md",
-      githubPath: "docs/scheduled-workload.md",
-    },
-  ],
-  [
-    "docs/service-workload",
-    {
-      srcFile: "docs/service-workload.md",
-      routePath: "/docs/service-workload",
-      rawPath: "/raw/docs/service-workload.md",
-      githubPath: "docs/service-workload.md",
-    },
-  ],
-  [
-    "docs/operations",
-    {
-      srcFile: "docs/operations.md",
-      routePath: "/docs/operations",
-      rawPath: "/raw/docs/operations.md",
-      githubPath: "docs/operations.md",
-    },
-  ],
-  [
-    "docs/releases",
-    {
-      srcFile: "docs/releases.md",
-      routePath: "/docs/releases",
-      rawPath: "/raw/docs/releases.md",
-      githubPath: "docs/releases.md",
-    },
-  ],
-  [
-    "docs/runtimes",
-    {
-      srcFile: "docs/runtimes.md",
-      routePath: "/docs/runtimes",
-      rawPath: "/raw/docs/runtimes.md",
-      githubPath: "docs/runtimes.md",
-    },
-  ],
-  [
-    "docs/evals",
-    {
-      srcFile: "docs/evals.md",
-      routePath: "/docs/evals",
-      rawPath: "/raw/docs/evals.md",
-      githubPath: "docs/evals.md",
-    },
-  ],
-  [
-    "SPEC",
-    {
-      srcFile: "SPEC.md",
-      routePath: "/SPEC",
-      rawPath: "/raw/SPEC.md",
-      githubPath: "SPEC.md",
-    },
-  ],
-  [
-    "docs/when-not-to-use-agents",
-    {
-      srcFile: "docs/when-not-to-use-agents.md",
-      routePath: "/docs/when-not-to-use-agents",
-      rawPath: "/raw/docs/when-not-to-use-agents.md",
-      githubPath: "docs/when-not-to-use-agents.md",
-    },
-  ],
-];
+const pageIds = docsConfig.navigation.groups.flatMap((group) => group.pages);
+
+/**
+ * @param {string} id
+ * @returns {PageMetadata}
+ */
+function derivePageMetadata(id) {
+  const srcFile = `${id}.md`;
+  return {
+    srcFile,
+    routePath: id === "docs/index" ? "/docs" : `/${id}`,
+    rawPath: `/raw/${srcFile}`,
+    githubPath: srcFile,
+  };
+}
 
 /** @type {ReadonlyMap<string, PageMetadata>} */
-export const pageMetadataById = new Map(pageMetadataEntries);
+export const pageMetadataById = new Map(
+  pageIds.map((id) => [id, derivePageMetadata(id)]),
+);
 
 /**
  * @param {string} id

--- a/docs-site/tests/shared-docs.test.mjs
+++ b/docs-site/tests/shared-docs.test.mjs
@@ -73,85 +73,20 @@ test("page metadata covers every navigation page with stable paths", () => {
 
   assert.equal(new Set(navIds).size, navIds.length);
   assert.deepEqual([...pageMetadataById.keys()].sort(), [...navIds].sort());
-  assert.deepEqual(Object.fromEntries(pageMetadataById), {
-    "docs/index": {
-      srcFile: "docs/index.md",
-      routePath: "/docs",
-      rawPath: "/raw/docs/index.md",
-      githubPath: "docs/index.md",
-    },
-    "docs/quickstart": {
-      srcFile: "docs/quickstart.md",
-      routePath: "/docs/quickstart",
-      rawPath: "/raw/docs/quickstart.md",
-      githubPath: "docs/quickstart.md",
-    },
-    "docs/resources": {
-      srcFile: "docs/resources.md",
-      routePath: "/docs/resources",
-      rawPath: "/raw/docs/resources.md",
-      githubPath: "docs/resources.md",
-    },
-    "docs/task-workload": {
-      srcFile: "docs/task-workload.md",
-      routePath: "/docs/task-workload",
-      rawPath: "/raw/docs/task-workload.md",
-      githubPath: "docs/task-workload.md",
-    },
-    "docs/scheduled-workload": {
-      srcFile: "docs/scheduled-workload.md",
-      routePath: "/docs/scheduled-workload",
-      rawPath: "/raw/docs/scheduled-workload.md",
-      githubPath: "docs/scheduled-workload.md",
-    },
-    "docs/service-workload": {
-      srcFile: "docs/service-workload.md",
-      routePath: "/docs/service-workload",
-      rawPath: "/raw/docs/service-workload.md",
-      githubPath: "docs/service-workload.md",
-    },
-    "docs/operations": {
-      srcFile: "docs/operations.md",
-      routePath: "/docs/operations",
-      rawPath: "/raw/docs/operations.md",
-      githubPath: "docs/operations.md",
-    },
-    "docs/releases": {
-      srcFile: "docs/releases.md",
-      routePath: "/docs/releases",
-      rawPath: "/raw/docs/releases.md",
-      githubPath: "docs/releases.md",
-    },
-    "docs/runtimes": {
-      srcFile: "docs/runtimes.md",
-      routePath: "/docs/runtimes",
-      rawPath: "/raw/docs/runtimes.md",
-      githubPath: "docs/runtimes.md",
-    },
-    "docs/evals": {
-      srcFile: "docs/evals.md",
-      routePath: "/docs/evals",
-      rawPath: "/raw/docs/evals.md",
-      githubPath: "docs/evals.md",
-    },
-    SPEC: {
-      srcFile: "SPEC.md",
-      routePath: "/SPEC",
-      rawPath: "/raw/SPEC.md",
-      githubPath: "SPEC.md",
-    },
-    "docs/when-not-to-use-agents": {
-      srcFile: "docs/when-not-to-use-agents.md",
-      routePath: "/docs/when-not-to-use-agents",
-      rawPath: "/raw/docs/when-not-to-use-agents.md",
-      githubPath: "docs/when-not-to-use-agents.md",
-    },
-  });
 
   for (const id of navIds) {
     const metadata = requirePageMetadata(id);
+    const srcFile = `${id}.md`;
+    assert.deepEqual(metadata, {
+      srcFile,
+      routePath: id === "docs/index" ? "/docs" : `/${id}`,
+      rawPath: `/raw/${srcFile}`,
+      githubPath: srcFile,
+    });
     assert.ok(fs.existsSync(path.join(repoRoot, metadata.githubPath)));
   }
+  assert.equal(requirePageMetadata("docs/index").routePath, "/docs");
+  assert.equal(requirePageMetadata("SPEC").rawPath, "/raw/SPEC.md");
   assert.throws(
     () => requirePageMetadata("docs/not-in-navigation"),
     /Missing page metadata/,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -225,29 +225,8 @@ repeating one-shot work is safe.
 - Deleting either CRD deletes every resource of that kind across the cluster.
 
 To remove the controller while retaining CRDs and resources outside
-`kontext-system`:
-
-```bash
-kubectl delete clusterrolebinding kontext-manager-rolebinding \
-  --ignore-not-found=true
-kubectl delete clusterrole kontext-manager-role \
-  --ignore-not-found=true
-kubectl delete mutatingwebhookconfiguration \
-  kontext-task-agentrun-mutator.kontext.dev --ignore-not-found=true
-kubectl delete clusterrolebinding kontext-webhook-registration-manager \
-  --ignore-not-found=true
-kubectl delete clusterrole kontext-webhook-registration-manager \
-  --ignore-not-found=true
-# Also clean identities used before the kontext- prefix.
-kubectl delete mutatingwebhookconfiguration \
-  task-agentrun-mutator.kontext.dev --ignore-not-found=true
-kubectl delete clusterrolebinding manager-rolebinding \
-  webhook-registration-manager --ignore-not-found=true
-kubectl delete clusterrole manager-role \
-  webhook-registration-manager --ignore-not-found=true
-kubectl delete namespace kontext-system \
-  --ignore-not-found=true --wait=true
-```
+`kontext-system`, follow the canonical
+[control-plane-only uninstall procedure](/docs/releases#uninstall).
 
 A complete uninstall deletes the release manifest:
 

--- a/scripts/e2e-kind-playwright-mcp.sh
+++ b/scripts/e2e-kind-playwright-mcp.sh
@@ -25,91 +25,87 @@ trap cleanup EXIT
 
 wait_for_pod_absent() {
   local name="$1"
-  for _ in $(seq 1 60); do
-    if ! kubectl get pod "${name}" -n "${NAMESPACE}" >/dev/null 2>&1; then
-      return 0
-    fi
-    sleep 1
-  done
-  echo "timed out waiting for Pod ${name} to be deleted" >&2
-  return 1
+  wait_until 60 1 "Pod ${name} deletion" \
+    pod_absent "${name}"
+}
+
+pod_absent() {
+  local name="$1"
+  ! kubectl get pod "${name}" -n "${NAMESPACE}" >/dev/null 2>&1
+}
+
+no_browser_processes() {
+  browser_process_details="$(
+    kubectl exec deployment/playwright-mcp -n "${NAMESPACE}" -- \
+      node -e '
+        const fs = require("fs");
+        const active = [];
+        for (const entry of fs.readdirSync("/proc")) {
+          if (!/^[0-9]+$/.test(entry) || Number(entry) === process.pid) continue;
+          try {
+            const command = fs.readFileSync(`/proc/${entry}/cmdline`, "utf8").replace(/\0/g, " ");
+            if (command.includes("/ms-playwright/") && /(chrome|chromium)/i.test(command)) {
+              active.push(`${entry}:${command}`);
+            }
+          } catch {}
+        }
+        if (active.length) {
+          console.error(active.join("\n"));
+          process.exit(1);
+        }
+      ' 2>&1
+  )"
 }
 
 wait_for_no_browser_processes() {
-  local details=""
-  for _ in $(seq 1 60); do
-    if details="$(
-      kubectl exec deployment/playwright-mcp -n "${NAMESPACE}" -- \
-        node -e '
-          const fs = require("fs");
-          const active = [];
-          for (const entry of fs.readdirSync("/proc")) {
-            if (!/^[0-9]+$/.test(entry) || Number(entry) === process.pid) continue;
-            try {
-              const command = fs.readFileSync(`/proc/${entry}/cmdline`, "utf8").replace(/\0/g, " ");
-              if (command.includes("/ms-playwright/") && /(chrome|chromium)/i.test(command)) {
-                active.push(`${entry}:${command}`);
-              }
-            } catch {}
-          }
-          if (active.length) {
-            console.error(active.join("\n"));
-            process.exit(1);
-          }
-        ' 2>&1
-    )"; then
-      return 0
-    fi
-    sleep 1
-  done
-  echo "Playwright retained browser processes after bounded cleanup polling:" >&2
-  echo "${details}" >&2
+  browser_process_details=""
+  if wait_until 60 1 "Playwright browser process cleanup" \
+    no_browser_processes; then
+    return 0
+  fi
+  echo "${browser_process_details}" >&2
   return 1
 }
 
+browser_processes_present() {
+  browser_process_count="$(
+    kubectl exec deployment/playwright-mcp -n "${NAMESPACE}" -- \
+      node -e '
+        const fs = require("fs");
+        let count = 0;
+        for (const entry of fs.readdirSync("/proc")) {
+          if (!/^[0-9]+$/.test(entry) || Number(entry) === process.pid) continue;
+          try {
+            const command = fs.readFileSync(`/proc/${entry}/cmdline`, "utf8").replace(/\0/g, " ");
+            if (command.includes("/ms-playwright/") && /(chrome|chromium)/i.test(command)) count++;
+          } catch {}
+        }
+        process.stdout.write(String(count));
+      ' 2>/dev/null || true
+  )"
+  [[ "${browser_process_count}" =~ ^[0-9]+$ && "${browser_process_count}" -gt 0 ]]
+}
+
 wait_for_browser_processes() {
-  local count=""
-  for _ in $(seq 1 80); do
-    count="$(
-      kubectl exec deployment/playwright-mcp -n "${NAMESPACE}" -- \
-        node -e '
-          const fs = require("fs");
-          let count = 0;
-          for (const entry of fs.readdirSync("/proc")) {
-            if (!/^[0-9]+$/.test(entry) || Number(entry) === process.pid) continue;
-            try {
-              const command = fs.readFileSync(`/proc/${entry}/cmdline`, "utf8").replace(/\0/g, " ");
-              if (command.includes("/ms-playwright/") && /(chrome|chromium)/i.test(command)) count++;
-            } catch {}
-          }
-          process.stdout.write(String(count));
-        ' 2>/dev/null || true
-    )"
-    if [[ "${count}" =~ ^[0-9]+$ && "${count}" -gt 0 ]]; then
-      echo "observed ${count} active Chromium processes before cancellation"
-      return 0
-    fi
-    sleep 0.25
-  done
-  echo "no Chromium process was observed before wallclock cancellation" >&2
-  return 1
+  browser_process_count=""
+  wait_until 80 0.25 "Chromium process before wallclock cancellation" \
+    browser_processes_present
+  echo "observed ${browser_process_count} active Chromium processes before cancellation"
+}
+
+runtime_log_contains() {
+  local pod="$1"
+  local pattern="$2"
+  local logs=""
+  logs="$(kubectl logs "${pod}" -n "${NAMESPACE}" -c runtime 2>/dev/null || true)"
+  [[ "${logs}" == *"${pattern}"* ]]
 }
 
 wait_for_runtime_log_pattern() {
   local pod="$1"
   local pattern="$2"
-  local logs=""
-  for _ in $(seq 1 80); do
-    logs="$(
-      kubectl logs "${pod}" -n "${NAMESPACE}" -c runtime 2>/dev/null || true
-    )"
-    if [[ "${logs}" == *"${pattern}"* ]]; then
-      return 0
-    fi
-    sleep 0.25
-  done
-  echo "${pod} did not reach expected tool state: ${pattern}" >&2
-  return 1
+  wait_until 80 0.25 "${pod} tool state ${pattern}" \
+    runtime_log_contains "${pod}" "${pattern}"
 }
 
 validate_tool_events() {

--- a/scripts/e2e-kind-scheduled.sh
+++ b/scripts/e2e-kind-scheduled.sh
@@ -30,21 +30,53 @@ need kubectl
 trap on_exit EXIT
 cleanup
 
-echo "==> waiting for one real Scheduled cron tick"
-"${APPLY_EXAMPLE}" echo-scheduled-agent.yaml
-
-scheduled_run=""
-for _ in $(seq 1 90); do
+scheduled_run_exists() {
   scheduled_run="$(
     kubectl get agent echo-scheduled \
       -o jsonpath='{.status.lastRunName}' 2>/dev/null || true
   )"
-  if [[ -n "${scheduled_run}" ]]; then
-    break
-  fi
-  sleep 2
-done
-if [[ -z "${scheduled_run}" ]]; then
+  [[ -n "${scheduled_run}" ]]
+}
+
+agent_generation_observed() {
+  observed_generation="$(
+    kubectl get agent echo-scheduled-forbid \
+      -o jsonpath='{.status.observedGeneration}' 2>/dev/null || true
+  )"
+  generation="$(
+    kubectl get agent echo-scheduled-forbid \
+      -o jsonpath='{.metadata.generation}' 2>/dev/null || true
+  )"
+  [[ -n "${generation}" && "${observed_generation}" == "${generation}" ]]
+}
+
+forbid_fixture_settled() {
+  settled_reason="$(
+    kubectl get agent echo-scheduled-forbid \
+      -o jsonpath='{.status.conditions[?(@.type=="Progressing")].reason}' \
+      2>/dev/null || true
+  )"
+  [[ "${settled_reason}" == "WaitingForSchedule" ]]
+}
+
+due_slot_advanced() {
+  local due_slot="$1"
+  evaluated_next="$(
+    kubectl get agent echo-scheduled-forbid \
+      -o jsonpath='{.status.nextScheduleTime}' 2>/dev/null || true
+  )"
+  [[ -n "${evaluated_next}" && "${evaluated_next}" != "${due_slot}" ]]
+}
+
+resource_absent() {
+  ! kubectl get "$@" >/dev/null 2>&1
+}
+
+echo "==> waiting for one real Scheduled cron tick"
+"${APPLY_EXAMPLE}" echo-scheduled-agent.yaml
+
+scheduled_run=""
+if ! wait_until 90 2 "Scheduled Agent to mint a run" scheduled_run_exists; then
   echo "Scheduled Agent did not mint a run from its controller requeue" >&2
   exit 1
 fi
@@ -85,21 +117,8 @@ spec:
     startingDeadlineSeconds: 3600
 EOF
 
-for _ in $(seq 1 30); do
-  observed_generation="$(
-    kubectl get agent echo-scheduled-forbid \
-      -o jsonpath='{.status.observedGeneration}' 2>/dev/null || true
-  )"
-  generation="$(
-    kubectl get agent echo-scheduled-forbid \
-      -o jsonpath='{.metadata.generation}' 2>/dev/null || true
-  )"
-  if [[ -n "${generation}" && "${observed_generation}" == "${generation}" ]]; then
-    break
-  fi
-  sleep 1
-done
-if [[ -z "${generation}" || "${observed_generation}" != "${generation}" ]]; then
+if ! wait_until 30 1 "Forbid fixture Agent initialization" \
+  agent_generation_observed; then
   echo "Forbid fixture Agent was not initialized" >&2
   exit 1
 fi
@@ -134,18 +153,7 @@ spec:
 EOF
 
 wait_for_run_phase echo-scheduled-forbid-active Running
-for _ in $(seq 1 30); do
-  settled_reason="$(
-    kubectl get agent echo-scheduled-forbid \
-      -o jsonpath='{.status.conditions[?(@.type=="Progressing")].reason}' \
-      2>/dev/null || true
-  )"
-  if [[ "${settled_reason}" == "WaitingForSchedule" ]]; then
-    break
-  fi
-  sleep 1
-done
-if [[ "${settled_reason}" != "WaitingForSchedule" ]]; then
+if ! wait_until 30 1 "Forbid fixture to settle" forbid_fixture_settled; then
   echo "Forbid fixture did not settle before forced due slot" >&2
   exit 1
 fi
@@ -160,17 +168,8 @@ kubectl annotate agent echo-scheduled-forbid \
   "kontext.dev/force-reconcile=$(date +%s)" --overwrite
 
 evaluated_next=""
-for _ in $(seq 1 30); do
-  evaluated_next="$(
-    kubectl get agent echo-scheduled-forbid \
-      -o jsonpath='{.status.nextScheduleTime}' 2>/dev/null || true
-  )"
-  if [[ -n "${evaluated_next}" && "${evaluated_next}" != "${due_slot}" ]]; then
-    break
-  fi
-  sleep 1
-done
-if [[ -z "${evaluated_next}" || "${evaluated_next}" == "${due_slot}" ]]; then
+if ! wait_until 30 1 "Forbid to advance the forced due slot" \
+  due_slot_advanced "${due_slot}"; then
   echo "Forbid did not advance the forced due slot" >&2
   exit 1
 fi
@@ -185,13 +184,8 @@ fi
 
 echo "==> verifying Agent deletion cascades to scheduled runs"
 kubectl delete agent echo-scheduled --wait=true
-for _ in $(seq 1 30); do
-  if ! kubectl get agentrun "${scheduled_run}" >/dev/null 2>&1; then
-    break
-  fi
-  sleep 1
-done
-if kubectl get agentrun "${scheduled_run}" >/dev/null 2>&1; then
+if ! wait_until 30 1 "scheduled run deletion" \
+  resource_absent agentrun "${scheduled_run}"; then
   echo "scheduled run survived Agent deletion" >&2
   exit 1
 fi

--- a/scripts/e2e-kind-task.sh
+++ b/scripts/e2e-kind-task.sh
@@ -22,16 +22,16 @@ need kubectl jq
 cleanup
 mkdir -p "${TMP_DIR}"
 
+agent_count_is() {
+  local expected="$1"
+  local count=""
+  count="$(kubectl get agent echo-task -o jsonpath='{.status.runsCreated}' 2>/dev/null || true)"
+  [[ "${count:-0}" == "${expected}" ]]
+}
+
 wait_for_agent_count() {
   local expected="$1"
-  for _ in $(seq 1 120); do
-    local count=""
-    count="$(kubectl get agent echo-task -o jsonpath='{.status.runsCreated}' 2>/dev/null || true)"
-    [[ "${count:-0}" == "${expected}" ]] && return 0
-    sleep 1
-  done
-  echo "timed out waiting for Task runsCreated=${expected}" >&2
-  return 1
+  wait_until 120 1 "Task runsCreated=${expected}" agent_count_is "${expected}"
 }
 
 expect_rejected() {

--- a/scripts/e2e-kind-webhook.sh
+++ b/scripts/e2e-kind-webhook.sh
@@ -31,25 +31,27 @@ trap cleanup EXIT
 
 need kubectl openssl curl
 
+jsonpath_equals() {
+  local resource="$1"
+  local expression="$2"
+  local expected="$3"
+  local namespace="${4:-}"
+  local value=""
+  if [[ -n "${namespace}" ]]; then
+    value="$(kubectl get "${resource}" -n "${namespace}" -o "jsonpath=${expression}" 2>/dev/null || true)"
+  else
+    value="$(kubectl get "${resource}" -o "jsonpath=${expression}" 2>/dev/null || true)"
+  fi
+  [[ "${value}" == "${expected}" ]]
+}
+
 wait_for_jsonpath() {
   local resource="$1"
   local expression="$2"
   local expected="$3"
   local namespace="${4:-}"
-  for _ in $(seq 1 120); do
-    local value=""
-    if [[ -n "${namespace}" ]]; then
-      value="$(kubectl get "${resource}" -n "${namespace}" -o "jsonpath=${expression}" 2>/dev/null || true)"
-    else
-      value="$(kubectl get "${resource}" -o "jsonpath=${expression}" 2>/dev/null || true)"
-    fi
-    if [[ "${value}" == "${expected}" ]]; then
-      return 0
-    fi
-    sleep 1
-  done
-  echo "timed out waiting for ${resource} ${expression}=${expected}" >&2
-  return 1
+  wait_until 120 1 "${resource} ${expression}=${expected}" \
+    jsonpath_equals "${resource}" "${expression}" "${expected}" "${namespace}"
 }
 
 secret_value() {
@@ -74,15 +76,18 @@ spec:
 EOF
 }
 
+create_task_invocation_captured() {
+  local name="$1"
+  create_task_invocation "${name}" >"${TMP_DIR}/${name}.out" 2>&1
+}
+
 create_task_invocation_retry() {
   local name="$1"
-  for _ in $(seq 1 60); do
-    if create_task_invocation "${name}" >"${TMP_DIR}/${name}.out" 2>&1; then
-      cat "${TMP_DIR}/${name}.out"
-      return 0
-    fi
-    sleep 1
-  done
+  if wait_until 60 1 "Task invocation ${name} creation" \
+    create_task_invocation_captured "${name}"; then
+    cat "${TMP_DIR}/${name}.out"
+    return 0
+  fi
   cat "${TMP_DIR}/${name}.out" >&2
   return 1
 }

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -49,6 +49,15 @@ on_exit() {
 need kubectl
 trap on_exit EXIT
 
+pod_phase_is() {
+  local pod="$1"
+  local expected="$2"
+  signal_phase="$(
+    kubectl get pod "${pod}" -o jsonpath='{.status.phase}' 2>/dev/null || true
+  )"
+  [[ "${signal_phase}" == "${expected}" ]]
+}
+
 echo "==> cleaning previous e2e resources"
 cleanup_e2e_resources
 
@@ -151,14 +160,8 @@ fi
 
 echo "==> verifying SIGTERM forwarding to the child"
 "${APPLY_EXAMPLE}" stdout-signal-run.yaml
-for _ in $(seq 1 60); do
-  signal_phase="$(kubectl get pod run-stdout-signal -o jsonpath='{.status.phase}' 2>/dev/null || true)"
-  if [[ "${signal_phase}" == "Running" ]]; then
-    break
-  fi
-  sleep 2
-done
-if [[ "${signal_phase}" != "Running" ]]; then
+if ! wait_until 60 2 "stdout signal Pod to reach Running" \
+  pod_phase_is run-stdout-signal Running; then
   echo "stdout signal pod did not reach Running" >&2
   exit 1
 fi
@@ -297,38 +300,4 @@ if [[ "${wallclock_phase}" != "BudgetExceeded" || -n "${wallclock_pod}" ]]; then
   exit 1
 fi
 
-echo "==> applying service echo agent"
-"${APPLY_EXAMPLE}" echo-service-agent.yaml
-
-echo "==> waiting for live service run"
-for _ in $(seq 1 60); do
-  current_run="$(kubectl get agent echo-service -o jsonpath='{.status.currentRunName}' 2>/dev/null || true)"
-  pod_phase="$(kubectl get pod -l kontext.dev/agent=echo-service -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)"
-  if [[ -n "${current_run}" && "${pod_phase}" == "Running" ]]; then
-    break
-  fi
-  sleep 2
-done
-
-service_pod="$(kubectl get pod -l kontext.dev/agent=echo-service -o jsonpath='{.items[0].metadata.name}')"
-if [[ -z "${service_pod}" ]]; then
-  echo "service agent pod not found" >&2
-  exit 1
-fi
-
-echo "==> deleting service pod to verify recast"
-before_run="$(kubectl get agent echo-service -o jsonpath='{.status.currentRunName}')"
-kubectl delete pod "${service_pod}" --wait=true
-
-for _ in $(seq 1 60); do
-  after_run="$(kubectl get agent echo-service -o jsonpath='{.status.currentRunName}')"
-  pod_phase="$(kubectl get pod -l kontext.dev/agent=echo-service -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)"
-  if [[ "${after_run}" != "${before_run}" && "${pod_phase}" == "Running" ]]; then
-    echo "recast verified: ${before_run} -> ${after_run}"
-    exit 0
-  fi
-  sleep 2
-done
-
-echo "service recast did not complete in time" >&2
-exit 1
+echo "keyless kind end-to-end scenarios passed"

--- a/scripts/eval-kind.sh
+++ b/scripts/eval-kind.sh
@@ -14,34 +14,39 @@ MARKER="${EVAL_DIR}/not-run.json"
 SERVICE_AGENT="echo-service"
 APPLY_EXAMPLE="${ROOT_DIR}/scripts/apply-example.sh"
 
-wait_for_service() {
-  local previous_run="${1:-}"
+service_is_running() {
+  local previous_run="$1"
   local current_run=""
   local pod_name=""
   local pod_phase=""
-  for _ in $(seq 1 60); do
-    current_run="$(
-      kubectl get agent "${SERVICE_AGENT}" -n "${EVAL_NAMESPACE}" \
-        -o jsonpath='{.status.currentRunName}' 2>/dev/null || true
-    )"
-    pod_name="$(
-      kubectl get pod -n "${EVAL_NAMESPACE}" \
-        -l "kontext.dev/agent=${SERVICE_AGENT}" \
-        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true
-    )"
-    pod_phase="$(
-      kubectl get pod "${pod_name}" -n "${EVAL_NAMESPACE}" \
-        -o jsonpath='{.status.phase}' 2>/dev/null || true
-    )"
-    if [[ -n "${current_run}" &&
-      "${current_run}" != "${previous_run}" &&
-      "${pod_phase}" == "Running" ]]; then
-      printf '%s\n' "${current_run}"
-      return 0
-    fi
-    sleep 2
-  done
-  echo "service did not become Running with a fresh run" >&2
+  current_run="$(
+    kubectl get agent "${SERVICE_AGENT}" -n "${EVAL_NAMESPACE}" \
+      -o jsonpath='{.status.currentRunName}' 2>/dev/null || true
+  )"
+  pod_name="$(
+    kubectl get pod -n "${EVAL_NAMESPACE}" \
+      -l "kontext.dev/agent=${SERVICE_AGENT}" \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true
+  )"
+  pod_phase="$(
+    kubectl get pod "${pod_name}" -n "${EVAL_NAMESPACE}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || true
+  )"
+  if [[ -n "${current_run}" &&
+    "${current_run}" != "${previous_run}" &&
+    "${pod_phase}" == "Running" ]]; then
+    printf '%s\n' "${current_run}"
+    return 0
+  fi
+  return 1
+}
+
+wait_for_service() {
+  local previous_run="${1:-}"
+  if wait_until 60 2 "Service to become Running with a fresh run" \
+    service_is_running "${previous_run}"; then
+    return 0
+  fi
   kubectl get agent,agentrun,pod -n "${EVAL_NAMESPACE}" -o wide >&2 || true
   return 1
 }

--- a/scripts/install-go-kind.sh
+++ b/scripts/install-go-kind.sh
@@ -15,6 +15,16 @@ STDOUT_FIXTURE_IMAGE="${KONTEXT_STDOUT_FIXTURE_IMAGE:-kontext-stdout-fixture:dev
 
 need docker kind kubectl
 
+controller_pod_replaced() {
+  local previous_uid="$1"
+  CONTROLLER_POD_UID_AFTER="$(
+    kubectl get pods -n kontext-system -l control-plane=controller-manager \
+      -o jsonpath='{range .items[*]}{.metadata.uid}{"\n"}{end}'
+  )"
+  [[ -n "${CONTROLLER_POD_UID_AFTER}" &&
+    "${CONTROLLER_POD_UID_AFTER}" != *"${previous_uid}"* ]]
+}
+
 case "${IMAGE_SET}" in
   full|network-policy) ;;
   *)
@@ -94,19 +104,8 @@ kubectl rollout status deployment/kontext-controller-manager -n kontext-system -
 if [[ -n "${CONTROLLER_POD_UID_BEFORE}" &&
   "${DEPLOYED_IMAGE_ID_BEFORE}" != "${OPERATOR_IMAGE_ID}" ]]; then
   CONTROLLER_POD_UID_AFTER=""
-  for _ in $(seq 1 30); do
-    CONTROLLER_POD_UID_AFTER="$(
-      kubectl get pods -n kontext-system -l control-plane=controller-manager \
-        -o jsonpath='{range .items[*]}{.metadata.uid}{"\n"}{end}'
-    )"
-    if [[ -n "${CONTROLLER_POD_UID_AFTER}" &&
-      "${CONTROLLER_POD_UID_AFTER}" != *"${CONTROLLER_POD_UID_BEFORE}"* ]]; then
-      break
-    fi
-    sleep 1
-  done
-  if [[ -z "${CONTROLLER_POD_UID_AFTER}" ||
-    "${CONTROLLER_POD_UID_AFTER}" == *"${CONTROLLER_POD_UID_BEFORE}"* ]]; then
+  if ! wait_until 30 1 "replacement controller Pod" \
+    controller_pod_replaced "${CONTROLLER_POD_UID_BEFORE}"; then
     echo "controller image changed but no new ready Pod was observed" >&2
     exit 1
   fi

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -36,6 +36,40 @@ validate_release_tag() {
   [[ "${tag}" =~ ${release_pattern} && "${#tag}" -le 63 ]]
 }
 
+wait_until() {
+  local attempts="${1:-}"
+  local interval_seconds="${2:-}"
+  local description="${3:-}"
+  local attempt
+
+  if [[ ! "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "poll attempts must be a positive whole number: ${attempts}" >&2
+    return 2
+  fi
+  if [[ ! "${interval_seconds}" =~ ^[0-9]+([.][0-9]+)?$ ||
+    "${interval_seconds}" =~ ^0+([.]0+)?$ ]]; then
+    echo "poll interval must be a positive number of seconds: ${interval_seconds}" >&2
+    return 2
+  fi
+  if [[ -z "${description}" || "$#" -lt 4 ]]; then
+    echo "usage: wait_until <attempts> <interval_seconds> <description> cmd args..." >&2
+    return 2
+  fi
+  shift 3
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if "$@"; then
+      return 0
+    fi
+    if ((attempt < attempts)); then
+      sleep "${interval_seconds}"
+    fi
+  done
+
+  echo "timed out waiting for ${description} after ${attempts} attempts" >&2
+  return 1
+}
+
 wait_for_run_phase() {
   local name="${1:?AgentRun name is required}"
   local expected="${2:?expected AgentRun phase is required}"

--- a/scripts/test-shell-common.sh
+++ b/scripts/test-shell-common.sh
@@ -31,6 +31,22 @@ if (need kontext-command-that-does-not-exist) 2>/dev/null; then
   fail "need accepted a missing command"
 fi
 
+attempt_count=0
+succeed_on_third_attempt() {
+  local expected="$1"
+  attempt_count=$((attempt_count + 1))
+  [[ "${attempt_count}" -eq "${expected}" ]]
+}
+wait_until 3 0.01 "third test attempt" succeed_on_third_attempt 3
+[[ "${attempt_count}" -eq 3 ]] ||
+  fail "wait_until did not retry until success"
+if timeout_error="$(wait_until 2 0.01 "test condition" false 2>&1)"; then
+  fail "wait_until accepted an exhausted poll"
+fi
+[[ "${timeout_error}" == \
+  "timed out waiting for test condition after 2 attempts" ]] ||
+  fail "wait_until gave an inconsistent timeout diagnostic"
+
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/kontext-shell-test.XXXXXX")"
 cleanup() {
   rm -rf "${tmp_dir}"
@@ -94,15 +110,28 @@ grep -Fq 'kontext.dev/local-operator-image-id: "sha256:local"' \
   fail "development overlay omitted the local image annotation"
 
 cat >"${tmp_dir}/tools.jsonl" <<'EOF'
-not-json
-{"type":"tool","data":{"name":"first","outputBytes":10,"isError":false,"truncated":false}}
-{"type":"tool","data":{"name":"second","outputBytes":20,"isError":true,"truncated":true}}
+{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-21T12:00:00Z","type":"tool","data":{"name":"first","count":1,"outputBytes":10,"isError":false,"truncated":false}}
+{"apiVersion":"kontext.dev/event/v1alpha1","timestamp":"2026-07-21T12:00:01Z","type":"tool","data":{"name":"second","count":2,"outputBytes":20,"isError":true,"truncated":true}}
+KONTEXT_RESULT:{"outcome":"Succeeded"}
 EOF
 "${ROOT_DIR}/scripts/validators/validate-tool-events.py" \
   "${tmp_dir}/tools.jsonl" 2 20 30 first,second 1 1
 if "${ROOT_DIR}/scripts/validators/validate-tool-events.py" \
   "${tmp_dir}/tools.jsonl" 1 20 30 first 0 0 2>/dev/null; then
   fail "tool-event validator accepted the wrong event count"
+fi
+
+printf '{malformed\n' >"${tmp_dir}/malformed-tools.jsonl"
+if "${ROOT_DIR}/scripts/validators/validate-tool-events.py" \
+  "${tmp_dir}/malformed-tools.jsonl" 0 20 30 "" 0 0 2>/dev/null; then
+  fail "tool-event validator ignored malformed JSON"
+fi
+cat >"${tmp_dir}/old-version-tools.jsonl" <<'EOF'
+{"apiVersion":"kontext.dev/event/v1alpha0","timestamp":"2026-07-21T12:00:00Z","type":"tool","data":{"name":"old","count":1,"outputBytes":10,"isError":false,"truncated":false}}
+EOF
+if "${ROOT_DIR}/scripts/validators/validate-tool-events.py" \
+  "${tmp_dir}/old-version-tools.jsonl" 1 20 30 old 0 0 2>/dev/null; then
+  fail "tool-event validator accepted an unsupported event apiVersion"
 fi
 
 cat >"${tmp_dir}/browser-pod.json" <<'EOF'

--- a/scripts/validators/validate-tool-events.py
+++ b/scripts/validators/validate-tool-events.py
@@ -4,6 +4,10 @@
 import json
 import sys
 
+EVENT_API_VERSION = "kontext.dev/event/v1alpha1"
+EVENT_FIELDS = {"apiVersion", "timestamp", "type", "data"}
+EVENT_TYPES = {"lifecycle", "output", "usage", "tool", "error"}
+
 
 def main() -> None:
     (
@@ -17,13 +21,62 @@ def main() -> None:
     ) = sys.argv[1:]
     events = []
     with open(path, encoding="utf-8") as stream:
-        for line in stream:
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
+        for line_number, line in enumerate(stream, start=1):
+            stripped = line.strip()
+            if not stripped or not stripped.startswith("{"):
                 continue
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError as error:
+                raise SystemExit(
+                    f"malformed JSON event on line {line_number}: {error.msg}"
+                ) from error
+            if not isinstance(event, dict) or set(event) != EVENT_FIELDS:
+                raise SystemExit(
+                    f"invalid event envelope on line {line_number}: "
+                    f"expected fields {sorted(EVENT_FIELDS)!r}"
+                )
+            if event["apiVersion"] != EVENT_API_VERSION:
+                raise SystemExit(
+                    f"unsupported event apiVersion on line {line_number}: "
+                    f"{event['apiVersion']!r}"
+                )
+            if event["type"] not in EVENT_TYPES:
+                raise SystemExit(
+                    f"unsupported event type on line {line_number}: {event['type']!r}"
+                )
+            if not isinstance(event["timestamp"], str) or not event["timestamp"]:
+                raise SystemExit(
+                    f"event timestamp is required on line {line_number}"
+                )
             if event.get("type") == "tool":
-                events.append(event["data"])
+                data = event["data"]
+                if not isinstance(data, dict):
+                    raise SystemExit(
+                        f"tool event data must be an object on line {line_number}"
+                    )
+                required = {"name", "count", "isError", "truncated"}
+                if not required.issubset(data):
+                    raise SystemExit(
+                        f"tool event data is missing required fields on line {line_number}"
+                    )
+                if not isinstance(data["name"], str) or not data["name"].strip():
+                    raise SystemExit(
+                        f"tool event name is required on line {line_number}"
+                    )
+                if type(data["count"]) is not int or data["count"] < 1:
+                    raise SystemExit(
+                        f"tool event count must be at least 1 on line {line_number}"
+                    )
+                if type(data["isError"]) is not bool:
+                    raise SystemExit(
+                        f"tool event isError must be boolean on line {line_number}"
+                    )
+                if type(data["truncated"]) is not bool:
+                    raise SystemExit(
+                        f"tool event truncated must be boolean on line {line_number}"
+                    )
+                events.append(data)
 
     expected_count = int(count)
     if len(events) != expected_count:

--- a/scripts/verify-release-install.sh
+++ b/scripts/verify-release-install.sh
@@ -20,46 +20,47 @@ if [[ -n "${PREVIOUS_MANIFEST}" && (! -f "${PREVIOUS_MANIFEST}" || -z "${PREVIOU
   exit 2
 fi
 
-remove_legacy_control_plane() {
-  kubectl delete deployment/controller-manager \
-    -n kontext-system --ignore-not-found=true --wait=true
-  kubectl delete \
-    mutatingwebhookconfiguration/task-agentrun-mutator.kontext.dev \
-    clusterrolebinding/manager-rolebinding \
-    clusterrolebinding/webhook-registration-manager \
-    clusterrole/manager-role \
-    clusterrole/webhook-registration-manager \
-    --ignore-not-found=true
-  kubectl delete \
-    service/webhook-service \
-    serviceaccount/controller-manager \
-    rolebinding/leader-election-manager \
-    rolebinding/webhook-certificate-manager \
-    role/leader-election-manager \
-    role/webhook-certificate-manager \
-    networkpolicy/controller-manager-webhook \
-    -n kontext-system --ignore-not-found=true
+control_plane_resources() {
+  local prefix="$1"
+  printf '%s\n' \
+    "deployment/${prefix}controller-manager" \
+    "mutatingwebhookconfiguration/${prefix}task-agentrun-mutator.kontext.dev" \
+    "clusterrolebinding/${prefix}manager-rolebinding" \
+    "clusterrolebinding/${prefix}webhook-registration-manager" \
+    "clusterrole/${prefix}manager-role" \
+    "clusterrole/${prefix}webhook-registration-manager" \
+    "service/${prefix}webhook-service" \
+    "serviceaccount/${prefix}controller-manager" \
+    "rolebinding/${prefix}leader-election-manager" \
+    "rolebinding/${prefix}webhook-certificate-manager" \
+    "role/${prefix}leader-election-manager" \
+    "role/${prefix}webhook-certificate-manager" \
+    "networkpolicy/${prefix}controller-manager-webhook"
 }
 
-remove_prefixed_control_plane() {
-  kubectl delete deployment/kontext-controller-manager \
-    -n kontext-system --ignore-not-found=true --wait=true
-  kubectl delete \
-    mutatingwebhookconfiguration/kontext-task-agentrun-mutator.kontext.dev \
-    clusterrolebinding/kontext-manager-rolebinding \
-    clusterrolebinding/kontext-webhook-registration-manager \
-    clusterrole/kontext-manager-role \
-    clusterrole/kontext-webhook-registration-manager \
-    --ignore-not-found=true
-  kubectl delete \
-    service/kontext-webhook-service \
-    serviceaccount/kontext-controller-manager \
-    rolebinding/kontext-leader-election-manager \
-    rolebinding/kontext-webhook-certificate-manager \
-    role/kontext-leader-election-manager \
-    role/kontext-webhook-certificate-manager \
-    networkpolicy/kontext-controller-manager-webhook \
-    -n kontext-system --ignore-not-found=true
+remove_control_plane() {
+  local prefix="$1"
+  local resources=()
+  while IFS= read -r resource; do
+    resources+=("${resource}")
+  done < <(control_plane_resources "${prefix}")
+  kubectl delete "${resources[@]}" -n kontext-system \
+    --ignore-not-found=true --wait=true
+}
+
+control_plane_resources_exist() {
+  local prefix="$1"
+  local resource=""
+  while IFS= read -r resource; do
+    if kubectl get "${resource}" -n kontext-system >/dev/null 2>&1; then
+      return 0
+    fi
+  done < <(control_plane_resources "${prefix}")
+  return 1
+}
+
+resource_absent() {
+  ! kubectl get "$@" >/dev/null 2>&1
 }
 
 manifest_identity() {
@@ -91,9 +92,9 @@ install_release() {
 
   kubectl apply -f "${manifest}"
   if [[ "${identity}" == "current" ]]; then
-    remove_legacy_control_plane
+    remove_control_plane ""
   else
-    remove_prefixed_control_plane
+    remove_control_plane "kontext-"
   fi
   kubectl rollout status "deployment/${deployment}" \
     --namespace kontext-system \
@@ -240,8 +241,8 @@ if [[ "${retained_result}" != *"Verify custom-resource retention during control-
   exit 1
 fi
 
-remove_prefixed_control_plane
-remove_legacy_control_plane
+remove_control_plane "kontext-"
+remove_control_plane ""
 kubectl delete namespace kontext-system --ignore-not-found=true --wait=true
 
 kubectl get crd agents.kontext.dev agentruns.kontext.dev >/dev/null
@@ -253,13 +254,8 @@ install_release "${CURRENT_MANIFEST}" true current
 kubectl get agent retained-install-check -n default >/dev/null
 kubectl get agentrun retained-install-invocation -n default >/dev/null
 kubectl delete agent retained-install-check -n default --wait=true
-for _ in $(seq 1 120); do
-  if ! kubectl get agentrun retained-install-invocation -n default >/dev/null 2>&1; then
-    break
-  fi
-  sleep 1
-done
-if kubectl get agentrun retained-install-invocation -n default >/dev/null 2>&1; then
+if ! wait_until 120 1 "retained Task invocation deletion" \
+  resource_absent agentrun retained-install-invocation -n default; then
   echo "retained Task Agent deletion did not cascade to its invocation" >&2
   exit 1
 fi
@@ -270,20 +266,8 @@ kubectl delete -f "${CURRENT_MANIFEST}" --ignore-not-found=true --wait=true
 if kubectl get crd agents.kontext.dev >/dev/null 2>&1 ||
   kubectl get crd agentruns.kontext.dev >/dev/null 2>&1 ||
   kubectl get namespace kontext-system >/dev/null 2>&1 ||
-  kubectl get clusterrole kontext-manager-role >/dev/null 2>&1 ||
-  kubectl get clusterrolebinding kontext-manager-rolebinding >/dev/null 2>&1 ||
-  kubectl get mutatingwebhookconfiguration \
-    kontext-task-agentrun-mutator.kontext.dev >/dev/null 2>&1 ||
-  kubectl get clusterrole kontext-webhook-registration-manager >/dev/null 2>&1 ||
-  kubectl get clusterrolebinding \
-    kontext-webhook-registration-manager >/dev/null 2>&1 ||
-  kubectl get deployment controller-manager -n kontext-system >/dev/null 2>&1 ||
-  kubectl get clusterrole manager-role >/dev/null 2>&1 ||
-  kubectl get clusterrolebinding manager-rolebinding >/dev/null 2>&1 ||
-  kubectl get mutatingwebhookconfiguration \
-    task-agentrun-mutator.kontext.dev >/dev/null 2>&1 ||
-  kubectl get clusterrole webhook-registration-manager >/dev/null 2>&1 ||
-  kubectl get clusterrolebinding webhook-registration-manager >/dev/null 2>&1; then
+  control_plane_resources_exist "kontext-" ||
+  control_plane_resources_exist ""; then
   echo "complete uninstall left Kontext resources behind" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- add a shared polling helper and use it across kind acceptance scripts while keeping retry counts and intervals unchanged
- single-source release control-plane resources, keep service recast coverage in the stronger evaluation path, and link operations docs to the canonical uninstall procedure
- derive docs page metadata from navigation and replace the duplicated expected table with rule-based checks
- pin third-party workflow actions to immutable commits
- align the tool-event validator with the versioned event envelope while retaining runtime-emitted output byte checks

## Test plan
- [x] `make verify`
- [x] `./scripts/test-shell-common.sh`
- [x] `bash -n` for every changed shell script
- [x] Python bytecode compilation for the tool-event validator
- [x] YAML parsing for changed workflows
- [x] `npm test` in `docs-site`
- [x] `npm run typecheck` in `docs-site`
- [x] `npm run build` in `docs-site`
- [x] `npm run verify:build` in `docs-site`
- [ ] kind acceptance jobs in CI