### PR TITLE
Prepare v0.1.0-alpha.2 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Kontext version
       description: Release tag or commit SHA
-      placeholder: v0.1.0-alpha.1
+      placeholder: v0.1.0-alpha.2
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ backward-compatible text projection. The full versioned contract is in
 An existing Kubernetes cluster needs only kubectl and permission to create
 CRDs, cluster-scoped RBAC, a Namespace, a Deployment, a Service, a
 NetworkPolicy, and a MutatingWebhookConfiguration. Install the published
-`v0.1.0-alpha.1` release directly from GitHub:
+`v0.1.0-alpha.2` release directly from GitHub:
 
 ```bash
-VERSION=v0.1.0-alpha.1
+VERSION=v0.1.0-alpha.2
 kubectl apply -f \
   "https://github.com/MFS-code/Kontext/releases/download/${VERSION}/install.yaml"
 kubectl rollout status deployment/kontext-controller-manager \
@@ -303,7 +303,7 @@ scripts/                   kind install + e2e
 
 ## Status
 
-The current public release is `v0.1.0-alpha.1`. Its GitHub release contains
+The current public release is `v0.1.0-alpha.2`. Its GitHub release contains
 the digest-pinned install manifest and versioned multi-architecture images.
 `v1alpha1` is alpha on purpose: the API shape is allowed to evolve. `Task`,
 `Service`, `Scheduled`, and standalone `AgentRun` paths are implemented and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ and should not be treated as a hardened multi-tenant sandbox.
 ## Supported versions
 
 Security fixes target the latest published alpha release, currently
-`v0.1.0-alpha.1`. The `main` branch is development code, not a supported
+`v0.1.0-alpha.2`. The `main` branch is development code, not a supported
 distribution. Older alpha releases may not receive patches.
 
 ## Reporting a vulnerability

--- a/deploy/examples/v1alpha1/README.md
+++ b/deploy/examples/v1alpha1/README.md
@@ -13,7 +13,7 @@ After the kind quickstart, map placeholders to the loaded local images:
 To apply an example with published images instead:
 
 ```bash
-KONTEXT_RELEASE_TAG=v0.1.0-alpha.1 \
+KONTEXT_RELEASE_TAG=v0.1.0-alpha.2 \
   ./scripts/apply-example.sh deploy/examples/v1alpha1/reference-fake-run.yaml
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ clone.
 ## Install
 
 ```bash
-VERSION=v0.1.0-alpha.1
+VERSION=v0.1.0-alpha.2
 kubectl apply -f \
   "https://github.com/MFS-code/Kontext/releases/download/${VERSION}/install.yaml"
 kubectl rollout status deployment/kontext-controller-manager \
@@ -42,7 +42,7 @@ spec:
   provider: echo
   model: echo-model
   runtime:
-    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.2
   budget:
     wallclock: 5m
 ```
@@ -75,7 +75,7 @@ spec:
   provider: echo
   model: echo-model
   runtime:
-    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.2
 ---
 apiVersion: kontext.dev/v1alpha1
 kind: AgentRun
@@ -109,7 +109,7 @@ spec:
   provider: echo
   model: echo-model
   runtime:
-    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.2
     command: ["/entrypoint.sh"]
   schedule:
     expression: "* * * * *"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,7 +6,7 @@ sidebarTitle: Releases
 
 # Release and image versioning
 
-The current public release is `v0.1.0-alpha.1`. Kontext releases use
+The current public release is `v0.1.0-alpha.2`. Kontext releases use
 SemVer-compatible git tags:
 
 ```text
@@ -45,7 +45,7 @@ Install a tagged release on an existing cluster without cloning the repository
 or building images:
 
 ```bash
-VERSION=v0.1.0-alpha.1
+VERSION=v0.1.0-alpha.2
 kubectl apply -f \
   "https://github.com/MFS-code/Kontext/releases/download/${VERSION}/install.yaml"
 ```
@@ -168,7 +168,7 @@ created inside `kontext-system` are deleted with that Namespace.
 To remove Kontext completely, including both CRDs:
 
 ```bash
-VERSION=v0.1.0-alpha.1
+VERSION=v0.1.0-alpha.2
 kubectl delete -f \
   "https://github.com/MFS-code/Kontext/releases/download/${VERSION}/install.yaml" \
   --ignore-not-found=true --wait=true

--- a/docs/scheduled-workload.md
+++ b/docs/scheduled-workload.md
@@ -25,7 +25,7 @@ spec:
   provider: echo
   model: echo-model
   runtime:
-    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.2
     command: ["/entrypoint.sh"]
   schedule:
     expression: "* * * * *"

--- a/docs/service-workload.md
+++ b/docs/service-workload.md
@@ -10,7 +10,7 @@ Service mode keeps an agent available the way a Deployment keeps a Pod
 available. The controller owns one live `AgentRun` for the `Agent` and mints a
 replacement when that run exits.
 
-> **Note:** The example uses the published `v0.1.0-alpha.1` echo image. Pin a
+> **Note:** The example uses the published `v0.1.0-alpha.2` echo image. Pin a
 > release tag or digest in your own manifests.
 
 ## Apply a Service Agent
@@ -26,7 +26,7 @@ spec:
   provider: echo
   model: echo-model
   runtime:
-    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.2
     command: ["/entrypoint.sh"]
   env:
     - name: KONTEXT_MODE

--- a/docs/task-workload.md
+++ b/docs/task-workload.md
@@ -29,7 +29,7 @@ spec:
   provider: echo
   model: echo-model
   runtime:
-    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1
+    image: ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.2
   budget:
     wallclock: 2m
 ```

--- a/website/index.html
+++ b/website/index.html
@@ -41,7 +41,7 @@
   <span class="tok-key">provider</span>: <span class="tok-str">echo</span>
   <span class="tok-key">model</span>: <span class="tok-str">echo-model</span>
   <span class="tok-key">runtime</span>:
-    <span class="tok-key">image</span>: <span class="tok-str">ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.1</span>
+    <span class="tok-key">image</span>: <span class="tok-str">ghcr.io/mfs-code/kontext-echo:v0.1.0-alpha.2</span>
 
 <span class="tok-prompt">$</span> <span class="tok-cmd">kubectl</span> apply -f run.yaml
 <span class="tok-prompt">$</span> <span class="tok-cmd">kubectl</span> logs -f run-review


### PR DESCRIPTION
## Summary
- update every public release, install, image, support, and bug-report reference to `v0.1.0-alpha.2`
- prepare a fresh version because the failed alpha.1 attempt left immutable images tied to an older commit

## Test plan
- [x] `make verify`
- [x] `make test`
- [x] `cd docs-site && npm test`
- [x] `cd docs-site && npm run typecheck`
- [x] `cd docs-site && npm run build`
- [x] `cd docs-site && npm run verify:build`
- [x] repository-wide search confirms no stale `v0.1.0-alpha.1` references