### PR TITLE
Wait for Pod garbage collection before reusing echo-review name

### DIFF
--- a/scripts/verify-release-install.sh
+++ b/scripts/verify-release-install.sh
@@ -144,9 +144,22 @@ install_release() {
   fi
 }
 
+# Deleting an AgentRun only waits for the AgentRun object; its Pod is
+# garbage-collected asynchronously. A new AgentRun reusing the name would find
+# the stale Pod it does not own and fail with a Pod name collision, so wait
+# for the Pod too before and after reusing the echo-review name.
+delete_echo_review_run() {
+  kubectl delete agentrun echo-review --ignore-not-found=true --wait=true
+  if ! wait_until 60 1 "echo-review Pod removal" \
+    resource_absent pod run-echo-review; then
+    echo "Pod run-echo-review was not garbage-collected after AgentRun deletion" >&2
+    return 1
+  fi
+}
+
 smoke_release_runtime() {
   local version="$1"
-  kubectl delete agentrun echo-review --ignore-not-found=true --wait=true
+  delete_echo_review_run
   KONTEXT_RELEASE_TAG="${version}" "${APPLY_EXAMPLE}" echo-task-run.yaml
   wait_for_run_phase echo-review Succeeded default 180 1
 
@@ -158,7 +171,7 @@ smoke_release_runtime() {
     echo "unexpected echo runtime image: ${runtime_image}" >&2
     return 1
   fi
-  kubectl delete agentrun echo-review --wait=true
+  delete_echo_review_run
 }
 
 CURRENT_IDENTITY="$(manifest_identity "${CURRENT_MANIFEST}")"


### PR DESCRIPTION
## Summary
- The third `v0.1.0-alpha.2` release attempt (after #114 and #115) failed in "Verify registry install, upgrade, and uninstall": the smoke test's `kubectl delete agentrun echo-review --wait` only waits for the AgentRun object, while its Pod is garbage-collected asynchronously. `e2e-kind.sh` then recreated `echo-review` ~300ms later, the controller found the stale `run-echo-review` Pod it did not own, and failed the run instantly as a Pod name collision.
- This never reproduces in PR CI because the keyless e2e there starts from a fresh install with no prior `echo-review` run; only the release verification chains a smoke run directly into the e2e.
- Fix: `verify-release-install.sh` now waits for `run-echo-review` to be gone both before creating and after deleting the smoke AgentRun.

Possible follow-up (not in this PR): the AgentRun controller could tolerate a foreign Pod that is already terminating (has a `deletionTimestamp`) instead of immediately failing the run, which would make name reuse race-free for users too.

## Test plan
- [x] `bash -n` passes
- [ ] Re-tag `v0.1.0-alpha.2` after merge and confirm the release workflow completes