### PR TITLE
Fix crawlability and homepage SEO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ review and safer to test than broad rewrites.
 
 Required tools:
 
-- Go 1.26.5
+- Go 1.26.6
 - Node.js 22 for the hosted docs site
 - Docker with Buildx
 - kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CONTEXT ?= .
 DIST_DIR ?= dist
 
 # Get the currently used golang version
-GO_VERSION ?= 1.26.5
+GO_VERSION ?= 1.26.6
 
 # Pin govulncheck so CI and local runs share the same analyzer.
 GOVULNCHECK_VERSION ?= v1.6.0

--- a/SPEC.md
+++ b/SPEC.md
@@ -698,7 +698,7 @@ subagents, or background orchestration.
 
 Configured MCP servers are a maintained-runtime concern, not control-plane
 vocabulary. The reference runtime uses the official MCP Go SDK v1.6.1, which
-requires Go 1.25 or newer; this repository declares Go 1.26.5. The SDK
+requires Go 1.25 or newer; this repository declares Go 1.26.6. The SDK
 negotiates protocol `2025-11-25` and accepts `2025-06-18`, `2025-03-26`, and
 `2024-11-05`. Discovered MCP tools join the same immutable allowlisted registry
 and use the same turn, call-count, output, cancellation, event, and cleanup

--- a/SPEC.md
+++ b/SPEC.md
@@ -195,7 +195,8 @@ single-active-run restriction. A user invokes a warm-delivery-enabled Service
 Agent with the same sparse `AgentRun` shape. Service Agents without
 `runtime.delivery` reject referenced invocations. Names matching the referenced
 Service Agent followed by a canonical positive integer, such as `owner-1`, are
-reserved for the controller's standing runs and reject user invocations.
+used for the controller's standing runs, so user invocations with those names
+are rejected.
 
 A referenced invocation request is sparse: it may contain only `agentRef` and
 optional `parameters`. Kubernetes
@@ -259,8 +260,8 @@ Every rejected referenced resolution includes one stable class:
 - `DeliveryDisabled`: the reference names a Service Agent without
   `runtime.delivery`.
 - `InvalidDelivery`: the Service delivery configuration is invalid.
-- `ReservedName`: a Service invocation uses the controller-reserved standing
-  run name pattern `<agent>-<positive integer>`.
+- `ReservedName`: a Service invocation uses the standing-run name pattern
+  `<agent>-<positive integer>` managed by the controller.
 - `InvalidTemplate`: the Agent definition has invalid goal/template shape or
   placeholder syntax.
 - `MissingParameters`: required placeholder names have no supplied value.

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Kontext documentation — Kubernetes-native control plane for AI agents as production workloads."
+      content="Documentation for running AI agents as production workloads on Kubernetes with Kontext."
     />
     <meta name="robots" content="index,follow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -13,15 +13,19 @@
     <link rel="alternate" type="text/plain" href="/llms.txt" title="Kontext docs for LLMs" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Kontext Docs" />
-    <meta property="og:title" content="Kontext Docs" />
+    <meta property="og:title" content="Kontext Docs | Run AI agents on Kubernetes" />
     <meta
       property="og:description"
-      content="Run AI agents as real Kubernetes workloads with Agent and AgentRun."
+      content="Documentation for running AI agents as production workloads on Kubernetes with Kontext."
     />
     <meta property="og:url" content="https://docs.kontext.run/" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Kontext Docs" />
-    <title>Kontext Docs</title>
+    <meta name="twitter:title" content="Kontext Docs | Run AI agents on Kubernetes" />
+    <meta
+      name="twitter:description"
+      content="Documentation for running AI agents as production workloads on Kubernetes with Kontext."
+    />
+    <title>Kontext Docs | Run AI agents on Kubernetes</title>
   </head>
   <body>
     <div id="root"></div>

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -8,7 +8,7 @@
     "predev": "npm run sync",
     "prebuild": "npm run sync",
     "dev": "vite",
-    "build": "tsc -b && vite build && node scripts/emit-llm-files.mjs",
+    "build": "tsc -b && vite build && node scripts/emit-llm-files.mjs && node scripts/emit-sitemap.mjs",
     "preview": "vite preview",
     "pretypecheck": "npm run sync",
     "typecheck": "tsc -b --noEmit",

