### PR TITLE
Trim legacy naming from the public result contract

### DIFF
--- a/internal/status/pod.go
+++ b/internal/status/pod.go
@@ -98,7 +98,7 @@ func observationFromTermination(terminated *corev1.ContainerStateTerminated) Pod
 	}
 	output := outputStatus(envelope)
 	usage := usageStatus(envelope)
-	legacyResult := resultv1alpha1.ProjectLegacyResult(envelope.Output)
+	legacyResult := resultv1alpha1.PlainText(envelope.Output)
 
 	if terminated.ExitCode == 0 {
 		if parseErr != nil {

--- a/pkg/result/v1alpha1/parse.go
+++ b/pkg/result/v1alpha1/parse.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 )
 
-// LegacyPayload is the pre-versioned Kontext termination contract.
-type LegacyPayload struct {
+type legacyPayload struct {
 	Result      string   `json:"result"`
 	TokensUsed  *int64   `json:"tokensUsed,omitempty"`
 	DollarsUsed *float64 `json:"dollarsUsed,omitempty"`
@@ -52,7 +51,7 @@ func Parse(message string) (Envelope, bool, error) {
 		return Envelope{}, false, errors.New("decode termination payload: unrecognized JSON object")
 	}
 
-	var legacy LegacyPayload
+	var legacy legacyPayload
 	if err := json.Unmarshal([]byte(message), &legacy); err != nil {
 		return Envelope{}, false, fmt.Errorf("decode legacy termination payload: %w", err)
 	}
@@ -89,9 +88,9 @@ func ParseVersioned(message string) (Envelope, error) {
 	return envelope, nil
 }
 
-// ProjectLegacyResult deterministically projects structured output into the
-// backward-compatible AgentRun status.result string.
-func ProjectLegacyResult(output *Output) string {
+// PlainText deterministically projects structured output into the plain-text
+// form used for AgentRun status.result.
+func PlainText(output *Output) string {
 	if output == nil || len(bytes.TrimSpace(output.Value)) == 0 {
 		return ""
 	}
@@ -127,7 +126,7 @@ func outputFromText(value string) *Output {
 	}
 }
 
-func usageFromLegacy(payload LegacyPayload) *Usage {
+func usageFromLegacy(payload legacyPayload) *Usage {
 	if payload.TokensUsed == nil && payload.DollarsUsed == nil {
 		return nil
 	}

--- a/pkg/result/v1alpha1/result_test.go
+++ b/pkg/result/v1alpha1/result_test.go
@@ -25,8 +25,8 @@ func TestParseVersionedEnvelopeWithArbitraryJSONOutput(t *testing.T) {
 	if legacy {
 		t.Fatalf("expected versioned envelope, got %#v", parsed)
 	}
-	if got := resultv1alpha1.ProjectLegacyResult(parsed.Output); got != `{"answer":42,"items":[true,null]}` {
-		t.Fatalf("unexpected legacy projection %q", got)
+	if got := resultv1alpha1.PlainText(parsed.Output); got != `{"answer":42,"items":[true,null]}` {
+		t.Fatalf("unexpected plain-text projection %q", got)
 	}
 	if parsed.Usage == nil || parsed.Usage.InputTokens == nil || *parsed.Usage.InputTokens != 0 {
 		t.Fatalf("expected measured zero input tokens, got %#v", parsed.Usage)
@@ -50,7 +50,7 @@ func TestParseLegacyPayload(t *testing.T) {
 	if !legacy || parsed.APIVersion != resultv1alpha1.APIVersion {
 		t.Fatalf("expected legacy payload, got %#v", parsed)
 	}
-	if got := resultv1alpha1.ProjectLegacyResult(parsed.Output); got != "done" {
+	if got := resultv1alpha1.PlainText(parsed.Output); got != "done" {
 		t.Fatalf("expected done, got %q", got)
 	}
 	if parsed.Usage == nil || parsed.Usage.TotalTokens == nil || *parsed.Usage.TotalTokens != 0 {
@@ -125,7 +125,7 @@ func TestParseClassifiesLegacyPayloadsByKnownKeys(t *testing.T) {
 			if !legacy {
 				t.Fatal("expected legacy wire format")
 			}
-			if got := resultv1alpha1.ProjectLegacyResult(envelope.Output); got != test.wantResult {
+			if got := resultv1alpha1.PlainText(envelope.Output); got != test.wantResult {
 				t.Fatalf("expected legacy result %q, got %q", test.wantResult, got)
 			}
 		})
@@ -175,7 +175,7 @@ func TestParsePlainText(t *testing.T) {
 	if parsed.Outcome != resultv1alpha1.OutcomeSucceeded {
 		t.Fatalf("expected explicit successful outcome, got %q", parsed.Outcome)
 	}
-	if got := resultv1alpha1.ProjectLegacyResult(parsed.Output); got != "plain answer" {
+	if got := resultv1alpha1.PlainText(parsed.Output); got != "plain answer" {
 		t.Fatalf("expected plain answer, got %q", got)
 	}
 }

--- a/runtimes/reference/internal/engine/engine_test.go
+++ b/runtimes/reference/internal/engine/engine_test.go
@@ -28,7 +28,7 @@ func TestRunnerCompletesFakeConversation(t *testing.T) {
 		result.Envelope.Execution.Model != "vendor/model@2026:beta" {
 		t.Fatalf("model identifier changed: %#v", result.Envelope.Execution)
 	}
-	if got := resultv1alpha1.ProjectLegacyResult(result.Envelope.Output); got !=
+	if got := resultv1alpha1.PlainText(result.Envelope.Output); got !=
 		"Fake provider completed goal: explain the contract" {
 		t.Fatalf("unexpected output %q", got)
 	}

--- a/runtimes/reporter/reporter_test.go
+++ b/runtimes/reporter/reporter_test.go
@@ -21,7 +21,7 @@ func TestEnvelopeFromLastLine(t *testing.T) {
 	if success.Outcome != resultv1alpha1.OutcomeSucceeded {
 		t.Fatalf("expected success, got %s", success.Outcome)
 	}
-	if got := resultv1alpha1.ProjectLegacyResult(success.Output); got != "final answer" {
+	if got := resultv1alpha1.PlainText(success.Output); got != "final answer" {
 		t.Fatalf("unexpected output %q", got)
 	}
 
@@ -36,7 +36,7 @@ func TestEnvelopeFromLastLine(t *testing.T) {
 	if failure.Error == nil || failure.Error.Code != "agent_process_exit" {
 		t.Fatalf("unexpected process error %#v", failure.Error)
 	}
-	if got := resultv1alpha1.ProjectLegacyResult(failure.Output); got != "partial answer" {
+	if got := resultv1alpha1.PlainText(failure.Output); got != "partial answer" {
 		t.Fatalf("unexpected partial output %q", got)
 	}
 
@@ -170,7 +170,7 @@ func TestRunReporterPreservesLogsAndChildExit(t *testing.T) {
 	if envelope.Error == nil || envelope.Error.Code != "agent_process_exit" {
 		t.Fatalf("unexpected error %#v", envelope.Error)
 	}
-	if got := resultv1alpha1.ProjectLegacyResult(envelope.Output); got != "final answer" {
+	if got := resultv1alpha1.PlainText(envelope.Output); got != "final answer" {
 		t.Fatalf("unexpected final output %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- keep the legacy termination payload parser private to the result package
- expose the structured-output projection as `PlainText` and update all callers without changing wire behavior

## Test plan
- `go build ./...`
- `go vet ./...`
- `go test ./pkg/... ./internal/status/... ./runtimes/...`
- `make verify`