### PR TITLE
Drop offline kubectl dry-run from release manifest job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,9 +264,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
-
       - name: Download image metadata
         uses: actions/download-artifact@v4
         with:
@@ -288,9 +285,7 @@ jobs:
             }' image-metadata/*.json >image-digests.json
 
       - name: Render pinned install manifest
-        run: |
-          make release-manifest IMAGE_DIGESTS=image-digests.json
-          kubectl create --dry-run=client -f dist/install.yaml -o name
+        run: make release-manifest IMAGE_DIGESTS=image-digests.json
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- The re-run of the `v0.1.0-alpha.2` release got past the fixed visibility check (#114) but failed in "Build release artifacts": `kubectl create --dry-run=client` needs API-server schema discovery even for client-side dry runs, so on a runner without a cluster it fails with `dial tcp [::1]:8080: connect: connection refused`. Reproduced locally with an empty kubeconfig; `--validate=false` fails the same way on type recognition.
- This step had never executed before — both prior release attempts failed earlier, at the package-visibility step.
- Remove the dry-run (and the now-unused kubectl setup in that job). The `verify-install` job applies the same manifest to a real kind cluster immediately afterwards, which is a strictly stronger check.

## Test plan
- [x] Reproduced the offline dry-run failure locally with `KUBECONFIG=/dev/null`
- [x] `make release-manifest` renders `dist/install.yaml` locally from a digest manifest
- [ ] Re-tag `v0.1.0-alpha.2` after merge and confirm the release workflow completes