--- a/docs-site/scripts/emit-sitemap.mjs
+++ b/docs-site/scripts/emit-sitemap.mjs
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { pageMetadataById } from "../shared/docs.js";
+
+const docsSite = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const dist = path.join(docsSite, "dist");
+const origin = "https://docs.kontext.run";
+const urls = [...pageMetadataById.values()].map(
+  ({ routePath }) => new URL(routePath, origin).href,
+);
+const sitemap = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+  ...urls.map((url) => `  <url><loc>${url}</loc></url>`),
+  "</urlset>",
+  "",
+].join("\n");
+
+fs.writeFileSync(path.join(dist, "sitemap.xml"), sitemap);
+console.log(`Generated sitemap.xml with ${urls.length} docs routes`);

--- a/docs-site/scripts/verify-build.mjs
+++ b/docs-site/scripts/verify-build.mjs
@@ -23,6 +23,16 @@ for (const metadata of pageMetadataById.values()) {
   );
 }
 
+const sitemap = fs.readFileSync(path.join(dist, "sitemap.xml"), "utf8");
+const sitemapUrls = [
+  ...sitemap.matchAll(/<loc>(https:\/\/docs\.kontext\.run\/[^<]*)<\/loc>/g),
+].map((match) => match[1]);
+const expectedSitemapUrls = [...pageMetadataById.values()].map(
+  ({ routePath }) => new URL(routePath, "https://docs.kontext.run").href,
+);
+assert.deepEqual(sitemapUrls, expectedSitemapUrls);
+assert.equal(new Set(sitemapUrls).size, pageMetadataById.size);
+
 const llmsIndex = fs.readFileSync(path.join(dist, "llms.txt"), "utf8");
 for (const page of ["task-workload", "scheduled-workload"]) {
   assert.match(

--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/((?!assets/|raw/|llms\\.txt$|llms-full\\.txt$|favicon\\.svg$).*)",
+      "source": "/((?!assets/|raw/|llms\\.txt$|llms-full\\.txt$|sitemap\\.xml$|favicon\\.svg$).*)",
       "destination": "/index.html"
     }
   ],
@@ -47,6 +47,15 @@
         {
           "key": "Content-Type",
           "value": "text/plain; charset=utf-8"
+        }
+      ]
+    },
+    {
+      "source": "/sitemap.xml",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/xml; charset=utf-8"
         }
       ]
     }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MFS-code/Kontext
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/jsonschema-go v0.4.3

--- a/runtimes/reference/Dockerfile
+++ b/runtimes/reference/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/runtimes/reference/README.md
+++ b/runtimes/reference/README.md
@@ -250,7 +250,7 @@ definitions.
 
 SDK v1.6.1 negotiates MCP protocol `2025-11-25` by default and accepts
 `2025-06-18`, `2025-03-26`, and `2024-11-05`. The SDK requires Go 1.25; this
-repository declares Go 1.26.5. Its runtime dependency footprint adds
+repository declares Go 1.26.6. Its runtime dependency footprint adds
 `google/jsonschema-go`, `segmentio/encoding`, `yosida95/uritemplate`,
 `golang.org/x/oauth2`, and their small transitive dependencies. Kontext uses
 the same JSON Schema package to reject malformed discovered schemas while

--- a/runtimes/reporter/Dockerfile
+++ b/runtimes/reporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/website/index.html
+++ b/website/index.html
@@ -3,19 +3,19 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>kontext</title>
+<title>Kontext — Kubernetes control plane for AI agents</title>
 <meta name="description" content="Kontext is a Kubernetes-native control plane for running AI agents as production workloads.">
 <link rel="canonical" href="https://kontext.run/">
 <meta name="theme-color" content="#fcfbf8">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Kontext">
 <meta property="og:url" content="https://kontext.run/">
