### PR TITLE
Verify GHCR package visibility instead of patching it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,31 +168,34 @@ jobs:
             org.opencontainers.image.version=${{ needs.validate.outputs.version }}
             org.opencontainers.image.licenses=MIT
 
-      - name: Make package public
+      - name: Verify package is public
         env:
-          GH_TOKEN: ${{ secrets.PACKAGES_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           PACKAGE: ${{ matrix.package }}
           OWNER_TYPE: ${{ github.event.repository.owner.type }}
           OWNER: ${{ needs.validate.outputs.github_owner }}
         run: |
-          # For user-owned repos, use /users/{owner}/... — not /user/..., which
-          # targets the authenticated token identity (often not the package owner).
+          # GitHub has no REST API to change container package visibility, so
+          # a package must be made public once, by hand, in its settings UI.
+          # Visibility persists across pushes; this step only verifies it and
+          # retries briefly to absorb read-after-write lag on first publish.
           if [[ "${OWNER_TYPE}" == "Organization" ]]; then
             endpoint="orgs/${OWNER}/packages/container/${PACKAGE}"
+            settings_url="https://github.com/orgs/${OWNER}/packages/container/${PACKAGE}/settings"
           else
             endpoint="users/${OWNER}/packages/container/${PACKAGE}"
+            settings_url="https://github.com/users/${OWNER}/packages/container/${PACKAGE}/settings"
           fi
 
           for attempt in 1 2 3 4 5; do
-            if gh api --method PATCH "${endpoint}" --field visibility=public >/dev/null &&
-              [[ "$(gh api "${endpoint}" --jq .visibility)" == "public" ]]; then
+            if [[ "$(gh api "${endpoint}" --jq .visibility)" == "public" ]]; then
               exit 0
             fi
             if [[ "${attempt}" -lt 5 ]]; then
               sleep $((attempt * 2))
             fi
           done
-          echo "::error::could not make ${REGISTRY}/${REGISTRY_OWNER}/${PACKAGE} public via ${endpoint}"
+          echo "::error::${REGISTRY}/${REGISTRY_OWNER}/${PACKAGE} is not public; make it public once at ${settings_url} and re-run this job"
           exit 1
 
       - name: Verify anonymous multi-arch pull

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -33,11 +33,12 @@ publish mutable `latest` or `dev` tags. The workflow refuses to overwrite an
 existing release image tag, verifies anonymous pulls, and attaches an
 `image-digests.json` asset containing immutable `image@sha256:...` references.
 
-The workflow uses its repository token to make new GHCR packages public. If
-the account's package policy denies visibility changes to that token, configure
-a classic `PACKAGES_TOKEN` repository secret with `write:packages`; the
-workflow uses it only for the visibility operation. Publication fails before a
-GitHub release is created if anonymous access cannot be verified.
+GitHub provides no API to change container package visibility, so each GHCR
+package must be made public once, manually, in its package settings on
+GitHub. Visibility persists across pushes. The workflow verifies that every
+package is public and fails with a link to the settings page if one is not.
+Publication fails before a GitHub release is created if anonymous access
+cannot be verified.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- The `v0.1.0-alpha.1` and `v0.1.0-alpha.2` release runs both failed at the "Make package public" step: GitHub has no REST API to change container package visibility (the feature request was closed as not planned), so the `gh api --method PATCH` call returned HTTP 404 on every retry — even though all four packages are already public.
- Replace the step with a visibility *verification*: succeed when the package is already public, and fail with a link to the package settings page (the only place visibility can be changed) when it is not.
- Drop the `PACKAGES_TOKEN` fallback and update `docs/releases.md` accordingly; no token can call an endpoint that does not exist.

## Test plan
- [x] Confirmed `PATCH users/MFS-code/packages/container/<pkg>` (and the `/user/...` and `/visibility` variants) return 404 with an owner PAT holding `write:packages`
- [x] Confirmed `GET users/MFS-code/packages/container/<pkg>` reports `"visibility": "public"` for all four packages, so the new check passes
- [ ] Re-tag `v0.1.0-alpha.2` after merge and confirm the release workflow completes