### PR TITLE
Move release checklist to contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,13 @@ mirrors, `llms.txt`, and `llms-full.txt`. The verification checks byte
 identity between source Markdown and raw output plus required Task, Scheduled,
 API, and webhook terms in the generated corpus.
 
+## Releasing
+
+The `public release references use the declared version` test in
+`docs-site/tests/content-integrity.test.mjs` enforces documented release
+versions and image tags. When bumping the release version, update its references
+and let that test verify completeness.
+
 ## Generated files
 
 Changes under `api/v1alpha1` may require regenerated deep-copy code, CRDs, and

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -39,13 +39,6 @@ a classic `PACKAGES_TOKEN` repository secret with `write:packages`; the
 workflow uses it only for the visibility operation. Publication fails before a
 GitHub release is created if anonymous access cannot be verified.
 
-## Release checklist
-
-- [ ] Bump the documented release version in `README.md`, `SECURITY.md`,
-  `docs/quickstart.md`, `docs/releases.md`, `docs/scheduled-workload.md`,
-  `docs/service-workload.md`, `docs/task-workload.md`, `website/index.html`,
-  `deploy/examples/v1alpha1/README.md`, and `.github/ISSUE_TEMPLATE/bug_report.yml`.
-
 ## Install
 
 Install a tagged release on an existing cluster without cloning the repository


### PR DESCRIPTION
## Summary
- remove the maintainer-only release checklist from the public Releases page
- document the content-integrity release-version check in the contributor guide

## Test plan
- [x] `cd docs-site && npm ci`
- [x] `cd docs-site && npm test`
- [x] `cd docs-site && npm run build`
- [x] `cd docs-site && npm run verify:build`