-<meta property="og:title" content="kontext">
-<meta property="og:description" content="A Kubernetes control plane for AI agents. Apply an AgentRun, watch runtime logs, read .status.result.">
+<meta property="og:title" content="Kontext — Kubernetes control plane for AI agents">
+<meta property="og:description" content="Kontext is a Kubernetes-native control plane for running AI agents as production workloads.">
 <meta property="og:image" content="https://kontext.run/favicon.svg">
 <meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="kontext">
-<meta name="twitter:description" content="A Kubernetes control plane for AI agents. Apply an AgentRun, watch runtime logs, read .status.result.">
+<meta name="twitter:title" content="Kontext — Kubernetes control plane for AI agents">
+<meta name="twitter:description" content="Kontext is a Kubernetes-native control plane for running AI agents as production workloads.">
 <meta name="twitter:image" content="https://kontext.run/favicon.svg">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/styles.css">

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -5,4 +5,9 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://docs.kontext.run/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,6 +1,19 @@
 {
   "cleanUrls": true,
   "trailingSlash": false,
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "www.kontext.run"
+        }
+      ],
+      "destination": "https://kontext.run/:path*",
+      "permanent": true
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Give the marketing homepage a descriptive search and social title while keeping the visible site unchanged.
- Keep canonical, Open Graph, robots, and sitemap URLs on `https://kontext.run`, and redirect `www` requests to the apex in Vercel routing.
- Generate a docs sitemap from `docs-nav.json`, serve it outside the SPA rewrite, and improve the docs shell metadata.
- Clarify the public wording for controller-managed Service run names and move all Go toolchain, image, and documentation pins to 1.26.6.

After merge, crawlers will receive an apex-host canonical homepage with a usable title, a marketing sitemap that points to both properties, and a docs sitemap containing all 12 navigation routes, including `/docs`, the workload pages, and `/SPEC`.

## Why

Production currently redirects the apex to `www` while HTML metadata and the sitemap declare the apex. The docs sitemap path also returns the Vite SPA shell instead of XML. These changes remove those conflicting host signals and expose the known docs routes without changing the marketing design or product voice.

The first CI run also exposed stale public wording caught by the existing docs test and five newly published standard-library advisories. All five report Go 1.26.6 as the fixed version. This branch updates `go.mod`, the Makefile tool installer pin, and all Go builder images to the published 1.26.6 tag instead of suppressing findings or changing unaffected controllers.

The Vercel dashboard must set `kontext.run` as the marketing project's primary domain and remove the current apex-to-`www` redirect. Domain-level redirects can run before `website/vercel.json`; leaving the current setting in place could override the new `www`-to-apex rule or create a redirect loop.

This PR does not add docs SSR or prerendering. Each route still serves the Vite shell, so route-specific HTML metadata and body content remain a follow-up if indexing stays weak after sitemap discovery.

## Test plan

- [x] `cd docs-site && npm test && npm run typecheck && npm run build && npm run verify:build`
- [x] `make verify && make test && make vulncheck`
- [x] Image smoke builds with `golang:1.26.6`
- [x] Confirm the official `golang:1.26.6` multi-architecture image tag is active on Docker Hub.
- [x] Validate both Vercel configuration files as JSON.
- [x] Parse marketing and generated docs sitemaps as XML. Marketing has 2 URLs; docs has 12.
- [x] Confirm homepage title, canonical, Open Graph URL, and robots sitemap use the apex host.
- [x] PR CI passes: Validate, Docs site, Image smoke, Kind e2e, Kind webhook TLS and HA, and Kind NetworkPolicy e2e.

## Contract and operations

- API or CRD impact: None
- Runtime contract impact: None
- RBAC, workload identity, Secret, or network impact: None
- Upgrade, uninstall, or data-retention impact: None
- Documentation updated: Homepage and docs metadata, sitemap discovery, docs build verification, Service run-name wording, and required Go patch version

## Checklist

- [x] The change stays within Kontext's general control-plane boundary.
- [x] Generated code and manifests are current.
- [x] New behavior has focused build verification.
- [x] Examples and status messages match the implementation.
- [x] The diff contains no credentials or private diagnostics.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b52eb16-9472-4293-bca6-fccb29617bde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b52eb16-9472-4293-bca6-fccb29617bde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

